### PR TITLE
feat: add file download support in file browser

### DIFF
--- a/backend/api/files.py
+++ b/backend/api/files.py
@@ -1,8 +1,10 @@
 import os
+import tempfile
 from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 router = APIRouter(prefix="/api/files", tags=["files"])
@@ -116,6 +118,32 @@ async def read_file(path: str = Query(..., description="Absolute file path")):
     return {"path": str(target), "content": content, "size": size}
 
 
+MAX_DOWNLOAD_SIZE = 100 * 1024 * 1024  # 100 MB
+
+
+@router.get("/download")
+async def download_file(path: str = Query(..., description="Absolute file path")):
+    """Download a file (max 100 MB)."""
+    target = _safe_path(path)
+    if not target.exists():
+        raise HTTPException(status_code=404, detail=f"File not found: {path}")
+    if not target.is_file():
+        raise HTTPException(status_code=400, detail="Path is not a file")
+
+    size = target.stat().st_size
+    if size > MAX_DOWNLOAD_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File too large ({size // 1024 // 1024} MB). Max is {MAX_DOWNLOAD_SIZE // 1024 // 1024} MB.",
+        )
+
+    return FileResponse(
+        path=str(target),
+        filename=target.name,
+        media_type="application/octet-stream",
+    )
+
+
 # ---------------------------------------------------------------------------
 # SSH endpoints
 # ---------------------------------------------------------------------------
@@ -180,3 +208,42 @@ async def ssh_read_file(req: SSHReadRequest):
         client.close()
 
     return {"path": req.path, "content": content, "size": size}
+
+
+@router.post("/ssh/download")
+async def ssh_download_file(req: SSHReadRequest):
+    """Download a file from a remote SSH server (max 100 MB)."""
+    client = _make_ssh_client(req)
+    try:
+        sftp = client.open_sftp()
+        try:
+            file_attr = sftp.stat(req.path)
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail=f"File not found: {req.path}")
+
+        size = file_attr.st_size or 0
+        if size > MAX_DOWNLOAD_SIZE:
+            raise HTTPException(
+                status_code=413,
+                detail=f"File too large ({size // 1024 // 1024} MB). Max is {MAX_DOWNLOAD_SIZE // 1024 // 1024} MB.",
+            )
+
+        filename = req.path.rstrip("/").rsplit("/", 1)[-1] or "download"
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=f"_{filename}")
+        try:
+            sftp.getfo(req.path, tmp)
+            tmp.close()
+        except PermissionError:
+            os.unlink(tmp.name)
+            raise HTTPException(status_code=403, detail="Permission denied")
+        finally:
+            sftp.close()
+    finally:
+        client.close()
+
+    return FileResponse(
+        path=tmp.name,
+        filename=filename,
+        media_type="application/octet-stream",
+        background=None,
+    )

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -351,11 +351,26 @@ export const api = {
   readFile: (path: string) =>
     request<{ path: string; content: string; size: number }>(`/api/files/read?path=${encodeURIComponent(path)}`),
 
+  // Files (download)
+  downloadFileUrl: (path: string) =>
+    `${getBase()}/api/files/download?path=${encodeURIComponent(path)}`,
+
   // Files (SSH)
   sshListDir: (creds: { host: string; port: number; username: string; password?: string; key_path?: string }, path: string) =>
     request<{ path: string; entries: { name: string; path: string; is_dir: boolean; size: number | null }[] }>('/api/files/ssh/list', { method: 'POST', body: JSON.stringify({ ...creds, path }) }),
   sshReadFile: (creds: { host: string; port: number; username: string; password?: string; key_path?: string }, path: string) =>
     request<{ path: string; content: string; size: number }>('/api/files/ssh/read', { method: 'POST', body: JSON.stringify({ ...creds, path }) }),
+  sshDownloadFile: (creds: { host: string; port: number; username: string; password?: string; key_path?: string }, path: string) => {
+    const token = getToken();
+    return fetch(`${getBase()}/api/files/ssh/download`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ ...creds, path }),
+    });
+  },
 
   // System
   health: () => request<{ status: string }>('/api/system/health'),

--- a/frontend/src/pages/FilesPage.tsx
+++ b/frontend/src/pages/FilesPage.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
 import {
   ChevronRight, ChevronDown, Folder, FolderOpen, FileText,
-  AlertCircle, Loader2, Plus, Trash2, Server, HardDrive,
+  AlertCircle, Loader2, Plus, Trash2, Server, HardDrive, Download,
 } from 'lucide-react';
-import { api } from '../api/client';
+import { api, getToken } from '../api/client';
 import type { Project } from '../api/client';
 
 // ---------------------------------------------------------------------------
@@ -353,6 +353,39 @@ export function FilesPage() {
     saveProfiles(next);
   };
 
+  const handleDownload = async () => {
+    if (!selectedFile) return;
+    if (mode === 'local') {
+      const url = api.downloadFileUrl(selectedFile);
+      const a = document.createElement('a');
+      a.href = url;
+      const token = getToken();
+      if (token) {
+        const res = await fetch(url, { headers: { 'Authorization': `Bearer ${token}` } });
+        if (!res.ok) { setFileError('Download failed'); return; }
+        const blob = await res.blob();
+        a.href = URL.createObjectURL(blob);
+      }
+      a.download = selectedFile.split('/').pop() || 'download';
+      a.click();
+      URL.revokeObjectURL(a.href);
+    } else if (activeProfile) {
+      try {
+        const res = await api.sshDownloadFile(profileToCreds(activeProfile), selectedFile);
+        if (!res.ok) { setFileError('Download failed'); return; }
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = selectedFile.split('/').pop() || 'download';
+        a.click();
+        URL.revokeObjectURL(url);
+      } catch {
+        setFileError('Download failed');
+      }
+    }
+  };
+
   const currentEntries = mode === 'local' ? rootEntries : sshEntries;
   const currentRootLabel = mode === 'local' ? rootPath : (activeProfile ? `${activeProfile.username}@${activeProfile.host}:${sshPath}` : '');
 
@@ -484,8 +517,15 @@ export function FilesPage() {
             )}
             {selectedFile && (
               <>
-                <div className="px-4 py-2 border-b border-gray-700 text-xs text-gray-400 truncate" title={selectedFile}>
-                  {selectedFile}
+                <div className="px-4 py-2 border-b border-gray-700 text-xs text-gray-400 flex items-center gap-2">
+                  <span className="truncate flex-1" title={selectedFile}>{selectedFile}</span>
+                  <button
+                    onClick={handleDownload}
+                    className="flex items-center gap-1 px-2 py-1 bg-indigo-600 text-white rounded text-xs hover:bg-indigo-700 flex-shrink-0"
+                    title="Download file"
+                  >
+                    <Download size={12} /> Download
+                  </button>
                 </div>
                 <div className="flex-1 overflow-auto">
                   {fileLoading && (


### PR DESCRIPTION
Add download button for both local and SSH file browsing, supporting files up to 100MB via new backend endpoints and frontend UI.