### PR TITLE
fix: stopped instance becomes idle so chat can reuse it

### DIFF
--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -276,7 +276,7 @@ class GlobalDispatcher:
                 # Find idle instances
                 async with self.db_factory() as db:
                     result = await db.execute(
-                        select(Instance).where(Instance.status.in_(["idle", "stopped"]))
+                        select(Instance).where(Instance.status == "idle")
                     )
                     idle_instances = list(result.scalars().all())
 

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -321,7 +321,7 @@ class InstanceManager:
             await db.execute(
                 update(Instance)
                 .where(Instance.id == instance_id)
-                .values(status="stopped", pid=None, current_task_id=None)
+                .values(status="idle", pid=None, current_task_id=None)
             )
             await db.commit()
 

--- a/backend/tests/test_service_instance_manager.py
+++ b/backend/tests/test_service_instance_manager.py
@@ -347,7 +347,7 @@ async def test_stop_terminates(db_factory):
 
     async with db_factory() as db:
         inst = await db.get(Instance, inst_id)
-        assert inst.status == "stopped"
+        assert inst.status == "idle"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
After interrupting a chat, the worker was set to "stopped" status, making it unavailable for subsequent chat messages (which only look for "idle" instances). Now stop() sets the instance back to "idle" directly, eliminating the "stopped" state entirely.