### PR TITLE
fix: resolve race condition where task shows completed before output …

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -145,6 +145,16 @@ async def send_chat_message(
         thinking_budget=inst.thinking_budget,
         effort_level=effort_level,
     )
+
+    task.status = "executing"
+    await db.commit()
+    await broadcaster.broadcast("tasks", {
+        "event": "status_change",
+        "task_id": task_id,
+        "new_status": "executing",
+        "instance_id": inst.id,
+    })
+
     return {"ok": True, "pid": pid, "instance_id": inst.id, "session_id": task.session_id}
 
 

--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -400,6 +400,17 @@ class GlobalDispatcher:
                     process.kill()
                     await process.wait()
 
+            # Wait for output consumer to finish processing all remaining
+            # buffered output before judging the result. Without this the
+            # task can be marked completed while the last chunk of Claude's
+            # reply is still being parsed/broadcast.
+            consumer = self.instance_manager._tasks.get(instance_id)
+            if consumer:
+                try:
+                    await asyncio.wait_for(consumer, timeout=30)
+                except asyncio.TimeoutError:
+                    logger.warning(f"Output consumer for instance {instance_id} did not finish in 30s, proceeding")
+
             exit_code = process.returncode if process else -1
 
             # === Step 5: Judge result ===

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -160,6 +160,20 @@ class InstanceManager:
                 await db.execute(
                     update(Instance).where(Instance.id == instance_id).values(**values)
                 )
+                # Restore task status for chat-initiated runs (not managed by dispatcher)
+                if task_id:
+                    result = await db.execute(
+                        update(Task)
+                        .where(Task.id == task_id, Task.status == "executing")
+                        .values(status="completed", completed_at=datetime.utcnow())
+                    )
+                    if result.rowcount:
+                        await self.broadcaster.broadcast("tasks", {
+                            "event": "status_change",
+                            "task_id": task_id,
+                            "new_status": "completed",
+                            "instance_id": instance_id,
+                        })
                 await db.commit()
 
             # Broadcast completion

--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -123,7 +123,9 @@ export function ChatView({ task, projects, onBack, onTaskUpdated }: ChatViewProp
     const eventType = msg.data.event_type as string;
 
     if (eventType === 'process_exit') {
-      setSending(false);
+      // Small delay so any final output messages queued just before
+      // process_exit are rendered before the "thinking" indicator hides.
+      setTimeout(() => setSending(false), 500);
       return;
     }
 


### PR DESCRIPTION
…finishes

Three related fixes:
1. Dispatcher now awaits the output consumer task before marking a task as completed, ensuring all Claude output is processed and broadcast before the status change.
2. Chat-initiated runs (--resume) now set task status to "executing" while Claude is responding, and restore to "completed" when done. This makes the interrupt button survive page refreshes.
3. Frontend delays clearing the "sending" state by 500ms on process_exit so final output messages render before the thinking indicator hides.