### PR TITLE
fix: optimize mobile UI to prevent element overlap

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -144,4 +144,4 @@ if FRONTEND_DIST.is_dir():
         file_path = FRONTEND_DIST / full_path
         if file_path.is_file():
             return FileResponse(str(file_path))
-        return FileResponse(str(FRONTEND_DIST / "index.html"))
+        return FileResponse(str(FRONTEND_DIST / "index.html"), headers={"Cache-Control": "no-cache"})

--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -365,7 +365,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated }: ChatViewProp
             <p className="text-xs text-gray-500 whitespace-nowrap">
               {task.session_id ? 'Session active' : 'No session yet'}
             </p>
-            {contextUsage && <><span className="flex-1" /><ContextUsageIndicator usage={contextUsage} /></>}
+            {contextUsage && <><span className="flex-1" /><span className="hidden sm:flex"><ContextUsageIndicator usage={contextUsage} /></span></>}
           </div>
           {editingTitle ? (
             <input
@@ -412,7 +412,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated }: ChatViewProp
             title="Interrupt session"
           >
             <StopCircle size={14} />
-            {interrupting ? 'Interrupting...' : 'Interrupt'}
+            <span className="hidden sm:inline">{interrupting ? 'Interrupting...' : 'Interrupt'}</span>
           </button>
         )}
       </div>

--- a/frontend/src/components/Tasks/TaskList.tsx
+++ b/frontend/src/components/Tasks/TaskList.tsx
@@ -116,7 +116,7 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat }: TaskListPro
               )}
               <span className="text-xs text-gray-500 capitalize">{t.status.replace('_', ' ')}</span>
               {t.model && (
-                <span className="text-xs bg-gray-700 text-gray-300 px-1.5 rounded">{t.model}</span>
+                <span className="hidden sm:inline text-xs bg-gray-700 text-gray-300 px-1.5 rounded">{t.model}</span>
               )}
             </div>
             {/* Title (editable) */}
@@ -182,7 +182,7 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat }: TaskListPro
                 className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium bg-indigo-600/20 text-indigo-400 hover:bg-indigo-600/30"
                 title="Chat"
               >
-                <MessageCircle size={14} /> Chat
+                <MessageCircle size={14} /><span className="hidden sm:inline"> Chat</span>
               </button>
             )}
             <button

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -802,7 +802,7 @@ export function ProjectsPage() {
             className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-300 border border-gray-600 rounded hover:bg-gray-700"
             title="Global Git Config"
           >
-            <Settings size={14} /> Global Git Config
+            <Settings size={14} /><span className="hidden sm:inline"> Global Git</span> Config
           </button>
           <button
             onClick={() => setShowTagManager(true)}
@@ -815,7 +815,7 @@ export function ProjectsPage() {
             onClick={() => setShowCreate(true)}
             className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-500"
           >
-            <Plus size={14} /> New project
+            <Plus size={14} /><span className="hidden sm:inline"> New project</span><span className="sm:hidden"> New</span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
- Hide model badge on mobile in TaskList (sm:inline)
- Hide Chat button text on mobile, keep icon only
- Hide context usage indicator on mobile in ChatView
- Hide Interrupt button text on mobile, keep icon only
- Shorten "Global Git Config" to "Config" and "New project" to "New" on mobile in ProjectsPage
- Add Cache-Control: no-cache to index.html to prevent stale frontend cache on mobile