### PR TITLE
fix: ProjectSelect extra option display + service worker network-first

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,10 +1,6 @@
-const CACHE_NAME = 'cc-manager-v1';
-const STATIC_ASSETS = ['/', '/index.html', '/icons/icon.svg'];
+const CACHE_NAME = 'cc-manager-v2';
 
 self.addEventListener('install', (event) => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS))
-  );
   self.skipWaiting();
 });
 
@@ -20,21 +16,21 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
 
-  // Network-first for API and WebSocket
+  // Skip API and WebSocket
   if (url.pathname.startsWith('/api') || url.pathname.startsWith('/ws')) {
     return;
   }
 
-  // Cache-first for static assets
+  // Network-first: try network, fall back to cache
   event.respondWith(
-    caches.match(event.request).then((cached) => {
-      return cached || fetch(event.request).then((response) => {
+    fetch(event.request)
+      .then((response) => {
         if (response.ok) {
           const clone = response.clone();
           caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
         }
         return response;
-      });
-    })
+      })
+      .catch(() => caches.match(event.request))
   );
 });

--- a/frontend/src/components/ProjectSelect.tsx
+++ b/frontend/src/components/ProjectSelect.tsx
@@ -45,7 +45,8 @@ export function ProjectSelect({
   }, []);
 
   const selected = projects.find((p) => String(p.id) === String(value));
-  const displayValue = selected ? selected.name : placeholder;
+  const extraSelected = extraOptions?.find((o) => o.value === String(value));
+  const displayValue = selected ? selected.name : extraSelected ? extraSelected.label : placeholder;
 
   return (
     <div ref={ref} className={`relative ${className}`}>


### PR DESCRIPTION
- ProjectSelect now shows the correct label when an extraOption is selected instead of falling through to placeholder text.
- Service worker switched from cache-first to network-first so users always get the latest frontend after a deploy.