### PR TITLE
Fix/cancel kills process

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -144,6 +144,7 @@ async def send_chat_message(
         git_env=git_env,
         thinking_budget=inst.thinking_budget,
         effort_level=effort_level,
+        chat_initiated=True,
     )
 
     task.status = "executing"

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -88,6 +88,22 @@ async def update_task(
     return task
 
 
+async def _stop_task_process(task_id: int, db: AsyncSession) -> bool:
+    """Stop the running Claude Code process for a task, if any. Returns True if stopped."""
+    from backend.main import instance_manager
+    for inst_id, proc in list(instance_manager.processes.items()):
+        if proc.returncode is not None:
+            continue
+        inst = await db.get(Instance, inst_id)
+        if inst and inst.current_task_id == task_id:
+            await instance_manager.stop(inst_id)
+            return True
+    task = await db.get(Task, task_id)
+    if task and task.instance_id:
+        return await instance_manager.stop(task.instance_id)
+    return False
+
+
 @router.delete("/{task_id}")
 async def delete_task(task_id: int, queue: TaskQueue = Depends(_get_queue)):
     ok = await queue.delete(task_id)
@@ -99,30 +115,15 @@ async def delete_task(task_id: int, queue: TaskQueue = Depends(_get_queue)):
 @router.post("/{task_id}/stop-session")
 async def stop_task_session(task_id: int, db: AsyncSession = Depends(get_db)):
     """Stop the running Claude Code session for a task."""
-    from backend.main import instance_manager
-    task = await db.get(Task, task_id)
-    if not task:
-        raise HTTPException(404, "Task not found")
-    # Find the instance running this task by checking instance_manager processes
-    stopped = False
-    for inst_id, proc in list(instance_manager.processes.items()):
-        if proc.returncode is not None:
-            continue
-        inst = await db.get(Instance, inst_id)
-        if inst and inst.current_task_id == task_id:
-            await instance_manager.stop(inst_id)
-            stopped = True
-            break
-    # Fallback: try task.instance_id
-    if not stopped and task.instance_id:
-        stopped = await instance_manager.stop(task.instance_id)
+    stopped = await _stop_task_process(task_id, db)
     if not stopped:
         raise HTTPException(400, "No running session found for this task")
     return {"ok": True}
 
 
 @router.post("/{task_id}/cancel", response_model=TaskResponse)
-async def cancel_task(task_id: int, queue: TaskQueue = Depends(_get_queue)):
+async def cancel_task(task_id: int, queue: TaskQueue = Depends(_get_queue), db: AsyncSession = Depends(get_db)):
+    await _stop_task_process(task_id, db)
     task = await queue.cancel(task_id)
     if not task:
         raise HTTPException(400, "Cannot cancel task")

--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -519,10 +519,13 @@ class GlobalDispatcher:
         max_iterations = task.max_iterations or 50
 
         while True:
-            # Check if task was cancelled externally between iterations
+            # Check if task was cancelled or deleted externally between iterations
             async with self.db_factory() as db:
                 t = await db.get(Task, task.id)
-                if t and t.status == "cancelled":
+                if not t:
+                    logger.info(f"Loop task {task.id} deleted, stopping")
+                    return
+                if t.status == "cancelled":
                     logger.info(f"Loop task {task.id} cancelled, stopping")
                     return
 
@@ -573,11 +576,13 @@ class GlobalDispatcher:
                     process.kill()
                     await process.wait()
 
-            # P1: Check if task was cancelled while the iteration was running
-            # (e.g. user called cancel + stop-session mid-iteration)
+            # P1: Check if task was cancelled/deleted while the iteration was running
             async with self.db_factory() as db:
                 t = await db.get(Task, task.id)
-                if t and t.status == "cancelled":
+                if not t:
+                    logger.info(f"Loop task {task.id} deleted during iteration {iteration}, stopping")
+                    return
+                if t.status == "cancelled":
                     logger.info(f"Loop task {task.id} cancelled during iteration {iteration}, stopping")
                     return
 
@@ -717,10 +722,13 @@ class GlobalDispatcher:
         session_id: str | None = None
 
         while turn < max_turns:
-            # Check if task was cancelled externally between turns
+            # Check if task was cancelled or deleted externally between turns
             async with self.db_factory() as db:
                 t = await db.get(Task, task.id)
-                if t and t.status == "cancelled":
+                if not t:
+                    logger.info(f"Goal task {task.id} deleted, stopping")
+                    return
+                if t.status == "cancelled":
                     logger.info(f"Goal task {task.id} cancelled, stopping")
                     return
 
@@ -762,10 +770,13 @@ class GlobalDispatcher:
                     process.kill()
                     await process.wait()
 
-            # Check if cancelled during execution
+            # Check if cancelled/deleted during execution
             async with self.db_factory() as db:
                 t = await db.get(Task, task.id)
-                if t and t.status == "cancelled":
+                if not t:
+                    logger.info(f"Goal task {task.id} deleted during turn {turn}, stopping")
+                    return
+                if t.status == "cancelled":
                     logger.info(f"Goal task {task.id} cancelled during turn {turn}, stopping")
                     return
 

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -27,7 +27,7 @@ class InstanceManager:
         self.processes: dict[int, asyncio.subprocess.Process] = {}
         self._tasks: dict[int, asyncio.Task] = {}  # instance_id -> consumer task
 
-    async def launch(self, instance_id: int, prompt: str, task_id: int | None = None, cwd: str | None = None, model: str | None = None, resume_session_id: str | None = None, loop_iteration: int | None = None, git_env: dict | None = None, thinking_budget: int | None = None, effort_level: str | None = None) -> int:
+    async def launch(self, instance_id: int, prompt: str, task_id: int | None = None, cwd: str | None = None, model: str | None = None, resume_session_id: str | None = None, loop_iteration: int | None = None, git_env: dict | None = None, thinking_budget: int | None = None, effort_level: str | None = None, chat_initiated: bool = False) -> int:
         """Launch a Claude Code subprocess for the given instance.
 
         If resume_session_id is provided, uses --resume to continue the conversation.
@@ -99,13 +99,13 @@ class InstanceManager:
 
         # Start consuming stdout
         consumer = asyncio.create_task(
-            self._consume_output(instance_id, task_id, process, loop_iteration)
+            self._consume_output(instance_id, task_id, process, loop_iteration, chat_initiated)
         )
         self._tasks[instance_id] = consumer
 
         return process.pid
 
-    async def _consume_output(self, instance_id: int, task_id: int | None, process: asyncio.subprocess.Process, loop_iteration: int | None = None):
+    async def _consume_output(self, instance_id: int, task_id: int | None, process: asyncio.subprocess.Process, loop_iteration: int | None = None, chat_initiated: bool = False):
         """Read NDJSON lines from stdout, parse, store, and broadcast.
 
         This method MUST keep running until the process closes stdout (EOF).
@@ -161,7 +161,7 @@ class InstanceManager:
                     update(Instance).where(Instance.id == instance_id).values(**values)
                 )
                 # Restore task status for chat-initiated runs (not managed by dispatcher)
-                if task_id:
+                if task_id and chat_initiated:
                     result = await db.execute(
                         update(Task)
                         .where(Task.id == task_id, Task.status == "executing")


### PR DESCRIPTION
---                                                                           
  Summary                                                                       
                                                                                
  - Extract _stop_task_process() helper from stop-session endpoint and reuse it
  in cancel_task, so cancelling a loop/goal task also kills the running Claude
  Code process
  - Handle deleted tasks in dispatcher loop/goal checkpoints — previously only
  checked for cancelled status, now also stops when the task is removed from DB 
  
  Test plan                                                                     
                                                                  
  - Start a loop task, click cancel in the UI, verify the Claude Code process is
   killed
  - Start a goal task, click cancel, verify process stops
  - Delete a running loop/goal task, verify dispatcher stops iterating    