### PR TITLE
fix: clean up stuck tasks and zombie instances on dispatcher restart

### DIFF
--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -149,11 +149,43 @@ class GlobalDispatcher:
             return
         self._running = True
 
+        await self._cleanup_stale_state()
+
         # Ensure we have worker instances up to max_concurrent_instances
         await self._ensure_instances()
 
         self._dispatch_task = asyncio.create_task(self._dispatch_loop())
         logger.info("GlobalDispatcher started")
+
+    async def _cleanup_stale_state(self):
+        """Reset instances and tasks stuck in active states after a crash/restart."""
+        import os
+        async with self.db_factory() as db:
+            result = await db.execute(
+                select(Instance).where(Instance.status == "running")
+            )
+            for inst in result.scalars().all():
+                alive = False
+                if inst.pid:
+                    try:
+                        os.kill(inst.pid, 0)
+                        alive = True
+                    except OSError:
+                        pass
+                if not alive:
+                    logger.warning(f"Cleaning up stale instance {inst.id} ({inst.name}), dead PID {inst.pid}")
+                    await db.execute(
+                        update(Instance)
+                        .where(Instance.id == inst.id)
+                        .values(status="idle", current_task_id=None, pid=None)
+                    )
+            result = await db.execute(
+                select(Task).where(Task.status.in_(["executing", "in_progress"]))
+            )
+            for t in result.scalars().all():
+                logger.warning(f"Resetting stuck task {t.id} from '{t.status}' to 'completed'")
+                t.status = "completed"
+            await db.commit()
 
     async def stop(self):
         self._running = False
@@ -496,6 +528,19 @@ class GlobalDispatcher:
             })
         finally:
             self._running_tasks.pop(instance_id, None)
+            try:
+                async with self.db_factory() as db:
+                    await db.execute(
+                        update(Instance)
+                        .where(Instance.id == instance_id)
+                        .values(status="idle", current_task_id=None, pid=None)
+                    )
+                    t = await db.get(Task, task.id)
+                    if t and t.status in ("executing", "in_progress"):
+                        t.status = "completed"
+                    await db.commit()
+            except Exception:
+                logger.exception(f"Failed to cleanup instance {instance_id} / task {task.id}")
 
     async def _run_loop_lifecycle(self, instance_id: int, task: Task, cwd: str, git_env: dict | None = None, effort_level: str | None = None):
         """Loop: repeatedly invoke Claude Code until it signals done or abort.


### PR DESCRIPTION
## Summary                                                      
  - Dispatcher 启动时自动检测并清理僵尸状态：                                                                                                                                                                  
    - PID 已死亡的 instance 重置为 idle                           
    - 卡在 executing/in_progress 的 task 重置为 completed（保留 session_id 可继续 chat）
  - _run_task_lifecycle 的 finally 块增加兜底：lifecycle 结束后重置 instance 为 idle，并恢复卡住的 task                                                                                                      
                                                                                                                                                                                                               
  ## 解决的问题                                                                                                                                                                                                
  - 服务重启后 task 卡在 executing 无人执行，interrupt 按钮无效                                                                                                                                                
  - loop/goal 模式被 CancelledError 中断时 task 状态未清理                                                                                                                                                     
                                                                                                                                                                                                               
  ## Test plan                                                                                                                                                                                                 
  - [ ] 手动将 task 设为 executing，重启 dispatcher，确认 task 自动恢复为 completed                                                                                                                            
  - [ ] 手动将 instance 设为 running + 假 PID，重启 dispatcher，确认 instance 恢复为 idle                                                                                                                      
  - [ ] 正常执行 task，中途杀进程，确认 task 和 instance 状态均被清理        