### PR TITLE
fix: prevent zombie workers and dangling task references

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -117,6 +117,11 @@ async def stop_task_session(task_id: int, db: AsyncSession = Depends(get_db)):
     """Stop the running Claude Code session for a task."""
     stopped = await _stop_task_process(task_id, db)
     if not stopped:
+        task = await db.get(Task, task_id)
+        if task and task.status in ("executing", "in_progress"):
+            task.status = "completed"
+            await db.commit()
+            return {"ok": True, "note": "No running process found, task marked as completed"}
         raise HTTPException(400, "No running session found for this task")
     return {"ok": True}
 

--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -451,16 +451,14 @@ class GlobalDispatcher:
             if interrupted:
                 logger.info(f"Task {task.id} was interrupted by user (exit_code={exit_code})")
                 async with self.db_factory() as db:
-                    # Reset task to pending so it's not marked as failed,
-                    # but keep session_id so chat can resume
                     await db.execute(
-                        update(Task).where(Task.id == task.id).values(status="pending")
+                        update(Task).where(Task.id == task.id).values(status="completed")
                     )
                     await db.commit()
                 await self.broadcaster.broadcast("tasks", {
                     "event": "status_change",
                     "task_id": task.id,
-                    "new_status": "pending",
+                    "new_status": "completed",
                     "instance_id": instance_id,
                 })
                 return

--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -149,11 +149,37 @@ class GlobalDispatcher:
             return
         self._running = True
 
+        await self._cleanup_stale_instances()
+
         # Ensure we have worker instances up to max_concurrent_instances
         await self._ensure_instances()
 
         self._dispatch_task = asyncio.create_task(self._dispatch_loop())
         logger.info("GlobalDispatcher started")
+
+    async def _cleanup_stale_instances(self):
+        """Reset instances that are stuck in 'running' with a dead PID (e.g. after a crash/restart)."""
+        import os
+        async with self.db_factory() as db:
+            result = await db.execute(
+                select(Instance).where(Instance.status == "running")
+            )
+            for inst in result.scalars().all():
+                alive = False
+                if inst.pid:
+                    try:
+                        os.kill(inst.pid, 0)
+                        alive = True
+                    except OSError:
+                        pass
+                if not alive:
+                    logger.warning(f"Cleaning up stale instance {inst.id} ({inst.name}), dead PID {inst.pid}")
+                    await db.execute(
+                        update(Instance)
+                        .where(Instance.id == inst.id)
+                        .values(status="idle", current_task_id=None, pid=None)
+                    )
+            await db.commit()
 
     async def stop(self):
         self._running = False
@@ -496,6 +522,13 @@ class GlobalDispatcher:
             })
         finally:
             self._running_tasks.pop(instance_id, None)
+            async with self.db_factory() as db:
+                await db.execute(
+                    update(Instance)
+                    .where(Instance.id == instance_id)
+                    .values(status="idle", current_task_id=None, pid=None)
+                )
+                await db.commit()
 
     async def _run_loop_lifecycle(self, instance_id: int, task: Task, cwd: str, git_env: dict | None = None, effort_level: str | None = None):
         """Loop: repeatedly invoke Claude Code until it signals done or abort.

--- a/backend/services/task_queue.py
+++ b/backend/services/task_queue.py
@@ -4,6 +4,7 @@ from sqlalchemy import delete as sa_delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.config import settings
+from backend.models.instance import Instance
 from backend.models.log_entry import LogEntry
 from backend.models.task import Task
 
@@ -98,6 +99,11 @@ class TaskQueue:
         if task.status not in ("pending", "failed", "cancelled", "conflict", "completed"):
             return False
         await self.db.execute(sa_delete(LogEntry).where(LogEntry.task_id == task_id))
+        await self.db.execute(
+            update(Instance)
+            .where(Instance.current_task_id == task_id)
+            .values(current_task_id=None)
+        )
         await self.db.delete(task)
         await self.db.commit()
         return True


### PR DESCRIPTION
- Reset instance to idle in _run_task_lifecycle finally block so workers never stay stuck in 'running' after task completion or crash
- Add _cleanup_stale_instances on dispatcher start to detect and reset instances whose PID is no longer alive (covers service restarts)
- Clear instance.current_task_id when deleting a task to prevent dashboard showing a worker assigned to a non-existent task