### PR TITLE
fix: show error feedback on interrupt/cancel failure  

### DIFF
--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -404,7 +404,9 @@ export function ChatView({ task, projects, onBack, onTaskUpdated }: ChatViewProp
                 setSending(false);
                 setStillRunning(false);
                 setError(null);
-              } catch { /* ignore */ }
+              } catch (e) {
+                setError(`Interrupt failed: ${e instanceof Error ? e.message : String(e)}`);
+              }
               finally { setInterrupting(false); }
             }}
             disabled={interrupting}

--- a/frontend/src/components/Chat/LoopChatView.tsx
+++ b/frontend/src/components/Chat/LoopChatView.tsx
@@ -409,8 +409,19 @@ export function LoopChatView({ task, onBack }: LoopChatViewProps) {
 
   const maxIteration = iterationGroups.length > 0 ? iterationGroups[iterationGroups.length - 1][0] : 0;
 
+  const [cancelling, setCancelling] = useState(false);
+  const [cancelError, setCancelError] = useState<string | null>(null);
+
   const handleCancel = async () => {
-    try { await api.cancelTask(task.id); } catch { /* ignore */ }
+    setCancelling(true);
+    setCancelError(null);
+    try {
+      await api.cancelTask(task.id);
+    } catch (e) {
+      setCancelError(`Cancel failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setCancelling(false);
+    }
   };
 
   const isRunning = ['executing', 'in_progress'].includes(task.status);
@@ -466,12 +477,16 @@ export function LoopChatView({ task, onBack }: LoopChatViewProps) {
 
       {/* Footer */}
       {isRunning && (
-        <div className="border-t border-gray-800 bg-gray-900 p-3 flex justify-center">
+        <div className="border-t border-gray-800 bg-gray-900 p-3 flex flex-col items-center gap-2">
+          {cancelError && (
+            <p className="text-xs text-red-400">{cancelError}</p>
+          )}
           <button
             onClick={handleCancel}
-            className="flex items-center gap-2 px-4 py-2 rounded text-sm font-medium bg-red-600/20 text-red-400 hover:bg-red-600/30"
+            disabled={cancelling}
+            className="flex items-center gap-2 px-4 py-2 rounded text-sm font-medium bg-red-600/20 text-red-400 hover:bg-red-600/30 disabled:opacity-50"
           >
-            <XCircle size={16} /> Cancel Loop
+            <XCircle size={16} /> {cancelling ? 'Cancelling...' : 'Cancel Loop'}
           </button>
         </div>
       )}


### PR DESCRIPTION
 ## Summary                                                      
  - ChatView：interrupt 失败时显示错误信息，替代原来的静默吞掉
  - LoopChatView：cancel 按钮增加 disabled 状态防止重复点击，失败时显示错误信息
                                                                               
  ## 解决的问题                                                                                                                                                                                              
  - 用户点击 interrupt/cancel 按钮无反应也无提示，不知道是否生效                                                                                                                                               
                                                                                                                                                                                                               
  ## Test plan                                                                                                                                                                                                 
  - [ ] 在 ChatView 中对已完成的 task 触发 interrupt，确认显示错误提示                                                                                                                                         
  - [ ] 在 LoopChatView 中点击 Cancel Loop，确认按钮变为 Cancelling... 且不可重复点击                                                                                                                          
  - [ ] cancel 失败时确认显示红色错误信息     