### PR TITLE
feat: 附件多文件上传 + archived_only 过滤 + completed 任务可删除  

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -15,8 +16,9 @@ router = APIRouter(prefix="/api/tasks", tags=["chat"])
 
 class ChatMessage(BaseModel):
     message: str
-    image_paths: list[str] | None = None  # absolute paths of uploaded images
-    secret_ids: list[int] | None = None  # IDs of secrets to inject into prompt
+    image_paths: list[str] | None = None  # kept for backwards compatibility
+    file_paths: list[str] | None = None
+    secret_ids: list[int] | None = None
 
 
 async def _find_idle_instance(db: AsyncSession) -> Instance | None:
@@ -67,10 +69,23 @@ async def send_chat_message(
         secrets_block = await _build_secrets_block(async_session, body.secret_ids)
         if secrets_block:
             prompt_parts.append(secrets_block)
-    if body.image_paths:
-        image_list = "\n".join(f"- {p}" for p in body.image_paths)
-        prompt_parts.append(f"请用 Read 工具查看以下图片：\n{image_list}")
+    all_paths = body.file_paths or body.image_paths or []
+    if all_paths:
+        file_list = "\n".join(f"- {p}" for p in all_paths)
+        prompt_parts.append(f"请用 Read 工具查看以下文件：\n{file_list}")
     prompt = "\n\n".join(prompt_parts)
+
+    # Build file attachment metadata for storage and display
+    _IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
+    attachments: list[dict] = []
+    for p in all_paths:
+        filename = os.path.basename(p)
+        ext = os.path.splitext(filename)[1].lower()
+        attachments.append({
+            "url": f"/api/uploads/{filename}",
+            "name": filename,
+            "is_image": ext in _IMAGE_EXTS,
+        })
 
     # Store user message as a log entry
     user_log = LogEntry(
@@ -79,6 +94,7 @@ async def send_chat_message(
         event_type="user_message",
         role="user",
         content=body.message,
+        raw_json=json.dumps({"attachments": attachments}) if attachments else None,
         is_error=False,
     )
     db.add(user_log)
@@ -98,6 +114,19 @@ async def send_chat_message(
     if not cwd or not os.path.isdir(cwd):
         raise HTTPException(400, "Task working directory not found.")
 
+    # Build git env (SSH key, HTTPS token, author info) same as dispatcher
+    from backend.services.dispatcher import _build_git_env
+    from backend.services.git_config import merge_git_config, settings_to_dict
+    from backend.models.project import Project
+    from backend.models.global_settings import GlobalSettings
+    merged: dict = {}
+    if task.project_id:
+        project = await db.get(Project, task.project_id)
+        global_cfg = await db.get(GlobalSettings, 1)
+        if project:
+            merged = merge_git_config(settings_to_dict(project), settings_to_dict(global_cfg))
+    git_env = _build_git_env(merged)
+
     # Resolve effort: task.effort_level → instance.effort_level → settings.default_effort
     from backend.config import settings as app_settings
     effort_level = task.effort_level or inst.effort_level or app_settings.default_effort
@@ -112,6 +141,7 @@ async def send_chat_message(
         cwd=cwd,
         model=task.model or inst.model,
         resume_session_id=task.session_id,
+        git_env=git_env,
         thinking_budget=inst.thinking_budget,
         effort_level=effort_level,
     )
@@ -134,6 +164,7 @@ async def get_chat_history(
         LogEntry.id, LogEntry.role, LogEntry.event_type, LogEntry.content,
         LogEntry.tool_name, LogEntry.tool_input, LogEntry.tool_output,
         LogEntry.is_error, LogEntry.loop_iteration, LogEntry.timestamp,
+        LogEntry.raw_json,
     ]
     if limit > 0:
         stmt = (
@@ -166,6 +197,20 @@ async def get_chat_history(
             tool_input = tool_input[:_TRUNCATE] + "\n…(truncated)"
         if tool_output and len(tool_output) > _TRUNCATE:
             tool_output = tool_output[:_TRUNCATE] + "\n…(truncated)"
+        attachments = None
+        image_urls = None
+        if row.raw_json:
+            try:
+                raw = json.loads(row.raw_json)
+                if isinstance(raw, dict):
+                    if raw.get("attachments"):
+                        attachments = raw["attachments"]
+                        image_urls = [a["url"] for a in attachments if a.get("is_image")]
+                    elif raw.get("image_urls"):
+                        image_urls = raw["image_urls"]
+                        attachments = [{"url": u, "name": u.split("/")[-1], "is_image": True} for u in image_urls]
+            except (json.JSONDecodeError, TypeError):
+                pass
         messages.append({
             "id": row.id,
             "role": row.role or ("assistant" if row.event_type in ("message", "result") else "system"),
@@ -177,6 +222,8 @@ async def get_chat_history(
             "is_error": row.is_error,
             "loop_iteration": row.loop_iteration,
             "timestamp": row.timestamp.isoformat() if row.timestamp else None,
+            "image_urls": image_urls or None,
+            "attachments": attachments,
         })
 
     return messages

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -18,12 +18,14 @@ def _get_queue(db: AsyncSession = Depends(get_db)) -> TaskQueue:
 async def count_tasks(
     status: str | None = None,
     include_archived: bool = False,
+    archived_only: bool = False,
     project_id: int | None = None,
     starred: bool | None = None,
     queue: TaskQueue = Depends(_get_queue),
 ):
     total = await queue.count_tasks(
         status=status, include_archived=include_archived,
+        archived_only=archived_only,
         project_id=project_id, starred=starred,
     )
     return {"total": total}
@@ -33,6 +35,7 @@ async def count_tasks(
 async def list_tasks(
     status: str | None = None,
     include_archived: bool = False,
+    archived_only: bool = False,
     project_id: int | None = None,
     starred: bool | None = None,
     limit: int = 50,
@@ -41,6 +44,7 @@ async def list_tasks(
 ):
     return await queue.list_tasks(
         status=status, include_archived=include_archived,
+        archived_only=archived_only,
         project_id=project_id, starred=starred,
         limit=limit, offset=offset,
     )
@@ -50,10 +54,15 @@ async def list_tasks(
 async def create_task(body: TaskCreate, queue: TaskQueue = Depends(_get_queue)):
     data = body.model_dump()
     image_paths = data.pop("image_paths", None)
+    file_paths = data.pop("file_paths", None)
+    attachments = data.pop("attachments", None)
     secret_ids = data.pop("secret_ids", None)
     meta = data.get("metadata_") or {}
-    if image_paths:
-        meta["image_paths"] = image_paths
+    all_paths = file_paths or image_paths
+    if all_paths:
+        meta["image_paths"] = all_paths
+    if attachments:
+        meta["attachments"] = attachments
     if secret_ids:
         meta["secret_ids"] = secret_ids
     if meta:

--- a/backend/api/uploads.py
+++ b/backend/api/uploads.py
@@ -10,7 +10,8 @@ router = APIRouter(prefix="/api/uploads", tags=["uploads"])
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 UPLOAD_DIR = _PROJECT_ROOT / "uploads"
 
-_ALLOWED_TYPES = {"image/png", "image/jpeg", "image/gif", "image/webp"}
+_BLOCKED_EXTENSIONS = {".exe", ".zip"}
+_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
 _MAX_SIZE_BYTES = 10 * 1024 * 1024  # 10 MB
 _MAX_FILES = 5
 
@@ -21,28 +22,25 @@ def _get_upload_dir() -> Path:
 
 
 @router.post("")
-async def upload_images(files: list[UploadFile] = File(...)):
-    """Upload up to 5 images. Returns list of {id, filename, path, url}."""
+async def upload_files(files: list[UploadFile] = File(...)):
+    """Upload up to 5 files. Returns list of {id, filename, path, url, is_image}."""
     if len(files) > _MAX_FILES:
         raise HTTPException(400, f"Maximum {_MAX_FILES} files allowed per request")
 
     results = []
     for file in files:
-        if file.content_type not in _ALLOWED_TYPES:
-            raise HTTPException(
-                400,
-                f"File type '{file.content_type}' not allowed. Allowed: png, jpg, gif, webp",
-            )
+        ext = Path(file.filename or "file").suffix.lower()
+        if ext in _BLOCKED_EXTENSIONS:
+            raise HTTPException(400, f"File type '{ext}' is not allowed")
 
         data = await file.read()
         if len(data) > _MAX_SIZE_BYTES:
             raise HTTPException(400, f"File '{file.filename}' exceeds 10 MB limit")
 
-        ext = Path(file.filename or "image").suffix.lower() or ".png"
         file_id = str(uuid.uuid4())
-        filename = f"{file_id}{ext}"
+        saved_name = f"{file_id}{ext}" if ext else file_id
 
-        save_path = _get_upload_dir() / filename
+        save_path = _get_upload_dir() / saved_name
         save_path.write_bytes(data)
 
         results.append(
@@ -50,7 +48,8 @@ async def upload_images(files: list[UploadFile] = File(...)):
                 "id": file_id,
                 "filename": file.filename,
                 "path": str(save_path.resolve()),
-                "url": f"/api/uploads/{filename}",
+                "url": f"/api/uploads/{saved_name}",
+                "is_image": ext in _IMAGE_EXTENSIONS,
             }
         )
 
@@ -58,8 +57,8 @@ async def upload_images(files: list[UploadFile] = File(...)):
 
 
 @router.get("/{filename}")
-async def get_image(filename: str):
-    """Serve an uploaded image (used for frontend preview)."""
+async def get_file(filename: str):
+    """Serve an uploaded file."""
     upload_dir = _get_upload_dir()
     file_path = upload_dir / filename
 

--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -18,8 +18,8 @@ class TokenAuthMiddleware(BaseHTTPMiddleware):
 
         path = request.url.path
 
-        # Skip auth for public paths and static files
-        if path in self.PUBLIC_PATHS or not path.startswith("/api"):
+        # Skip auth for public paths, static files, and uploaded images (UUID filenames)
+        if path in self.PUBLIC_PATHS or not path.startswith("/api") or path.startswith("/api/uploads/"):
             return await call_next(request)
 
         # Skip auth for WebSocket (handled separately)

--- a/backend/schemas/task.py
+++ b/backend/schemas/task.py
@@ -17,8 +17,10 @@ class TaskCreate(BaseModel):
     model: str | None = None
     effort_level: str | None = None
     tags: list[str] | None = None
-    image_paths: list[str] | None = None  # absolute paths of uploaded images
-    secret_ids: list[int] | None = None  # IDs of secrets to inject into prompt
+    image_paths: list[str] | None = None  # kept for backwards compat
+    file_paths: list[str] | None = None
+    attachments: list[dict] | None = None  # [{url, name, is_image}, ...]
+    secret_ids: list[int] | None = None
 
     @model_validator(mode='after')
     def validate_mode_fields(self):
@@ -71,6 +73,7 @@ class TaskResponse(BaseModel):
     has_unread: bool
     error_message: str | None
     tags: list[str] | None
+    metadata_: dict | None = None
     context_window_usage: dict | None
     created_at: datetime
     started_at: datetime | None

--- a/backend/services/task_queue.py
+++ b/backend/services/task_queue.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 
-from sqlalchemy import func, select, update
+from sqlalchemy import delete as sa_delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.config import settings
+from backend.models.log_entry import LogEntry
 from backend.models.task import Task
 
 
@@ -23,11 +24,14 @@ class TaskQueue:
 
     async def list_tasks(
         self, status: str | None = None, include_archived: bool = False,
+        archived_only: bool = False,
         project_id: int | None = None, starred: bool | None = None,
         limit: int = 50, offset: int = 0,
     ) -> list[Task]:
         stmt = select(Task).order_by(Task.starred.desc(), Task.created_at.desc())
-        if not include_archived:
+        if archived_only:
+            stmt = stmt.where(Task.archived == True)
+        elif not include_archived:
             stmt = stmt.where(Task.archived == False)
         if status:
             stmt = stmt.where(Task.status == status)
@@ -41,10 +45,13 @@ class TaskQueue:
 
     async def count_tasks(
         self, status: str | None = None, include_archived: bool = False,
+        archived_only: bool = False,
         project_id: int | None = None, starred: bool | None = None,
     ) -> int:
         stmt = select(func.count(Task.id))
-        if not include_archived:
+        if archived_only:
+            stmt = stmt.where(Task.archived == True)
+        elif not include_archived:
             stmt = stmt.where(Task.archived == False)
         if status:
             stmt = stmt.where(Task.status == status)
@@ -88,8 +95,9 @@ class TaskQueue:
         task = await self.get(task_id)
         if not task:
             return False
-        if task.status not in ("pending", "failed", "cancelled", "conflict"):
+        if task.status not in ("pending", "failed", "cancelled", "conflict", "completed"):
             return False
+        await self.db.execute(sa_delete(LogEntry).where(LogEntry.task_id == task_id))
         await self.db.delete(task)
         await self.db.commit()
         return True

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -98,6 +98,11 @@ export interface Task {
   model: string | null;
   effort_level: string | null;
   tags: string[] | null;
+  metadata_: {
+    image_paths?: string[];
+    attachments?: FileAttachment[];
+    secret_ids?: number[];
+  } | null;
   context_window_usage: {
     input_tokens: number;
     cache_read_input_tokens: number;
@@ -127,6 +132,12 @@ export interface Instance {
   last_heartbeat: string | null;
 }
 
+export interface FileAttachment {
+  url: string;
+  name: string;
+  is_image: boolean;
+}
+
 export interface ChatMessage {
   id: number;
   role: string;
@@ -138,6 +149,8 @@ export interface ChatMessage {
   is_error: boolean;
   loop_iteration: number | null;
   timestamp: string | null;
+  image_urls: string[] | null;
+  attachments: FileAttachment[] | null;
 }
 
 export interface LogEntry {
@@ -172,6 +185,7 @@ export interface UploadResult {
   filename: string | null;
   path: string;
   url: string;
+  is_image: boolean;
 }
 
 export const api = {
@@ -258,19 +272,19 @@ export const api = {
   },
 
   // Tasks
-  listTasks: (status?: string, includeArchived?: boolean, projectId?: number, starred?: boolean, limit?: number, offset?: number) =>
+  listTasks: (status?: string, includeArchived?: boolean, projectId?: number, starred?: boolean, limit?: number, offset?: number, archivedOnly?: boolean) =>
     request<Task[]>(`/api/tasks?${new URLSearchParams({
       ...(status ? { status } : {}),
-      ...(includeArchived ? { include_archived: 'true' } : {}),
+      ...(archivedOnly ? { archived_only: 'true' } : includeArchived ? { include_archived: 'true' } : {}),
       ...(projectId != null ? { project_id: String(projectId) } : {}),
       ...(starred != null ? { starred: String(starred) } : {}),
       ...(limit != null ? { limit: String(limit) } : {}),
       ...(offset != null ? { offset: String(offset) } : {}),
     })}`),
-  countTasks: (status?: string, includeArchived?: boolean, projectId?: number, starred?: boolean) =>
+  countTasks: (status?: string, includeArchived?: boolean, projectId?: number, starred?: boolean, archivedOnly?: boolean) =>
     request<{ total: number }>(`/api/tasks/count?${new URLSearchParams({
       ...(status ? { status } : {}),
-      ...(includeArchived ? { include_archived: 'true' } : {}),
+      ...(archivedOnly ? { archived_only: 'true' } : includeArchived ? { include_archived: 'true' } : {}),
       ...(projectId != null ? { project_id: String(projectId) } : {}),
       ...(starred != null ? { starred: String(starred) } : {}),
     })}`),
@@ -282,7 +296,7 @@ export const api = {
     request<Task>(`/api/tasks/${id}/read`, { method: 'POST' }),
   stopTaskSession: (id: number) =>
     request<{ ok: boolean }>(`/api/tasks/${id}/stop-session`, { method: 'POST' }),
-  createTask: (data: { title?: string; description?: string; project_id?: number; priority?: number; target_branch?: string; mode?: string; todo_file_path?: string; max_iterations?: number; image_paths?: string[]; secret_ids?: number[]; model?: string; effort_level?: string }) =>
+  createTask: (data: { title?: string; description?: string; project_id?: number; priority?: number; target_branch?: string; mode?: string; todo_file_path?: string; max_iterations?: number; image_paths?: string[]; file_paths?: string[]; attachments?: { url: string; name: string; is_image: boolean }[]; secret_ids?: number[]; model?: string; effort_level?: string }) =>
     request<Task>('/api/tasks', { method: 'POST', body: JSON.stringify(data) }),
   updateTask: (id: number, data: { title?: string; description?: string; priority?: number }) =>
     request<Task>(`/api/tasks/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
@@ -326,8 +340,8 @@ export const api = {
     request<{ ok: boolean }>('/api/dispatcher/stop', { method: 'POST' }),
 
   // Chat (task-based)
-  sendTaskChat: (taskId: number, message: string, imagePaths?: string[], secretIds?: number[]) =>
-    request<{ ok: boolean; pid: number; instance_id: number; session_id: string }>(`/api/tasks/${taskId}/chat`, { method: 'POST', body: JSON.stringify({ message, image_paths: imagePaths, secret_ids: secretIds }) }),
+  sendTaskChat: (taskId: number, message: string, filePaths?: string[], secretIds?: number[]) =>
+    request<{ ok: boolean; pid: number; instance_id: number; session_id: string }>(`/api/tasks/${taskId}/chat`, { method: 'POST', body: JSON.stringify({ message, file_paths: filePaths, secret_ids: secretIds }) }),
   getTaskChatHistory: (taskId: number, limit = 0) =>
     request<ChatMessage[]>(`/api/tasks/${taskId}/chat/history?limit=${limit}`),
 

--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { api } from '../../api/client';
-import type { ChatMessage, Task, Project, UploadResult } from '../../api/client';
+import type { ChatMessage, FileAttachment, Task, Project, UploadResult } from '../../api/client';
 import { useWebSocket } from '../../hooks/useWebSocket';
 import { Send, ArrowLeft, Loader2, ChevronDown, ChevronRight, Copy, Check, Paperclip, X, StopCircle, Pencil } from 'lucide-react';
 import { SecretPicker } from '../Secrets/SecretPicker';
@@ -101,8 +101,8 @@ export function ChatView({ task, projects, onBack, onTaskUpdated }: ChatViewProp
   const [interrupting, setInterrupting] = useState(false);
   const [stillRunning, setStillRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [pendingImages, setPendingImages] = useState<File[]>([]);
-  const [imagePreviews, setImagePreviews] = useState<string[]>([]);
+  const [pendingFiles, setPendingFiles] = useState<File[]>([]);
+  const [filePreviews, setFilePreviews] = useState<string[]>([]);
   const [selectedSecretIds, setSelectedSecretIds] = useState<number[]>([]);
   const [contextUsage, setContextUsage] = useState<ContextUsage | null>(task.context_window_usage ?? null);
   const [editingTitle, setEditingTitle] = useState(false);
@@ -160,6 +160,8 @@ export function ChatView({ task, projects, onBack, onTaskUpdated }: ChatViewProp
       is_error: (msg.data.is_error as boolean) || false,
       loop_iteration: (msg.data.loop_iteration as number) || null,
       timestamp: new Date().toISOString(),
+      image_urls: (msg.data.image_urls as string[]) || null,
+      attachments: (msg.data.attachments as FileAttachment[]) || null,
     };
     setMessages((prev) => [...prev, entry]);
   }, [task.id]);
@@ -225,19 +227,22 @@ export function ChatView({ task, projects, onBack, onTaskUpdated }: ChatViewProp
     el.style.height = el.scrollHeight + 'px';
   }, [input]);
 
-  const handleImageSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const IMAGE_EXTS = ['.png', '.jpg', '.jpeg', '.gif', '.webp'];
+  const isImageFile = (f: File) => IMAGE_EXTS.some((ext) => f.name.toLowerCase().endsWith(ext));
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
     if (!files.length) return;
-    const combined = [...pendingImages, ...files].slice(0, 5);
-    setPendingImages(combined);
-    setImagePreviews(combined.map((f) => URL.createObjectURL(f)));
+    const combined = [...pendingFiles, ...files].slice(0, 5);
+    setPendingFiles(combined);
+    setFilePreviews(combined.map((f) => isImageFile(f) ? URL.createObjectURL(f) : ''));
     e.target.value = '';
   };
 
-  const removeImage = (idx: number) => {
-    URL.revokeObjectURL(imagePreviews[idx]);
-    setPendingImages((prev) => prev.filter((_, i) => i !== idx));
-    setImagePreviews((prev) => prev.filter((_, i) => i !== idx));
+  const removeFile = (idx: number) => {
+    if (filePreviews[idx]) URL.revokeObjectURL(filePreviews[idx]);
+    setPendingFiles((prev) => prev.filter((_, i) => i !== idx));
+    setFilePreviews((prev) => prev.filter((_, i) => i !== idx));
   };
 
   const handleTitleSave = async () => {
@@ -255,40 +260,44 @@ export function ChatView({ task, projects, onBack, onTaskUpdated }: ChatViewProp
 
   const handleSend = async () => {
     const text = input.trim();
-    if ((!text && pendingImages.length === 0) || sending) return;
+    if ((!text && pendingFiles.length === 0) || sending) return;
 
-    const snapshotImages = [...pendingImages];
-    const snapshotPreviews = [...imagePreviews];
+    const snapshotFiles = [...pendingFiles];
+    const snapshotPreviews = [...filePreviews];
 
     setInput('');
-    snapshotPreviews.forEach((url) => URL.revokeObjectURL(url));
-    setPendingImages([]);
-    setImagePreviews([]);
+    setPendingFiles([]);
+    setFilePreviews([]);
     setSending(true);
     setError(null);
 
-    // Optimistically add user message
-    const userMsg: ChatMessage = {
-      id: Date.now(),
-      role: 'user',
-      event_type: 'user_message',
-      content: text || '(images attached)',
-      tool_name: null,
-      tool_input: null,
-      tool_output: null,
-      is_error: false,
-      loop_iteration: null,
-      timestamp: new Date().toISOString(),
-    };
-    setMessages((prev) => [...prev, userMsg]);
-
     try {
       let uploadedPaths: string[] | undefined;
-      if (snapshotImages.length > 0) {
-        const results: UploadResult[] = await api.uploadImages(snapshotImages);
+      let attachments: FileAttachment[] | undefined;
+      if (snapshotFiles.length > 0) {
+        const results: UploadResult[] = await api.uploadImages(snapshotFiles);
         uploadedPaths = results.map((r) => r.path);
+        attachments = results.map((r) => ({ url: r.url, name: r.filename || r.url.split('/').pop() || 'file', is_image: r.is_image }));
       }
-      await api.sendTaskChat(task.id, text || '(images attached)', uploadedPaths, selectedSecretIds.length > 0 ? selectedSecretIds : undefined);
+      snapshotPreviews.forEach((url) => { if (url) URL.revokeObjectURL(url); });
+
+      const userMsg: ChatMessage = {
+        id: Date.now(),
+        role: 'user',
+        event_type: 'user_message',
+        content: text || '(files attached)',
+        tool_name: null,
+        tool_input: null,
+        tool_output: null,
+        is_error: false,
+        loop_iteration: null,
+        timestamp: new Date().toISOString(),
+        image_urls: attachments?.filter((a) => a.is_image).map((a) => a.url) || null,
+        attachments: attachments || null,
+      };
+      setMessages((prev) => [...prev, userMsg]);
+
+      await api.sendTaskChat(task.id, text || '(files attached)', uploadedPaths, selectedSecretIds.length > 0 ? selectedSecretIds : undefined);
     } catch (e) {
       setSending(false);
       const errMsg = String(e);
@@ -399,6 +408,21 @@ export function ChatView({ task, projects, onBack, onTaskUpdated }: ChatViewProp
             <div className="text-center text-xs text-gray-600 py-1 mb-1">— Initial Prompt —</div>
             <div className="flex justify-end">
               <div className="max-w-[85%] rounded-2xl px-4 py-2.5 text-sm bg-indigo-600 text-white rounded-br-md whitespace-pre-wrap">
+                {task.metadata_?.attachments && task.metadata_.attachments.length > 0 && (
+                  <div className="mb-2 flex flex-wrap gap-2">
+                    {task.metadata_.attachments.filter((a) => a.is_image).length > 0 && (
+                      <MessageImages urls={task.metadata_.attachments.filter((a) => a.is_image).map((a) => a.url)} />
+                    )}
+                    {task.metadata_.attachments.filter((a) => !a.is_image).map((a, i) => (
+                      <a key={i} href={a.url} target="_blank" rel="noopener noreferrer"
+                        className="flex items-center gap-1.5 px-3 py-1.5 bg-indigo-500/30 rounded-lg text-xs text-indigo-100 hover:bg-indigo-500/40 transition-colors max-w-[200px]"
+                      >
+                        <Paperclip size={12} className="shrink-0" />
+                        <span className="truncate">{a.name}</span>
+                      </a>
+                    ))}
+                  </div>
+                )}
                 {task.description}
               </div>
             </div>
@@ -430,15 +454,24 @@ export function ChatView({ task, projects, onBack, onTaskUpdated }: ChatViewProp
       {/* Input */}
       <div className="border-t border-gray-800 bg-gray-900 p-3">
         <div className="flex flex-col gap-2 max-w-3xl mx-auto">
-          {/* Image preview strip */}
-          {imagePreviews.length > 0 && (
+          {/* File preview strip */}
+          {pendingFiles.length > 0 && (
             <div className="flex gap-2 flex-wrap">
-              {imagePreviews.map((src, idx) => (
-                <div key={idx} className="relative w-14 h-14 rounded overflow-hidden border border-gray-600">
-                  <img src={src} alt="" className="w-full h-full object-cover" />
+              {pendingFiles.map((file, idx) => (
+                <div key={idx} className="relative rounded overflow-hidden border border-gray-600">
+                  {filePreviews[idx] ? (
+                    <div className="w-14 h-14">
+                      <img src={filePreviews[idx]} alt="" className="w-full h-full object-cover" />
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-gray-800 text-xs text-gray-300 max-w-[150px]">
+                      <Paperclip size={12} className="shrink-0" />
+                      <span className="truncate">{file.name}</span>
+                    </div>
+                  )}
                   <button
                     type="button"
-                    onClick={() => removeImage(idx)}
+                    onClick={() => removeFile(idx)}
                     className="absolute top-0 right-0 bg-gray-900/80 rounded-bl p-0.5 text-gray-300 hover:text-white"
                   >
                     <X size={10} />
@@ -451,17 +484,16 @@ export function ChatView({ task, projects, onBack, onTaskUpdated }: ChatViewProp
             <input
               ref={fileInputRef}
               type="file"
-              accept="image/png,image/jpeg,image/gif,image/webp"
               multiple
               className="hidden"
-              onChange={handleImageSelect}
+              onChange={handleFileSelect}
             />
             <button
               type="button"
               onClick={() => fileInputRef.current?.click()}
-              disabled={sending || !task.session_id || pendingImages.length >= 5}
+              disabled={sending || !task.session_id || pendingFiles.length >= 5}
               className="p-2.5 text-gray-500 hover:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed"
-              title="Attach images"
+              title="Attach files"
             >
               <Paperclip size={18} />
             </button>
@@ -485,7 +517,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated }: ChatViewProp
             />
             <button
               onClick={handleSend}
-              disabled={(!input.trim() && pendingImages.length === 0) || sending || !task.session_id}
+              disabled={(!input.trim() && pendingFiles.length === 0) || sending || !task.session_id}
               className="p-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg disabled:opacity-40 disabled:cursor-not-allowed"
             >
               <Send size={18} />
@@ -719,6 +751,35 @@ function MessageTimestamp({ timestamp, className }: { timestamp: string | null; 
   );
 }
 
+function ImageLightbox({ src, onClose }: { src: string; onClose: () => void }) {
+  return (
+    <div className="fixed inset-0 z-[9999] bg-black/80 flex items-center justify-center" onClick={onClose}>
+      <button onClick={onClose} className="absolute top-4 right-4 text-white/70 hover:text-white text-3xl font-light">&times;</button>
+      <img src={src} alt="" className="max-w-[90vw] max-h-[90vh] object-contain rounded-lg" onClick={(e) => e.stopPropagation()} />
+    </div>
+  );
+}
+
+function MessageImages({ urls }: { urls: string[] }) {
+  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+  return (
+    <>
+      <div className="flex flex-wrap gap-2">
+        {urls.map((url, i) => (
+          <img
+            key={i}
+            src={url}
+            alt=""
+            className="max-w-[200px] max-h-[150px] rounded-lg object-cover cursor-pointer hover:opacity-80 transition-opacity"
+            onClick={() => setLightboxSrc(url)}
+          />
+        ))}
+      </div>
+      {lightboxSrc && <ImageLightbox src={lightboxSrc} onClose={() => setLightboxSrc(null)} />}
+    </>
+  );
+}
+
 function MessageBubble({ message }: { message: ChatMessage }) {
   const isUser = message.role === 'user';
 
@@ -793,7 +854,29 @@ function MessageBubble({ message }: { message: ChatMessage }) {
         }`}
       >
         {isUser ? (
-          message.content || ''
+          <>
+            {message.attachments && message.attachments.length > 0 && (
+              <div className="mb-2 flex flex-wrap gap-2">
+                {message.attachments.filter((a) => a.is_image).length > 0 && (
+                  <MessageImages urls={message.attachments.filter((a) => a.is_image).map((a) => a.url)} />
+                )}
+                {message.attachments.filter((a) => !a.is_image).map((a, i) => (
+                  <a key={i} href={a.url} target="_blank" rel="noopener noreferrer"
+                    className="flex items-center gap-1.5 px-3 py-1.5 bg-indigo-500/30 rounded-lg text-xs text-indigo-100 hover:bg-indigo-500/40 transition-colors max-w-[200px]"
+                  >
+                    <Paperclip size={12} className="shrink-0" />
+                    <span className="truncate">{a.name}</span>
+                  </a>
+                ))}
+              </div>
+            )}
+            {message.image_urls && !message.attachments && message.image_urls.length > 0 && (
+              <div className="mb-2">
+                <MessageImages urls={message.image_urls} />
+              </div>
+            )}
+            {message.content && message.content !== '(files attached)' && message.content !== '(images attached)' ? message.content : !message.attachments?.length && !message.image_urls?.length ? message.content || '' : null}
+          </>
         ) : (
           <MarkdownContent content={message.content || ''} />
         )}

--- a/frontend/src/components/Chat/LoopChatView.tsx
+++ b/frontend/src/components/Chat/LoopChatView.tsx
@@ -362,6 +362,8 @@ export function LoopChatView({ task, onBack }: LoopChatViewProps) {
       is_error: (msg.data.is_error as boolean) || false,
       loop_iteration: (msg.data.loop_iteration as number) ?? activeIteration ?? 0,
       timestamp: new Date().toISOString(),
+      image_urls: null,
+      attachments: null,
     };
     setMessages((prev) => [...prev, entry]);
   }, [task.id, activeIteration]);

--- a/frontend/src/components/Tasks/TaskForm.tsx
+++ b/frontend/src/components/Tasks/TaskForm.tsx
@@ -33,8 +33,8 @@ export function TaskForm({ onCreated }: TaskFormProps) {
   const [projects, setProjects] = useState<Project[]>([]);
   const [tagItems, setTagItems] = useState<TagItem[]>([]);
   const [tagFilter, setTagFilter] = useState<string>('');
-  const [pendingImages, setPendingImages] = useState<File[]>([]);
-  const [imagePreviews, setImagePreviews] = useState<string[]>([]);
+  const [pendingFiles, setPendingFiles] = useState<File[]>([]);
+  const [filePreviews, setFilePreviews] = useState<string[]>([]);
   const [selectedSecretIds, setSelectedSecretIds] = useState<number[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -65,22 +65,22 @@ export function TaskForm({ onCreated }: TaskFormProps) {
     }
   };
 
-  const handleImageSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const IMAGE_EXTS = ['.png', '.jpg', '.jpeg', '.gif', '.webp'];
+  const isImageFile = (f: File) => IMAGE_EXTS.some((ext) => f.name.toLowerCase().endsWith(ext));
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
     if (!files.length) return;
-    const combined = [...pendingImages, ...files].slice(0, 5);
-    setPendingImages(combined);
-    setImagePreviews(combined.map((f) => URL.createObjectURL(f)));
-    // Reset input so same file can be re-selected after removal
+    const combined = [...pendingFiles, ...files].slice(0, 5);
+    setPendingFiles(combined);
+    setFilePreviews(combined.map((f) => isImageFile(f) ? URL.createObjectURL(f) : ''));
     e.target.value = '';
   };
 
-  const removeImage = (idx: number) => {
-    URL.revokeObjectURL(imagePreviews[idx]);
-    const imgs = pendingImages.filter((_, i) => i !== idx);
-    const prevs = imagePreviews.filter((_, i) => i !== idx);
-    setPendingImages(imgs);
-    setImagePreviews(prevs);
+  const removeFile = (idx: number) => {
+    if (filePreviews[idx]) URL.revokeObjectURL(filePreviews[idx]);
+    setPendingFiles((prev) => prev.filter((_, i) => i !== idx));
+    setFilePreviews((prev) => prev.filter((_, i) => i !== idx));
   };
 
   const canSubmit =
@@ -111,9 +111,15 @@ export function TaskForm({ onCreated }: TaskFormProps) {
       }
 
       let uploadedPaths: string[] = [];
-      if (pendingImages.length > 0) {
-        const results: UploadResult[] = await api.uploadImages(pendingImages);
+      let attachments: { url: string; name: string; is_image: boolean }[] = [];
+      if (pendingFiles.length > 0) {
+        const results: UploadResult[] = await api.uploadImages(pendingFiles);
         uploadedPaths = results.map((r) => r.path);
+        attachments = results.map((r) => ({
+          url: r.url,
+          name: r.filename || r.url.split('/').pop() || 'file',
+          is_image: r.is_image,
+        }));
       }
 
       await api.createTask({
@@ -122,16 +128,17 @@ export function TaskForm({ onCreated }: TaskFormProps) {
         priority,
         mode,
         ...(mode === 'loop' ? { todo_file_path: todoFilePath, max_iterations: maxIterations } : {}),
-        ...(uploadedPaths.length > 0 ? { image_paths: uploadedPaths } : {}),
+        ...(uploadedPaths.length > 0 ? { file_paths: uploadedPaths } : {}),
+        ...(attachments.length > 0 ? { attachments } : {}),
         ...(selectedSecretIds.length > 0 ? { secret_ids: selectedSecretIds } : {}),
         model: model || defaultModel,
         ...(effort ? { effort_level: effort } : {}),
       });
       setDescription('');
       setPriority(0);
-      imagePreviews.forEach((url) => URL.revokeObjectURL(url));
-      setPendingImages([]);
-      setImagePreviews([]);
+      filePreviews.forEach((url) => URL.revokeObjectURL(url));
+      setPendingFiles([]);
+      setFilePreviews([]);
       setSelectedSecretIds([]);
       setModel('');
       setEffort('');
@@ -159,27 +166,35 @@ export function TaskForm({ onCreated }: TaskFormProps) {
         <input
           ref={fileInputRef}
           type="file"
-          accept="image/png,image/jpeg,image/gif,image/webp"
           multiple
           className="hidden"
-          onChange={handleImageSelect}
+          onChange={handleFileSelect}
         />
         <button
           type="button"
           onClick={() => fileInputRef.current?.click()}
-          disabled={pendingImages.length >= 5}
+          disabled={pendingFiles.length >= 5}
           className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-200 px-2 py-1 rounded border border-gray-600 hover:border-gray-400 disabled:opacity-40"
         >
           <Paperclip size={13} />
-          {pendingImages.length > 0 ? `${pendingImages.length}/5 images` : 'Attach images'}
+          {pendingFiles.length > 0 ? `${pendingFiles.length}/5 files` : 'Attach files'}
         </button>
         <SecretPicker selectedIds={selectedSecretIds} onChange={setSelectedSecretIds} />
-        {imagePreviews.map((src, idx) => (
-          <div key={idx} className="relative w-12 h-12 rounded overflow-hidden border border-gray-600">
-            <img src={src} alt="" className="w-full h-full object-cover" />
+        {pendingFiles.map((file, idx) => (
+          <div key={idx} className="relative rounded overflow-hidden border border-gray-600">
+            {filePreviews[idx] ? (
+              <div className="w-12 h-12">
+                <img src={filePreviews[idx]} alt="" className="w-full h-full object-cover" />
+              </div>
+            ) : (
+              <div className="flex items-center gap-1 px-2 py-1.5 bg-gray-700 text-xs text-gray-300 max-w-[120px]">
+                <Paperclip size={11} className="shrink-0" />
+                <span className="truncate">{file.name}</span>
+              </div>
+            )}
             <button
               type="button"
-              onClick={() => removeImage(idx)}
+              onClick={() => removeFile(idx)}
               className="absolute top-0 right-0 bg-gray-900/80 rounded-bl p-0.5 text-gray-300 hover:text-white"
             >
               <X size={10} />

--- a/frontend/src/components/Tasks/TaskList.tsx
+++ b/frontend/src/components/Tasks/TaskList.tsx
@@ -218,7 +218,7 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat }: TaskListPro
                     {t.archived ? <ArchiveRestore size={14} /> : <Archive size={14} />}
                     {t.archived ? 'Unarchive' : 'Archive'}
                   </button>
-                  {['pending', 'failed', 'cancelled'].includes(t.status) && (
+                  {['pending', 'failed', 'cancelled', 'completed'].includes(t.status) && (
                     <button
                       onClick={() => { handleDelete(t.id); setMenuOpenId(null); }}
                       className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-red-400 hover:bg-gray-800 text-left"

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -34,9 +34,9 @@ export function TasksPage() {
     try {
       const offset = (page - 1) * PAGE_SIZE;
       const [filtered, count, all, projs, tags] = await Promise.all([
-        api.listTasks(filter || undefined, showArchived, projectFilter, starredFilter || undefined, PAGE_SIZE, offset),
-        api.countTasks(filter || undefined, showArchived, projectFilter, starredFilter || undefined),
-        api.listTasks(undefined, showArchived, undefined, undefined, PAGE_SIZE, 0),
+        api.listTasks(filter || undefined, false, projectFilter, starredFilter || undefined, PAGE_SIZE, offset, showArchived),
+        api.countTasks(filter || undefined, false, projectFilter, starredFilter || undefined, showArchived),
+        api.listTasks(undefined, false, undefined, undefined, PAGE_SIZE, 0, showArchived),
         api.listProjects(),
         api.listTags(),
       ]);

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,18 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
+name = "aiomysql"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pymysql" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/e0/302aeffe8d90853556f47f3106b89c16cc2ec2a4d269bdfd82e3f4ae12cc/aiomysql-0.3.2.tar.gz", hash = "sha256:72d15ef5cfc34c03468eb41e1b90adb9fd9347b0b589114bd23ead569a02ac1a", size = 108311, upload-time = "2025-10-22T00:15:21.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/af/aae0153c3e28712adaf462328f6c7a3c196a1c1c27b491de4377dd3e6b52/aiomysql-0.3.2-py3-none-any.whl", hash = "sha256:c82c5ba04137d7afd5c693a258bea8ead2aad77101668044143a991e04632eb2", size = 71834, upload-time = "2025-10-22T00:15:15.905Z" },
+]
+
+[[package]]
 name = "aiosqlite"
 version = "0.22.1"
 source = { registry = "https://pypi.org/simple" }
@@ -88,6 +100,54 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+]
+
+[[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/17/cc02bc49bc350623d050fa139e34ea512cd6e020562f2a7312a7bcae4bc9/asyncpg-0.31.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eee690960e8ab85063ba93af2ce128c0f52fd655fdff9fdb1a28df01329f031d", size = 643159, upload-time = "2025-11-24T23:25:36.443Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/62/4ded7d400a7b651adf06f49ea8f73100cca07c6df012119594d1e3447aa6/asyncpg-0.31.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2657204552b75f8288de08ca60faf4a99a65deef3a71d1467454123205a88fab", size = 638157, upload-time = "2025-11-24T23:25:37.89Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5b/4179538a9a72166a0bf60ad783b1ef16efb7960e4d7b9afe9f77a5551680/asyncpg-0.31.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a429e842a3a4b4ea240ea52d7fe3f82d5149853249306f7ff166cb9948faa46c", size = 2918051, upload-time = "2025-11-24T23:25:39.461Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/35/c27719ae0536c5b6e61e4701391ffe435ef59539e9360959240d6e47c8c8/asyncpg-0.31.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0807be46c32c963ae40d329b3a686356e417f674c976c07fa49f1b30303f109", size = 2972640, upload-time = "2025-11-24T23:25:41.512Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f4/01ebb9207f29e645a64699b9ce0eefeff8e7a33494e1d29bb53736f7766b/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e5d5098f63beeae93512ee513d4c0c53dc12e9aa2b7a1af5a81cddf93fe4e4da", size = 2851050, upload-time = "2025-11-24T23:25:43.153Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/f4/03ff1426acc87be0f4e8d40fa2bff5c3952bef0080062af9efc2212e3be8/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37fc6c00a814e18eef51833545d1891cac9aa69140598bb076b4cd29b3e010b9", size = 2962574, upload-time = "2025-11-24T23:25:44.942Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/39/cc788dfca3d4060f9d93e67be396ceec458dfc429e26139059e58c2c244d/asyncpg-0.31.0-cp311-cp311-win32.whl", hash = "sha256:5a4af56edf82a701aece93190cc4e094d2df7d33f6e915c222fb09efbb5afc24", size = 521076, upload-time = "2025-11-24T23:25:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/28/fc/735af5384c029eb7f1ca60ccb8fa95521dbdaeef788edf4cecfc604c3cab/asyncpg-0.31.0-cp311-cp311-win_amd64.whl", hash = "sha256:480c4befbdf079c14c9ca43c8c5e1fe8b6296c96f1f927158d4f1e750aacc047", size = 584980, upload-time = "2025-11-24T23:25:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a6/59d0a146e61d20e18db7396583242e32e0f120693b67a8de43f1557033e2/asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad", size = 662042, upload-time = "2025-11-24T23:25:49.578Z" },
+    { url = "https://files.pythonhosted.org/packages/36/01/ffaa189dcb63a2471720615e60185c3f6327716fdc0fc04334436fbb7c65/asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d", size = 638504, upload-time = "2025-11-24T23:25:51.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/3f699ba45d8bd24c5d65392190d19656d74ff0185f42e19d0bbd973bb371/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a", size = 3426241, upload-time = "2025-11-24T23:25:53.278Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671", size = 3520321, upload-time = "2025-11-24T23:25:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1a/cce4c3f246805ecd285a3591222a2611141f1669d002163abef999b60f98/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec", size = 3316685, upload-time = "2025-11-24T23:25:57.43Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/0fc961179e78cc579e138fad6eb580448ecae64908f95b8cb8ee2f241f67/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20", size = 3471858, upload-time = "2025-11-24T23:25:59.636Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b2/b20e09670be031afa4cbfabd645caece7f85ec62d69c312239de568e058e/asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8", size = 527852, upload-time = "2025-11-24T23:26:01.084Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f0/f2ed1de154e15b107dc692262395b3c17fc34eafe2a78fc2115931561730/asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186", size = 597175, upload-time = "2025-11-24T23:26:02.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
 ]
 
 [[package]]
@@ -388,6 +448,16 @@ dependencies = [
     { name = "websockets" },
 ]
 
+[package.optional-dependencies]
+mysql = [
+    { name = "aiomysql" },
+    { name = "pymysql" },
+]
+postgres = [
+    { name = "asyncpg" },
+    { name = "psycopg2-binary" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
@@ -397,19 +467,24 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiomysql", marker = "extra == 'mysql'", specifier = ">=0.2.0" },
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "alembic", specifier = ">=1.13.0" },
+    { name = "asyncpg", marker = "extra == 'postgres'", specifier = ">=0.29.0" },
     { name = "auto-backup", git = "ssh://git@github.com/zjw49246/auto-backup" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "paramiko", specifier = ">=3.0.0" },
+    { name = "psycopg2-binary", marker = "extra == 'postgres'", specifier = ">=2.9.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "pymysql", marker = "extra == 'mysql'", specifier = ">=1.1.0" },
     { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
+provides-extras = ["postgres", "mysql"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -815,6 +890,58 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg2-binary"
+version = "2.9.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/19/d4ce60954f3bb9d8e3bc5e5c4d1f2487de2d3851bf2391d54954c9df12a6/psycopg2_binary-2.9.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5c8ce6c61bd1b1f6b9c24ee32211599f6166af2c55abb19456090a21fd16554b", size = 3712338, upload-time = "2026-04-20T23:34:03.961Z" },
+    { url = "https://files.pythonhosted.org/packages/53/71/c85409ee0d78890f0660eff262e815e7dd2bb741a17611d82e9e8cd9dc5e/psycopg2_binary-2.9.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b4a9eaa6e7f4ff91bec10aa3fb296878e75187bced5cc4bafe17dc40915e1326", size = 3822407, upload-time = "2026-04-20T23:34:05.977Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/ed/60486c2c7f0d4d1ede2bfb1ed27e2498477ce646bc7f6b2759906303117e/psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c6528cefc8e50fcc6f4a107e27a672058b36cc5736d665476aeb413ba88dbb06", size = 4578425, upload-time = "2026-04-20T23:34:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b9/656cb03fad9f4f49f2145c334b1126ee75189929ca4e6187d485a2d59951/psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e4e184b1fb6072bf05388aa41c697e1b2d01b3473f107e7ec44f186a32cfd0b8", size = 4273709, upload-time = "2026-04-20T23:34:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/99/66/08cf0da0e25cc6fb142c89be45fc8418792858f0c4cbff5e24530ff02cd6/psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4766ab678563054d3f1d064a4db19cc4b5f9e3a8d9018592a8285cf200c248f3", size = 5893779, upload-time = "2026-04-20T23:34:13.905Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d7/eecd9ce8e146d3721115d82d3836efdbb712187e4590325df549989d18f4/psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5a0253224780c978746cb9be55a946bcdaf40fe3519c0f622924cdabdafe2c39", size = 4109308, upload-time = "2026-04-20T23:34:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2e/b1dc289b362cc8d45697b57eefbd673186f49a4ea0906928988e3affcc98/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0dc9228d47c46bda253d2ecd6bb93b56a9f2d7ad33b684a1fa3622bf74ffe30c", size = 3654405, upload-time = "2026-04-20T23:34:19.303Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/4c4aea6473214dbdbd0fbba11aa4691e76dc01722c55724c5951719865ff/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f921f3cd87035ef7df233383011d7a53ea1d346224752c1385f1edfd790ceb6a", size = 3299187, upload-time = "2026-04-20T23:34:21.206Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/5d/b03b99986446a4f57b170ed9a2579fb7ff9783ca0fa5226b19db99737fee/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d999bd982a723113c1a45b55a7a6a90d64d0ed2278020ed625c490ff7bef96c", size = 3047716, upload-time = "2026-04-20T23:34:23.077Z" },
+    { url = "https://files.pythonhosted.org/packages/14/86/382ee4afbd1d97500c9d2862b20c2fdeddf4b7335e984df3fb4309f64108/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29d4d134bd0ab46ffb04e94aa3c5fa3ef582e9026609165e2f758ff76fc3a3be", size = 3349237, upload-time = "2026-04-20T23:34:25.211Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/16/9a57c75ba1eda7165c017342f526810d5f5a12647dde749c99ae9a7141d7/psycopg2_binary-2.9.12-cp311-cp311-win_amd64.whl", hash = "sha256:cb4a1dacdd48077150dc762a9e5ddbf32c256d66cb46f80839391aa458774936", size = 2757036, upload-time = "2026-04-20T23:34:27.77Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/ef4ef3c8e15083df90ca35265cfd1a081a2f0cc07bb229c6314c6af817f4/psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433", size = 3712459, upload-time = "2026-04-20T23:34:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/01/3dd14e46ba48c1e1a6ec58ee599fa1b5efa00c246d5046cd903d0eeb1af1/psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6", size = 3822936, upload-time = "2026-04-20T23:34:32.77Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f7/0640e4901119d8a9f7a1784b927f494e2198e213ceb593753d1f2c8b1b30/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580", size = 4578676, upload-time = "2026-04-20T23:34:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/55/44df3965b5f297c50cc0b1b594a31c67d6127a9d133045b8a66611b14dfb/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f", size = 4274917, upload-time = "2026-04-20T23:34:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/74535248b1eac0c9336862e8617c765ac94dac76f9e25d7c4a79588c8907/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d", size = 5894843, upload-time = "2026-04-20T23:34:40.856Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ba/f1bf8d2ae71868ad800b661099086ee52bc0f8d9f05be1acd8ebb06757cc/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9", size = 4110556, upload-time = "2026-04-20T23:34:44.016Z" },
+    { url = "https://files.pythonhosted.org/packages/45/46/c15706c338403b7c420bcc0c2905aad116cc064545686d8bf85f1999ea00/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d", size = 3655714, upload-time = "2026-04-20T23:34:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/a2d5dc09b64a4564db242a0fe418fde7d33f6f8259dd2c5b9d7def00fb5a/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e", size = 3301154, upload-time = "2026-04-20T23:34:49.528Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/e8/cc8c9a4ce71461f9ec548d38cadc41dc184b34c73e6455450775a9334ccd/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6", size = 3048882, upload-time = "2026-04-20T23:34:51.86Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/31e2296bc0787c5ab75d3d118e40b239db8151b5192b90b77c72bc9256e9/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b", size = 3351298, upload-time = "2026-04-20T23:34:54.124Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a8/75f4e3e11203b590150abed2cf7794b9c9c9f7eceddae955191138b44dde/psycopg2_binary-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:398fcd4db988c7d7d3713e2b8e18939776fd3fb447052daae4f24fa39daede4c", size = 2757230, upload-time = "2026-04-20T23:34:56.242Z" },
+    { url = "https://files.pythonhosted.org/packages/91/bb/4608c96f970f6e0c56572e87027ef4404f709382a3503e9934526d7ba051/psycopg2_binary-2.9.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7c729a73c7b1b84de3582f73cdd27d905121dc2c531f3d9a3c32a3011033b965", size = 3712419, upload-time = "2026-04-20T23:34:58.754Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/af/48f76af9d50d61cf390f8cd657b503168b089e2e9298e48465d029fcc713/psycopg2_binary-2.9.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4413d0caef93c5cf50b96863df4c2efe8c269bf2267df353225595e7e15e8df7", size = 3822990, upload-time = "2026-04-20T23:35:00.821Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/df/aba0f99397cd811d32e06fc0cc781f1f3ce98bc0e729cb423925085d781a/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4dfcf8e45ebb0c663be34a3442f65e17311f3367089cd4e5e3a3e8e62c978777", size = 4578696, upload-time = "2026-04-20T23:35:03.409Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/eaa74021ac4e4d5c2f83d82fc6615a63f4fe6c94dc4e94c3990427053f67/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c41321a14dd74aceb6a9a643b9253a334521babfa763fa873e33d89cfa122fb5", size = 4274982, upload-time = "2026-04-20T23:35:05.583Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ed/c25deff98bd26187ba48b3b250a3ffc3037c46c5b89362534a15d200e0db/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83946ba43979ebfdc99a3cd0ee775c89f221df026984ba19d46133d8d75d3cd9", size = 5894867, upload-time = "2026-04-20T23:35:07.902Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/8d0e21ca77373c6c9589e5c4528f6e8f0c08c62cafc76fb0bddb7a2cee22/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:411e85815652d13560fbe731878daa5d92378c4995a22302071890ec3397d019", size = 4110578, upload-time = "2026-04-20T23:35:10.149Z" },
+    { url = "https://files.pythonhosted.org/packages/00/fc/f481e2435bd8f742d0123309174aae4165160ad3ef17c1b99c3622c241d2/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c8ad4c08e00f7679559eaed7aff1edfffc60c086b976f93972f686384a95e2c", size = 3655816, upload-time = "2026-04-20T23:35:12.56Z" },
+    { url = "https://files.pythonhosted.org/packages/53/79/b9f46466bdbe9f239c96cde8be33c1aace4842f06013b47b730dc9759187/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f", size = 3301307, upload-time = "2026-04-20T23:35:15.029Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/19/7dc003b32fe35024df89b658104f7c8538a8b2dcbde7a4e746ce929742e7/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:98062447aebc20ed20add1f547a364fd0ef8933640d5372ff1873f8deb9b61be", size = 3048968, upload-time = "2026-04-20T23:35:16.757Z" },
+    { url = "https://files.pythonhosted.org/packages/91/58/2dbd7db5c604d45f4950d988506aae672a14126ec22998ced5021cbb76bb/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66a7685d7e548f10fb4ce32fb01a7b7f4aa702134de92a292c7bd9e0d3dbd290", size = 3351369, upload-time = "2026-04-20T23:35:18.933Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ee/dee8dcaad07f735824de3d6563bc67119fa6c28257b17977a8d624f02fab/psycopg2_binary-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:b6937f5fe4e180aeee87de907a2fa982ded6f7f15d7218f78a083e4e1d68f2a0", size = 2757347, upload-time = "2026-04-20T23:35:21.283Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1b/708c0dca874acfad6d65314271859899a79007686f3a1f74e82a2ed4b645/psycopg2_binary-2.9.12-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f3b3de8a74ef8db215f22edffb19e32dc6fa41340456de7ec99efdc8a7b3ec2", size = 3712428, upload-time = "2026-04-20T23:35:23.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/39/ddbea9d4b4de6aca9431b6ed253f530f8a02d3b8f9bcfd0dbfe2b3de6fe4/psycopg2_binary-2.9.12-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1006fb62f0f0bc5ce256a832356c6262e91be43f5e4eb15b5eaf38079464caf2", size = 3823184, upload-time = "2026-04-20T23:35:25.92Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a0/bc2fef74b106fa345567122a0659e6d94512ed7dc0131ec44c9e5aba3725/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:840066105706cd2eb29b9a1c2329620056582a4bf3e8169dec5c447042d0869f", size = 4579157, upload-time = "2026-04-20T23:35:28.542Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/d4e3b2005d3de607ca4fbb0e8742e248056e52184a6b94ebda3c1c2c329b/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:863f5d12241ebe1c76a72a04c2113b6dc905f90b9cef0e9be0efd994affd9354", size = 4274970, upload-time = "2026-04-20T23:35:30.418Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/42/c9853f8db3967fe08bcde11f53d53b85d351750cae726ce001cb68afa9c1/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a99eaab34a9010f1a086b126de467466620a750634d114d20455f3a824aae033", size = 5895175, upload-time = "2026-04-20T23:35:33.584Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/b82b5601a97630308bef079f545ffec481bbbc795c2ba5ec416a01d03f60/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ffdd7dc5463ccd61845ac37b7012d0f35a1548df9febe14f8dd549be4a0bc81e", size = 4110658, upload-time = "2026-04-20T23:35:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/62/8c/32ca69b0389ef25dd22937bf9e8fbe2ce27aea20b05ded48c4ce4cb42475/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:54a0dfecab1b48731f934e06139dfe11e24219fb6d0ceb32177cf0375f14c7b5", size = 3656251, upload-time = "2026-04-20T23:35:37.854Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/29/96992a2b59e3b9d730fcf9612d0a387305025dc867a9fc490a9e496e074e/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:96937c9c5d891f772430f418a7a8b4691a90c3e6b93cf72b5bd7cad8cbca32a5", size = 3301810, upload-time = "2026-04-20T23:35:39.927Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ad/44b06659949b243ae10112cd3b20a197f9bf3e81d5651379b9eb889bfaad/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:77b348775efd4cdab410ec6609d81ccecd1139c90265fa583a7255c8064bc03d", size = 3048977, upload-time = "2026-04-20T23:35:41.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f2/10a1bcebadb6aa55e280e1f58975c36a7b560ea525184c7aa4064c466633/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:527e6342b3e44c2f0544f6b8e927d60de7f163f5723b8f1dfa7d2a84298738cd", size = 3351466, upload-time = "2026-04-20T23:35:43.993Z" },
+    { url = "https://files.pythonhosted.org/packages/20/be/b732c8418ffa5bcfda002890f5dc4c869fc17db66ff11f53b17cfe44afc0/psycopg2_binary-2.9.12-cp314-cp314-win_amd64.whl", hash = "sha256:f12ae41fcafadb39b2785e64a40f9db05d6de2ac114077457e0e7c597f3af980", size = 2848762, upload-time = "2026-04-20T23:35:46.421Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -986,6 +1113,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pymysql"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/ec/8d45c920e90445f0b75c590b32851853ed319763b0d8dff8d283052da8cf/pymysql-1.1.3.tar.gz", hash = "sha256:e70ebf2047a4edf6138cf79c68ad418ef620af65900aa585c5e8bfc95044d43a", size = 48207, upload-time = "2026-05-01T09:09:54.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/dc/9085f3d6f497e9b25fb40d6e8ecef3ddbb5cf977a949b933624a299f5c16/pymysql-1.1.3-py3-none-any.whl", hash = "sha256:8164ba62c552f6105f3b11753352d0f16b90d1703ba67d81923d5a8a5d1c5289", size = 45356, upload-time = "2026-05-01T09:09:53.316Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- **多文件上传**:                                                           
  上传接口从图片白名单改为黑名单机制，支持任意文件类型（.exe/.zip
  除外），前端支持图片缩略图预览 + 非图片文件标签展示 + Lightbox 放大           
  - **附件元数据**: 附件信息存入 LogEntry.raw_json，聊天历史和任务创建均支持
  attachments 字段                                                              
  - **archived_only 过滤**: 任务列表 API 新增 archived_only 参数                
  - **completed 任务可删除**: 删除时级联清理关联日志                          
  - **chat git env**: 对话中透传 git 环境变量，与 dispatcher 保持一致 