### PR TITLE
feat: model selection for Instance/Task + model-based dispatching

### DIFF
--- a/alembic/versions/838a9806d6fe_add_model_to_task.py
+++ b/alembic/versions/838a9806d6fe_add_model_to_task.py
@@ -1,0 +1,28 @@
+"""add model to task
+
+Revision ID: 838a9806d6fe
+Revises: f3a8b2c1d9e0
+Create Date: 2026-03-26 17:14:56.560516
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '838a9806d6fe'
+down_revision: Union[str, None] = 'f3a8b2c1d9e0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('tasks', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('model', sa.String(length=100), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('tasks', schema=None) as batch_op:
+        batch_op.drop_column('model')

--- a/backend/api/system.py
+++ b/backend/api/system.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from backend.config import settings
 from backend.database import get_db
 from backend.models.task import Task
 from backend.models.instance import Instance
@@ -31,4 +32,11 @@ async def stats(db: AsyncSession = Depends(get_db)):
     return {
         "tasks": task_counts,
         "running_instances": running_instances,
+    }
+
+
+@router.get("/config")
+async def get_config():
+    return {
+        "default_model": settings.default_model,
     }

--- a/backend/api/system.py
+++ b/backend/api/system.py
@@ -39,4 +39,5 @@ async def stats(db: AsyncSession = Depends(get_db)):
 async def get_config():
     return {
         "default_model": settings.default_model,
+        "model_options": [m.strip() for m in settings.model_options.split(",") if m.strip()],
     }

--- a/backend/config.py
+++ b/backend/config.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     max_concurrent_instances: int = 5
     claude_binary: str = "claude"
     default_model: str = "opus"
+    model_options: str = "default,opus[1m],opus,sonnet,haiku"  # comma-separated
     host: str = "0.0.0.0"
     port: int = 8000
     workspace_dir: str = "~/Projects"

--- a/backend/models/task.py
+++ b/backend/models/task.py
@@ -33,6 +33,7 @@ class Task(Base):
     session_id: Mapped[str | None] = mapped_column(String(200), nullable=True)
     last_cwd: Mapped[str | None] = mapped_column(String(500), nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    model: Mapped[str | None] = mapped_column(String(100), nullable=True)
     tags: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     metadata_: Mapped[dict | None] = mapped_column("metadata", JSON, nullable=True)
     context_window_usage: Mapped[dict | None] = mapped_column(JSON, nullable=True)

--- a/backend/schemas/task.py
+++ b/backend/schemas/task.py
@@ -14,6 +14,7 @@ class TaskCreate(BaseModel):
     mode: str = "auto"  # "auto", "plan", or "loop"
     todo_file_path: str | None = None  # required when mode="loop"
     max_iterations: int = 50  # loop only: max iterations before auto-abort
+    model: str | None = None
     tags: list[str] | None = None
     image_paths: list[str] | None = None  # absolute paths of uploaded images
     secret_ids: list[int] | None = None  # IDs of secrets to inject into prompt
@@ -62,6 +63,7 @@ class TaskResponse(BaseModel):
     plan_content: str | None
     plan_approved: bool | None
     session_id: str | None
+    model: str | None
     starred: bool
     archived: bool
     has_unread: bool

--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -199,6 +199,37 @@ class GlobalDispatcher:
                 await db.commit()
             logger.info(f"Created {needed} worker instances")
 
+    async def _ensure_instances_for_pending_tasks(self):
+        """Auto-create instances for pending tasks whose required model has no instance."""
+        async with self.db_factory() as db:
+            # Get distinct models required by pending tasks (excluding None/empty)
+            result = await db.execute(
+                select(Task.model).where(
+                    Task.status == "pending",
+                    Task.model.isnot(None),
+                    Task.model != "",
+                ).distinct()
+            )
+            required_models = [row[0] for row in result.all()]
+
+            if not required_models:
+                return
+
+            # Get existing instance models
+            result = await db.execute(select(Instance.model))
+            existing_models = {row[0] for row in result.all()}
+
+            # Create instances for models that have no instance at all
+            for model in required_models:
+                if model not in existing_models:
+                    name = f"worker-{model}-1"
+                    instance = Instance(name=name, model=model)
+                    db.add(instance)
+                    existing_models.add(model)
+                    logger.info(f"Auto-created instance '{name}' for model '{model}'")
+
+            await db.commit()
+
     async def _dispatch_loop(self):
         """Poll for idle instances + pending tasks and dispatch."""
         while self._running:
@@ -215,13 +246,13 @@ class GlobalDispatcher:
                     if instance.id in self._running_tasks and not self._running_tasks[instance.id].done():
                         continue
 
-                    # Dequeue a task
+                    # Dequeue a task matching this instance's model
                     async with self.db_factory() as db:
                         queue = TaskQueue(db)
-                        task = await queue.dequeue()
+                        task = await queue.dequeue(instance_model=instance.model)
 
                     if not task:
-                        break  # No more tasks
+                        continue  # No matching task for this instance, try next
 
                     # Resolve project -> target_repo + git config
                     merged: dict = {}
@@ -245,6 +276,9 @@ class GlobalDispatcher:
                     self._running_tasks[instance.id] = asyncio.create_task(
                         self._run_task_lifecycle(instance.id, task, git_env)
                     )
+
+                # Auto-create instances for pending tasks whose model has no instance
+                await self._ensure_instances_for_pending_tasks()
 
                 await asyncio.sleep(2)
 
@@ -316,7 +350,7 @@ class GlobalDispatcher:
                 prompt=full_prompt,
                 task_id=task.id,
                 cwd=cwd,
-                model=None,
+                model=task.model,
                 git_env=git_env or {},
             )
 

--- a/backend/services/task_queue.py
+++ b/backend/services/task_queue.py
@@ -77,14 +77,38 @@ class TaskQueue:
         await self.db.commit()
         return True
 
-    async def dequeue(self) -> Task | None:
-        """Get the highest-priority pending task and mark it as in_progress."""
-        stmt = (
-            select(Task)
-            .where(Task.status == "pending")
-            .order_by(Task.priority.asc(), Task.created_at.asc())
-            .limit(1)
-        )
+    async def dequeue(self, instance_model: str | None = None) -> Task | None:
+        """Get the highest-priority pending task matching the instance model.
+
+        Matching rules:
+        - Tasks with no model (None) can be picked by any instance.
+        - Tasks with a specific model are only picked by instances with that model.
+        - Prefer model-matching tasks over unspecified tasks.
+        """
+        base = select(Task).where(Task.status == "pending")
+
+        if instance_model and instance_model != "default":
+            # First try exact model match, then fall back to tasks with no model specified
+            stmt = (
+                base
+                .where((Task.model == instance_model) | (Task.model.is_(None)))
+                .order_by(
+                    # Prefer tasks that explicitly match this model
+                    (Task.model == instance_model).desc(),
+                    Task.priority.asc(),
+                    Task.created_at.asc(),
+                )
+                .limit(1)
+            )
+        else:
+            # Default instance: only pick tasks with no model specified
+            stmt = (
+                base
+                .where(Task.model.is_(None))
+                .order_by(Task.priority.asc(), Task.created_at.asc())
+                .limit(1)
+            )
+
         result = await self.db.execute(stmt)
         task = result.scalar_one_or_none()
         if task:

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -268,7 +268,7 @@ export const api = {
     request<Task>(`/api/tasks/${id}/read`, { method: 'POST' }),
   stopTaskSession: (id: number) =>
     request<{ ok: boolean }>(`/api/tasks/${id}/stop-session`, { method: 'POST' }),
-  createTask: (data: { title?: string; description?: string; project_id?: number; priority?: number; target_branch?: string; mode?: string; todo_file_path?: string; max_iterations?: number; image_paths?: string[]; secret_ids?: number[] }) =>
+  createTask: (data: { title?: string; description?: string; project_id?: number; priority?: number; target_branch?: string; mode?: string; todo_file_path?: string; max_iterations?: number; image_paths?: string[]; secret_ids?: number[]; model?: string }) =>
     request<Task>('/api/tasks', { method: 'POST', body: JSON.stringify(data) }),
   deleteTask: (id: number) =>
     request<{ ok: boolean }>(`/api/tasks/${id}`, { method: 'DELETE' }),
@@ -330,4 +330,5 @@ export const api = {
   // System
   health: () => request<{ status: string }>('/api/system/health'),
   stats: () => request<{ tasks: Record<string, number>; running_instances: number }>('/api/system/stats'),
+  config: () => request<{ default_model: string }>('/api/system/config'),
 };

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -330,5 +330,5 @@ export const api = {
   // System
   health: () => request<{ status: string }>('/api/system/health'),
   stats: () => request<{ tasks: Record<string, number>; running_instances: number }>('/api/system/stats'),
-  config: () => request<{ default_model: string }>('/api/system/config'),
+  config: () => request<{ default_model: string; model_options: string[] }>('/api/system/config'),
 };

--- a/frontend/src/components/Instances/InstanceGrid.tsx
+++ b/frontend/src/components/Instances/InstanceGrid.tsx
@@ -16,8 +16,11 @@ const statusColors: Record<string, string> = {
   stopped: 'bg-yellow-500',
 };
 
+const MODEL_OPTIONS = ['default', 'opus[1m]', 'opus', 'sonnet', 'haiku'];
+
 export function InstanceGrid({ instances, onRefresh, onViewLogs }: InstanceGridProps) {
   const [newName, setNewName] = useState('');
+  const [newModel, setNewModel] = useState('');
   const [dispatcherRunning, setDispatcherRunning] = useState(false);
 
   useEffect(() => {
@@ -28,8 +31,9 @@ export function InstanceGrid({ instances, onRefresh, onViewLogs }: InstanceGridP
 
   const handleCreate = async () => {
     const name = newName || `worker-${instances.length + 1}`;
-    await api.createInstance({ name });
+    await api.createInstance({ name, model: newModel || 'default' });
     setNewName('');
+    setNewModel('');
     onRefresh();
   };
 
@@ -62,6 +66,18 @@ export function InstanceGrid({ instances, onRefresh, onViewLogs }: InstanceGridP
           value={newName}
           onChange={(e) => setNewName(e.target.value)}
         />
+        <input
+          className="w-[180px] bg-gray-700 text-foreground rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          placeholder="Model (default)"
+          value={newModel}
+          onChange={(e) => setNewModel(e.target.value)}
+          list="model-options"
+        />
+        <datalist id="model-options">
+          {MODEL_OPTIONS.map((m) => (
+            <option key={m} value={m} />
+          ))}
+        </datalist>
         <button
           onClick={handleCreate}
           className="flex items-center gap-1 bg-indigo-600 hover:bg-indigo-700 text-white px-3 py-2 rounded text-sm font-medium whitespace-nowrap"

--- a/frontend/src/components/Instances/InstanceGrid.tsx
+++ b/frontend/src/components/Instances/InstanceGrid.tsx
@@ -16,16 +16,19 @@ const statusColors: Record<string, string> = {
   stopped: 'bg-yellow-500',
 };
 
-const MODEL_OPTIONS = ['default', 'opus[1m]', 'opus', 'sonnet', 'haiku'];
-
 export function InstanceGrid({ instances, onRefresh, onViewLogs }: InstanceGridProps) {
   const [newName, setNewName] = useState('');
   const [newModel, setNewModel] = useState('');
   const [dispatcherRunning, setDispatcherRunning] = useState(false);
+  const [modelOptions, setModelOptions] = useState<string[]>([]);
+  const [defaultModel, setDefaultModel] = useState('');
 
   useEffect(() => {
     api.dispatcherStatus()
       .then((s) => setDispatcherRunning(s.running))
+      .catch(() => {});
+    api.config()
+      .then((c) => { setModelOptions(c.model_options); setDefaultModel(c.default_model); })
       .catch(() => {});
   }, []);
 
@@ -68,14 +71,14 @@ export function InstanceGrid({ instances, onRefresh, onViewLogs }: InstanceGridP
         />
         <input
           className="w-[180px] bg-gray-700 text-foreground rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          placeholder="Model (default)"
+          placeholder={defaultModel ? `Model (default: ${defaultModel})` : 'Model (default)'}
           value={newModel}
           onChange={(e) => setNewModel(e.target.value)}
           list="model-options"
         />
         <datalist id="model-options">
-          {MODEL_OPTIONS.map((m) => (
-            <option key={m} value={m} />
+          {modelOptions.map((m) => (
+            <option key={m} value={m} label={m === 'default' && defaultModel ? `default (${defaultModel})` : m} />
           ))}
         </datalist>
         <button
@@ -110,7 +113,7 @@ export function InstanceGrid({ instances, onRefresh, onViewLogs }: InstanceGridP
 
             <div className="text-xs text-gray-400 space-y-0.5">
               <p>Status: <span className="text-gray-300">{inst.status}</span></p>
-              <p>Model: <span className="text-gray-300">{inst.model}</span></p>
+              <p>Model: <span className="text-gray-300">{inst.model}{inst.model === 'default' && defaultModel ? ` (${defaultModel})` : ''}</span></p>
               <p>Completed: <span className="text-gray-300">{inst.total_tasks_completed}</span></p>
               {inst.current_task_id && <p>Task: <span className="text-indigo-400">#{inst.current_task_id}</span></p>}
               {inst.pid && <p>PID: <span className="text-gray-300">{inst.pid}</span></p>}

--- a/frontend/src/components/Tasks/TaskForm.tsx
+++ b/frontend/src/components/Tasks/TaskForm.tsx
@@ -21,6 +21,8 @@ export function TaskForm({ onCreated }: TaskFormProps) {
   const [newProjectUrl, setNewProjectUrl] = useState('');
   const [priority, setPriority] = useState(0);
   const [mode, setMode] = useState('auto');
+  const [model, setModel] = useState('');
+  const [defaultModel, setDefaultModel] = useState('opus');
   const [todoFilePath, setTodoFilePath] = useState('');
   const [maxIterations, setMaxIterations] = useState(50);
   const [loading, setLoading] = useState(false);
@@ -39,6 +41,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
 
   useEffect(() => {
     loadProjects();
+    api.config().then((c) => setDefaultModel(c.default_model)).catch(() => {});
   }, []);
 
   const handleProjectChange = (val: string) => {
@@ -112,6 +115,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
         ...(mode === 'loop' ? { todo_file_path: todoFilePath, max_iterations: maxIterations } : {}),
         ...(uploadedPaths.length > 0 ? { image_paths: uploadedPaths } : {}),
         ...(selectedSecretIds.length > 0 ? { secret_ids: selectedSecretIds } : {}),
+        model: model || defaultModel,
       });
       setDescription('');
       setPriority(0);
@@ -119,6 +123,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
       setPendingImages([]);
       setImagePreviews([]);
       setSelectedSecretIds([]);
+      setModel('');
       onCreated();
     } finally {
       setLoading(false);
@@ -253,6 +258,19 @@ export function TaskForm({ onCreated }: TaskFormProps) {
           value={priority}
           onChange={(e) => setPriority(Number(e.target.value))}
         />
+        <label className="text-sm text-gray-400 ml-2">Model:</label>
+        <input
+          className="w-[130px] bg-gray-700 text-foreground rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          placeholder={`${defaultModel} (default)`}
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          list="task-model-options"
+        />
+        <datalist id="task-model-options">
+          {['opus[1m]', 'opus', 'sonnet', 'haiku'].map((m) => (
+            <option key={m} value={m} />
+          ))}
+        </datalist>
         <label className="text-sm text-gray-400 ml-2">Mode:</label>
         <select
           className="bg-gray-700 text-foreground rounded px-2 py-1 text-sm"

--- a/frontend/src/components/Tasks/TaskForm.tsx
+++ b/frontend/src/components/Tasks/TaskForm.tsx
@@ -23,6 +23,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
   const [mode, setMode] = useState('auto');
   const [model, setModel] = useState('');
   const [defaultModel, setDefaultModel] = useState('opus');
+  const [modelOptions, setModelOptions] = useState<string[]>([]);
   const [todoFilePath, setTodoFilePath] = useState('');
   const [maxIterations, setMaxIterations] = useState(50);
   const [loading, setLoading] = useState(false);
@@ -41,7 +42,10 @@ export function TaskForm({ onCreated }: TaskFormProps) {
 
   useEffect(() => {
     loadProjects();
-    api.config().then((c) => setDefaultModel(c.default_model)).catch(() => {});
+    api.config().then((c) => {
+      setDefaultModel(c.default_model);
+      setModelOptions(c.model_options.filter((m) => m !== 'default'));
+    }).catch(() => {});
   }, []);
 
   const handleProjectChange = (val: string) => {
@@ -267,7 +271,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
           list="task-model-options"
         />
         <datalist id="task-model-options">
-          {['opus[1m]', 'opus', 'sonnet', 'haiku'].map((m) => (
+          {modelOptions.map((m) => (
             <option key={m} value={m} />
           ))}
         </datalist>


### PR DESCRIPTION
## Feat
  - Added `model` field to Task model, allowing model selection when creating tasks (defaults to `config.default_model`)
  - Instance creation now supports model selection with datalist suggestions, showing the actual model name for "default"
  - Dispatcher matches tasks to instances by model; auto-creates instances when no matching model instance exists
  - Added `/api/system/config` endpoint for frontend to dynamically fetch `default_model` and `model_options`
  - `MODEL_OPTIONS` managed via backend config (`.env`: `MODEL_OPTIONS=default,opus[1m],opus,sonnet,haiku`), no hardcoding
  - Alembic migration: adds nullable `model` column to tasks table, auto-applied on startup