### PR TITLE
fix: clear error_message when task completes or starts executing

### DIFF
--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -185,6 +185,7 @@ class GlobalDispatcher:
             for t in result.scalars().all():
                 logger.warning(f"Resetting stuck task {t.id} from '{t.status}' to 'completed'")
                 t.status = "completed"
+                t.error_message = None
             await db.commit()
 
     async def stop(self):
@@ -458,7 +459,7 @@ class GlobalDispatcher:
                 logger.info(f"Task {task.id} was interrupted by user (exit_code={exit_code})")
                 async with self.db_factory() as db:
                     await db.execute(
-                        update(Task).where(Task.id == task.id).values(status="completed")
+                        update(Task).where(Task.id == task.id).values(status="completed", error_message=None)
                     )
                     await db.commit()
                 await self.broadcaster.broadcast("tasks", {
@@ -542,6 +543,7 @@ class GlobalDispatcher:
                 t = await db.get(Task, task_id)
                 if t and t.status in ("executing", "in_progress"):
                     t.status = "completed"
+                    t.error_message = None
                     await db.commit()
                     logger.warning(f"Safety reset: task {task_id} was still '{t.status}' after lifecycle ended")
         except Exception:

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import re
 import signal
 from datetime import datetime
 
@@ -143,9 +144,15 @@ class InstanceManager:
             await process.wait()
             exit_code = process.returncode
 
-            # Read stderr
+            # Read stderr, filtering out launcher informational lines
             stderr_data = await process.stderr.read()
             stderr_text = stderr_data.decode("utf-8", errors="replace").strip() if stderr_data else ""
+            if stderr_text:
+                _ansi_re = re.compile(r"\x1b\[[0-9;]*m")
+                stderr_text = "\n".join(
+                    line for line in stderr_text.splitlines()
+                    if not _ansi_re.sub("", line).startswith("[auto]")
+                ).strip()
 
             # Update instance status
             # SIGINT (exit code -2 or 130) = user interrupt, treat as idle not error
@@ -166,7 +173,7 @@ class InstanceManager:
                         result = await db.execute(
                             update(Task)
                             .where(Task.id == task_id, Task.status == "executing")
-                            .values(status="completed", completed_at=datetime.utcnow())
+                            .values(status="completed", completed_at=datetime.utcnow(), error_message=None)
                         )
                         if result.rowcount:
                             await self.broadcaster.broadcast("tasks", {

--- a/backend/services/task_queue.py
+++ b/backend/services/task_queue.py
@@ -155,6 +155,7 @@ class TaskQueue:
         if task:
             task.status = "in_progress"
             task.started_at = datetime.utcnow()
+            task.error_message = None
             await self.db.commit()
             await self.db.refresh(task)
         return task
@@ -173,7 +174,7 @@ class TaskQueue:
         await self.db.execute(
             update(Task)
             .where(Task.id == task_id)
-            .values(status="completed", completed_at=datetime.utcnow())
+            .values(status="completed", completed_at=datetime.utcnow(), error_message=None)
         )
         await self.db.commit()
 


### PR DESCRIPTION
Previously, error_message persisted even after a task successfully completed, causing the frontend to permanently display stale error text. Now all completion paths and task pickup clear the field.

Also filters out Claude Code launcher [auto] informational lines from stderr to avoid false error reports.