### PR TITLE
feat: PTY 常驻会话模式（use_pty_mode，运行时可切换）

### DIFF
--- a/.claude-manager/loop_signal_5.json
+++ b/.claude-manager/loop_signal_5.json
@@ -1,0 +1,1 @@
+{"action": "continue", "reason": "Task 2 done, task 3 remaining", "progress": "2/3", "summary": "启动了 nohup sleep 500 后台进程并确认运行中"}

--- a/.env.b
+++ b/.env.b
@@ -1,0 +1,6 @@
+AUTH_TOKEN=bcIljazMC2dHJdgw7ENwxenCdNbtAyVn
+DATABASE_URL=sqlite+aiosqlite:///./claude_manager_b.db
+WORKSPACE_DIR=/home/ubuntu/Projects
+AUTO_START_DISPATCHER=true
+PORT=8002
+POOL_ENABLED=true

--- a/.env.backup
+++ b/.env.backup
@@ -1,0 +1,11 @@
+AUTH_TOKEN=ycs_ccm_2026_secure
+DATABASE_URL=sqlite+aiosqlite:///./claude_manager_b.db
+WORKSPACE_DIR=/home/ubuntu/Projects
+AUTO_START_DISPATCHER=true
+PORT=8000
+CODEX_BINARY=/usr/bin/codex
+DEFAULT_CODEX_MODEL=gpt-5.5
+CODEX_MODEL_OPTIONS=default,gpt-5.5,gpt-5.4,gpt-5.4-mini,gpt-5.3-codex-spark
+CODEX_EFFORT_OPTIONS=low,medium,high,xhigh
+DEFAULT_CODEX_GOAL_EVALUATOR_MODEL=gpt-5.4-mini
+POOL_ENABLED=true

--- a/.env.c.backup
+++ b/.env.c.backup
@@ -1,0 +1,13 @@
+AUTH_TOKEN=codex123
+DATABASE_URL=sqlite+aiosqlite:///./claude_manager_c.db
+WORKSPACE_DIR=/home/ubuntu/Projects
+AUTO_START_DISPATCHER=true
+PORT=8004
+POOL_ENABLED=false
+DEFAULT_PROVIDER=codex
+PROVIDER_OPTIONS=claude,codex
+CODEX_BINARY=/home/ubuntu/.local/bin/codex
+DEFAULT_CODEX_MODEL=gpt-5.5
+CODEX_MODEL_OPTIONS=default,gpt-5.5,gpt-5.4,gpt-5.4-mini,gpt-5.3-codex-spark
+CODEX_EFFORT_OPTIONS=low,medium,high,xhigh
+DEFAULT_CODEX_GOAL_EVALUATOR_MODEL=gpt-5.4-mini

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,12 @@ dist/
 .DS_Store
 *.log
 *.egg-info/
+
+# Runtime artifacts (never commit)
+uploads/
+claude_manager.db
+claude_manager.db-*
+ccm.db
+claude_manager_dev.db
+*.db-shm
+*.db-wal

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -138,6 +138,8 @@
 - [x] 端到端冒烟 `scripts/pty_smoke.py`：launch → 事件入库/广播 → exit 0 → **第二轮热复用同一进程 7.8s 完成**
 - 依赖 claude_pty >= a478051（/home/ubuntu/Projects/PTY，dev venv editable 安装）
 - 已知边界：交互模式无 result 事件 → instance.total_cost_usd 暂不更新（待 usage 累加方案）；goal evaluator / monitor 子 agent 仍走 -p（设计如此）
+- **号池注意（Phase 3 最高优先）**：PTY 模式撞限不退进程（-p 靠 exit code + stderr 触发换号），当前表现为 turn 超时而非自动 rotation。迁移基础设施已就绪（config_dir 注入 / migrate_session 硬链接 / on_exit rotation 钩子），缺撞限检测信号——计划扫 PTY 输出 usage-limit 标志或 JSONL error 事件后调 migrate_and_relaunch
+- 开关语义（commit 待定）：关闭 PTY 模式立即回收所有 idle 会话，mid-turn 会话跑完为止
 
 ## 问题记录
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -141,6 +141,15 @@
 - **号池注意（Phase 3 最高优先）**：PTY 模式撞限不退进程（-p 靠 exit code + stderr 触发换号），当前表现为 turn 超时而非自动 rotation。迁移基础设施已就绪（config_dir 注入 / migrate_session 硬链接 / on_exit rotation 钩子），缺撞限检测信号——计划扫 PTY 输出 usage-limit 标志或 JSONL error 事件后调 migrate_and_relaunch
 - 开关语义（commit 待定）：关闭 PTY 模式立即回收所有 idle 会话，mid-turn 会话跑完为止
 
+### 实测反馈修复（2026-06-10，commit 见本条）
+- [x] **回复黑洞**：channel 注入 + pty_bridge_reply 工具让 CC 把真实回答"发"进无人消费的通道，用户只看到一句自我总结（task 47/48/50 的"回复一点点/报告没发/提示词丢失"全是此因）。修复：PTY 仓库移除该工具 + 指示语改为"channel 消息=用户消息，在对话中直接回答"（PTY commit 30b6588）
+- [x] **冷恢复投递被吞**：spawn 瞬间写 stdin 时 TUI 未就绪 → turn 永不开始 → 消费者挂 30 分钟霸占任务队列（task 47/48 后期全卡死）。修复：删除 spawn 时投递，统一走 channel 注入
+- [x] **orphan CC 进程**：后端重启不回收 PTY 会话 → 旧 CC 占着 session 文件。修复：lifespan shutdown 调 pty_backend.shutdown()
+- [x] **池尸体**：手动中断/超时 kill 后死会话残留 pool。修复：全路径 pool.remove
+- [x] **日志盲区**：未配 root logger，claude_pty 日志全丢。修复：basicConfig INFO
+- [x] **额度 unknown**：交互模式无 contextWindow。修复：按 task.model 回填（[1m]→1M，否则 200K）
+- 已知无解/待做：thinking 在交互 JSONL 中加密（CC 行为，仅能显示占位）；loop 单 turn 跑完导致无逐轮进度（Phase 3 设计）；号池撞限检测（Phase 3）
+
 ## 问题记录
 
 > 格式：问题 → 原因 → 解决 → 预防措施 → commit ID

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -131,6 +131,14 @@
 
 ---
 
+### 阶段 N：PTY 常驻会话模式（2026-06-10，commit 1b6d45b）
+- [x] `use_pty_mode` flag（默认 false，-p 行为零变化），claude 任务分流到 claude_pty CCMBackend
+- [x] 输入走 channel 注入（MCP notification），输出走会话 JSONL，事件结构与 StreamParser 对齐，下游无感知
+- [x] stop() PTY 分支（Esc 中断 + 会话回收）；dispatcher 超时 kill 经 proxy 真正回收会话
+- [x] 端到端冒烟 `scripts/pty_smoke.py`：launch → 事件入库/广播 → exit 0 → **第二轮热复用同一进程 7.8s 完成**
+- 依赖 claude_pty >= a478051（/home/ubuntu/Projects/PTY，dev venv editable 安装）
+- 已知边界：交互模式无 result 事件 → instance.total_cost_usd 暂不更新（待 usage 累加方案）；goal evaluator / monitor 子 agent 仍走 -p（设计如此）
+
 ## 问题记录
 
 > 格式：问题 → 原因 → 解决 → 预防措施 → commit ID

--- a/alembic/versions/b7c8d9e0f1a2_add_use_pty_mode_to_global_settings.py
+++ b/alembic/versions/b7c8d9e0f1a2_add_use_pty_mode_to_global_settings.py
@@ -1,0 +1,26 @@
+"""add use_pty_mode to global_settings
+
+Revision ID: b7c8d9e0f1a2
+Revises: a60bd886e7d9
+Create Date: 2026-06-10
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b7c8d9e0f1a2'
+down_revision: Union[str, None] = 'a60bd886e7d9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('global_settings', sa.Column('use_pty_mode', sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('global_settings', 'use_pty_mode')

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -62,6 +62,14 @@ async def update_runtime_settings(
     from backend.main import instance_manager
 
     effective = instance_manager.set_pty_mode(body.use_pty_mode)
+    if not effective:
+        # Reclaim idle PTY processes; mid-turn sessions finish first.
+        drained = await instance_manager.drain_idle_pty_sessions()
+        if drained:
+            import logging
+            logging.getLogger(__name__).info(
+                "PTY mode off: drained %d idle session(s)", drained
+            )
     row = await _get_or_create(db)
     row.use_pty_mode = effective
     await db.commit()

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -3,7 +3,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.database import get_db
 from backend.models.global_settings import GlobalSettings
-from backend.schemas.global_settings import GlobalSettingsUpdate, GlobalSettingsResponse
+from backend.schemas.global_settings import (
+    GlobalSettingsUpdate,
+    GlobalSettingsResponse,
+    RuntimeSettingsUpdate,
+    RuntimeSettingsResponse,
+)
 
 router = APIRouter(prefix="/api/settings", tags=["settings"])
 
@@ -31,3 +36,36 @@ async def update_git_settings(body: GlobalSettingsUpdate, db: AsyncSession = Dep
     await db.commit()
     await db.refresh(row)
     return row
+
+
+def _pty_available() -> bool:
+    try:
+        import claude_pty.adapters.ccm  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+@router.get("/runtime", response_model=RuntimeSettingsResponse)
+async def get_runtime_settings(db: AsyncSession = Depends(get_db)):
+    from backend.main import instance_manager
+    return RuntimeSettingsResponse(
+        use_pty_mode=instance_manager.pty_mode_enabled,
+        pty_available=_pty_available(),
+    )
+
+
+@router.put("/runtime", response_model=RuntimeSettingsResponse)
+async def update_runtime_settings(
+    body: RuntimeSettingsUpdate, db: AsyncSession = Depends(get_db)
+):
+    from backend.main import instance_manager
+
+    effective = instance_manager.set_pty_mode(body.use_pty_mode)
+    row = await _get_or_create(db)
+    row.use_pty_mode = effective
+    await db.commit()
+    return RuntimeSettingsResponse(
+        use_pty_mode=effective,
+        pty_available=_pty_available(),
+    )

--- a/backend/config.py
+++ b/backend/config.py
@@ -29,6 +29,12 @@ class Settings(BaseSettings):
     goal_evaluation_timeout: int = 120
     git_ssh_key_path: str = ""  # Instance-level SSH key, fallback when project has none
 
+    # --- PTY persistent-session mode (claude provider only) ---
+    # When true, claude tasks run in long-lived interactive PTY sessions
+    # (claude_pty): prompts are delivered via channel injection, events come
+    # from the session JSONL. Flip to false to fall back to `claude -p`.
+    use_pty_mode: bool = False
+
     # --- Claude account pool (auto-rotation on rate limit) ---
     pool_enabled: bool = False
     pool_config_path: str = "~/.claude-pool/accounts.json"

--- a/backend/main.py
+++ b/backend/main.py
@@ -90,6 +90,12 @@ async def _reset_stale_discussion_agents():
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await init_db()
+    # Apply persisted runtime-settings override (frontend PTY toggle)
+    from backend.models.global_settings import GlobalSettings
+    async with async_session() as db:
+        row = await db.get(GlobalSettings, 1)
+        if row is not None and row.use_pty_mode is not None:
+            instance_manager.set_pty_mode(row.use_pty_mode)
     await _reset_stale_discussion_agents()
     await _sync_tags()
     if settings.auto_start_dispatcher:

--- a/backend/main.py
+++ b/backend/main.py
@@ -36,6 +36,14 @@ from backend.services.instance_manager import InstanceManager
 from backend.services.ralph_loop import RalphLoop
 from backend.services.dispatcher import GlobalDispatcher
 
+# Logging: surface INFO from our services AND claude_pty in the server log.
+# Without this, PTY delivery/turn diagnostics are invisible (learned the
+# hard way while debugging silent message loss).
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+
 # Global singletons
 logger = logging.getLogger(__name__)
 broadcaster = WebSocketBroadcaster()
@@ -127,6 +135,14 @@ async def lifespan(app: FastAPI):
     upload_cleanup_task = await start_upload_cleanup_loop()
 
     yield
+
+    # Stop all PTY sessions on shutdown — orphaned CC processes keep holding
+    # their session files and break cold resume after restart.
+    if instance_manager._pty_backend is not None:
+        try:
+            await instance_manager._pty_backend.shutdown()
+        except Exception:
+            logger.exception("PTY backend shutdown failed")
 
     upload_cleanup_task.cancel()
     # Stop all running Claude processes before shutdown

--- a/backend/models/global_settings.py
+++ b/backend/models/global_settings.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Integer, String
+from sqlalchemy import Boolean, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.database import Base
@@ -17,3 +17,5 @@ class GlobalSettings(Base):
     git_ssh_key_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
     git_https_username: Mapped[str | None] = mapped_column(String(200), nullable=True)
     git_https_token: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # Runtime mode switches (None = follow env default)
+    use_pty_mode: Mapped[bool | None] = mapped_column(Boolean, nullable=True)

--- a/backend/schemas/global_settings.py
+++ b/backend/schemas/global_settings.py
@@ -19,3 +19,12 @@ class GlobalSettingsResponse(BaseModel):
     git_https_token: str | None
 
     model_config = {"from_attributes": True}
+
+
+class RuntimeSettingsResponse(BaseModel):
+    use_pty_mode: bool
+    pty_available: bool
+
+
+class RuntimeSettingsUpdate(BaseModel):
+    use_pty_mode: bool

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -770,6 +770,17 @@ class InstanceManager:
             await self.broadcaster.broadcast(f"task:{task_id}", broadcast_data)
 
         # Persist and broadcast context usage
+        if context_usage and not context_usage.get("context_window"):
+            # Interactive (PTY) mode has no result event carrying contextWindow.
+            # Fill from the task's model choice: [1m] variants get 1M, else 200K.
+            model_name = ""
+            if task_id:
+                async with self.db_factory() as db:
+                    t = await db.get(Task, task_id)
+                    model_name = (t.model or "") if t else ""
+            context_usage["context_window"] = (
+                1_000_000 if "[1m]" in model_name else 200_000
+            )
         if context_usage and task_id:
             async with self.db_factory() as db:
                 await db.execute(

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -35,20 +35,44 @@ class InstanceManager:
         self._last_stderr: dict[int, str] = {}  # instance_id -> stderr from last run
         self._launch_params: dict[int, dict] = {}  # instance_id -> params for re-launch on rotation
 
-        # PTY persistent-session backend (claude provider only, behind flag).
-        # When active, claude launches are delegated to claude_pty and the
-        # `claude -p` subprocess path below is bypassed entirely.
+        # PTY persistent-session backend (claude provider only).
+        # Runtime-switchable: env USE_PTY_MODE is the boot default, the
+        # /api/settings/runtime endpoint can flip it live (affects new
+        # launches only; running sessions finish on their current path).
         self._pty_backend = None
+        self._pty_enabled = False
         if settings.use_pty_mode:
-            try:
-                from claude_pty.adapters.ccm import CCMBackend
-                self._pty_backend = CCMBackend(self)
-                logger.info("PTY mode enabled (claude_pty persistent sessions)")
-            except ImportError:
-                logger.warning(
-                    "USE_PTY_MODE is set but claude_pty is not installed; "
-                    "falling back to `claude -p` mode"
-                )
+            self.set_pty_mode(True)
+
+    @property
+    def pty_mode_enabled(self) -> bool:
+        return self._pty_enabled and self._pty_backend is not None
+
+    def set_pty_mode(self, enabled: bool) -> bool:
+        """Enable/disable PTY mode at runtime. Returns the effective state.
+
+        The backend is created lazily on first enable and kept on disable
+        (it may still manage sessions that started in PTY mode).
+        """
+        if enabled:
+            if self._pty_backend is None:
+                try:
+                    from claude_pty.adapters.ccm import CCMBackend
+                    self._pty_backend = CCMBackend(self)
+                    logger.info("PTY mode enabled (claude_pty persistent sessions)")
+                except ImportError:
+                    logger.warning(
+                        "PTY mode requested but claude_pty is not installed; "
+                        "staying on `claude -p` mode"
+                    )
+                    self._pty_enabled = False
+                    return False
+            self._pty_enabled = True
+        else:
+            if self._pty_enabled:
+                logger.info("PTY mode disabled; new launches use `claude -p`")
+            self._pty_enabled = False
+        return self._pty_enabled
 
     async def launch(self, instance_id: int, prompt: str, task_id: int | None = None, cwd: str | None = None, model: str | None = None, resume_session_id: str | None = None, loop_iteration: int | None = None, git_env: dict | None = None, thinking_budget: int | None = None, effort_level: str | None = None, chat_initiated: bool = False, config_dir: str | None = None, provider: str = "claude", enable_workflows: bool = False, enabled_skills: dict | None = None) -> int:
         """Launch a Claude Code subprocess for the given instance.
@@ -64,7 +88,7 @@ class InstanceManager:
             from backend.services.mcp_config import generate_mcp_config
             mcp_config_path = generate_mcp_config(task_id, enabled_skills)
 
-        if provider == "claude" and self._pty_backend is not None:
+        if provider == "claude" and self.pty_mode_enabled:
             return await self._launch_pty(
                 instance_id=instance_id,
                 prompt=prompt,

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -48,6 +48,13 @@ class InstanceManager:
     def pty_mode_enabled(self) -> bool:
         return self._pty_enabled and self._pty_backend is not None
 
+    async def drain_idle_pty_sessions(self) -> int:
+        """Stop idle PTY sessions (called after PTY mode is switched off).
+        In-flight turns are untouched and finish on the PTY path."""
+        if self._pty_backend is None:
+            return 0
+        return await self._pty_backend.drain_idle_sessions()
+
     def set_pty_mode(self, enabled: bool) -> bool:
         """Enable/disable PTY mode at runtime. Returns the effective state.
 

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -35,6 +35,21 @@ class InstanceManager:
         self._last_stderr: dict[int, str] = {}  # instance_id -> stderr from last run
         self._launch_params: dict[int, dict] = {}  # instance_id -> params for re-launch on rotation
 
+        # PTY persistent-session backend (claude provider only, behind flag).
+        # When active, claude launches are delegated to claude_pty and the
+        # `claude -p` subprocess path below is bypassed entirely.
+        self._pty_backend = None
+        if settings.use_pty_mode:
+            try:
+                from claude_pty.adapters.ccm import CCMBackend
+                self._pty_backend = CCMBackend(self)
+                logger.info("PTY mode enabled (claude_pty persistent sessions)")
+            except ImportError:
+                logger.warning(
+                    "USE_PTY_MODE is set but claude_pty is not installed; "
+                    "falling back to `claude -p` mode"
+                )
+
     async def launch(self, instance_id: int, prompt: str, task_id: int | None = None, cwd: str | None = None, model: str | None = None, resume_session_id: str | None = None, loop_iteration: int | None = None, git_env: dict | None = None, thinking_budget: int | None = None, effort_level: str | None = None, chat_initiated: bool = False, config_dir: str | None = None, provider: str = "claude", enable_workflows: bool = False, enabled_skills: dict | None = None) -> int:
         """Launch a Claude Code subprocess for the given instance.
 
@@ -48,6 +63,25 @@ class InstanceManager:
         if enabled_skills and provider == "claude" and task_id:
             from backend.services.mcp_config import generate_mcp_config
             mcp_config_path = generate_mcp_config(task_id, enabled_skills)
+
+        if provider == "claude" and self._pty_backend is not None:
+            return await self._launch_pty(
+                instance_id=instance_id,
+                prompt=prompt,
+                task_id=task_id,
+                cwd=cwd,
+                model=model,
+                resume_session_id=resume_session_id,
+                loop_iteration=loop_iteration,
+                git_env=git_env,
+                thinking_budget=thinking_budget,
+                effort_level=effort_level,
+                chat_initiated=chat_initiated,
+                config_dir=config_dir,
+                enable_workflows=enable_workflows,
+                enabled_skills=enabled_skills,
+                mcp_config_path=str(mcp_config_path) if mcp_config_path else None,
+            )
 
         cmd = self._build_command(
             provider=provider,
@@ -134,6 +168,75 @@ class InstanceManager:
         self._tasks[instance_id] = consumer
 
         return process.pid
+
+    async def _launch_pty(
+        self,
+        instance_id: int,
+        prompt: str,
+        task_id: int | None,
+        cwd: str | None,
+        model: str | None,
+        resume_session_id: str | None,
+        loop_iteration: int | None,
+        git_env: dict | None,
+        thinking_budget: int | None,
+        effort_level: str | None,
+        chat_initiated: bool,
+        config_dir: str | None,
+        enable_workflows: bool,
+        enabled_skills: dict | None,
+        mcp_config_path: str | None,
+    ) -> int:
+        """PTY-mode launch: delegate to claude_pty, mirror -p bookkeeping.
+
+        The backend installs a process proxy into self.processes and a
+        consumer into self._tasks; events flow back through _process_event,
+        so everything downstream (DB, WebSocket, dispatcher wait) is
+        unchanged.
+        """
+        await self._pty_backend.launch_for_ccm(
+            instance_id=instance_id,
+            prompt=prompt,
+            task_id=task_id,
+            cwd=cwd,
+            model=model if model and model != "default" else None,
+            resume_session_id=resume_session_id,
+            loop_iteration=loop_iteration,
+            git_env=git_env,
+            thinking_budget=thinking_budget,
+            effort_level=effort_level,
+            chat_initiated=chat_initiated,
+            config_dir=config_dir,
+            enable_workflows=enable_workflows,
+            enabled_skills=enabled_skills,
+            mcp_config_path=mcp_config_path,
+        )
+
+        process = self.processes.get(instance_id)
+        pid = getattr(process, "pid", 0) or 0
+
+        async with self.db_factory() as db:
+            await db.execute(
+                update(Instance)
+                .where(Instance.id == instance_id)
+                .values(
+                    pid=pid,
+                    status="running",
+                    current_task_id=task_id,
+                    started_at=datetime.utcnow(),
+                    last_heartbeat=datetime.utcnow(),
+                )
+            )
+            if task_id:
+                actual_cwd = cwd or os.getcwd()
+                await db.execute(
+                    update(Task)
+                    .where(Task.id == task_id)
+                    .values(last_cwd=actual_cwd)
+                )
+            await db.commit()
+
+        return pid
 
     def _build_command(
         self,
@@ -660,17 +763,31 @@ class InstanceManager:
             return False
 
         self._stopping.add(instance_id)
-        import signal
-        process.send_signal(signal.SIGINT)
-        try:
-            await asyncio.wait_for(process.wait(), timeout=10.0)
-        except asyncio.TimeoutError:
-            process.terminate()
+        pty_managed = (
+            self._pty_backend is not None
+            and instance_id in getattr(self._pty_backend, "_sessions", {})
+        )
+        if pty_managed:
+            # Esc-interrupt the turn, then tear the session down; the proxy's
+            # wait() is unblocked by the backend's on_exit.
+            await self._pty_backend.stop(instance_id)
             try:
-                await asyncio.wait_for(process.wait(), timeout=5.0)
+                await asyncio.wait_for(process.wait(), timeout=10.0)
             except asyncio.TimeoutError:
                 process.kill()
                 await process.wait()
+        else:
+            import signal
+            process.send_signal(signal.SIGINT)
+            try:
+                await asyncio.wait_for(process.wait(), timeout=10.0)
+            except asyncio.TimeoutError:
+                process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=5.0)
+                except asyncio.TimeoutError:
+                    process.kill()
+                    await process.wait()
 
         # Cancel consumer task
         task = self._tasks.get(instance_id)

--- a/backend/tests/test_api_settings_runtime.py
+++ b/backend/tests/test_api_settings_runtime.py
@@ -1,0 +1,39 @@
+"""Tests for /api/settings/runtime — frontend PTY mode toggle."""
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_get_runtime_settings(client):
+    resp = await client.get("/api/settings/runtime")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "use_pty_mode" in data
+    assert "pty_available" in data
+
+
+@pytest.mark.asyncio
+async def test_toggle_pty_mode_roundtrip(client):
+    from backend.main import instance_manager
+
+    try:
+        resp = await client.put(
+            "/api/settings/runtime", json={"use_pty_mode": True}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        # claude_pty installed in dev venv -> enable succeeds
+        assert body["pty_available"] is True
+        assert body["use_pty_mode"] is True
+        assert instance_manager.pty_mode_enabled is True
+
+        resp = await client.put(
+            "/api/settings/runtime", json={"use_pty_mode": False}
+        )
+        assert resp.json()["use_pty_mode"] is False
+        assert instance_manager.pty_mode_enabled is False
+
+        # GET reflects current state
+        resp = await client.get("/api/settings/runtime")
+        assert resp.json()["use_pty_mode"] is False
+    finally:
+        instance_manager.set_pty_mode(False)

--- a/backend/tests/test_api_settings_runtime.py
+++ b/backend/tests/test_api_settings_runtime.py
@@ -37,3 +37,28 @@ async def test_toggle_pty_mode_roundtrip(client):
         assert resp.json()["use_pty_mode"] is False
     finally:
         instance_manager.set_pty_mode(False)
+
+
+@pytest.mark.asyncio
+async def test_toggle_off_drains_idle_sessions(client):
+    from unittest.mock import AsyncMock
+    from backend.main import instance_manager
+
+    class FakeBackend:
+        drain_idle_sessions = AsyncMock(return_value=2)
+
+    old_backend = instance_manager._pty_backend
+    old_enabled = instance_manager._pty_enabled
+    try:
+        instance_manager._pty_backend = FakeBackend()
+        instance_manager._pty_enabled = True
+
+        resp = await client.put(
+            "/api/settings/runtime", json={"use_pty_mode": False}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["use_pty_mode"] is False
+        FakeBackend.drain_idle_sessions.assert_awaited_once()
+    finally:
+        instance_manager._pty_backend = old_backend
+        instance_manager._pty_enabled = old_enabled

--- a/backend/tests/test_service_instance_manager.py
+++ b/backend/tests/test_service_instance_manager.py
@@ -1391,3 +1391,107 @@ async def test_launch_non_chat_does_not_store_params(db_factory):
 
     assert inst_id not in im._launch_params
     await asyncio.sleep(0.1)
+
+
+# ---------- PTY mode wiring (use_pty_mode flag) ----------
+
+class _FakeDB:
+    def __init__(self):
+        self.executed = []
+
+    async def execute(self, stmt):
+        self.executed.append(stmt)
+        return MagicMock(rowcount=1)
+
+    async def commit(self):
+        pass
+
+    async def get(self, model, pk):
+        inst = MagicMock()
+        inst.current_task_id = None
+        return inst
+
+
+class _FakeDBFactory:
+    def __init__(self):
+        self.db = _FakeDB()
+
+    def __call__(self):
+        return self
+
+    async def __aenter__(self):
+        return self.db
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def test_pty_backend_disabled_by_default():
+    im = InstanceManager(MagicMock(), MagicMock())
+    assert im._pty_backend is None
+
+
+@pytest.mark.asyncio
+async def test_launch_delegates_to_pty_backend_for_claude():
+    im = InstanceManager(_FakeDBFactory(), MagicMock())
+    calls = {}
+
+    class FakeBackend:
+        async def launch_for_ccm(self, **kwargs):
+            calls.update(kwargs)
+            im.processes[kwargs["instance_id"]] = MagicMock(pid=4242)
+            return "sess-1"
+
+    im._pty_backend = FakeBackend()
+    pid = await im.launch(
+        instance_id=7, prompt="do it", task_id=3, cwd="/w",
+        model="default", provider="claude",
+    )
+    assert pid == 4242
+    assert calls["instance_id"] == 7
+    assert calls["prompt"] == "do it"
+    assert calls["model"] is None  # "default" normalized away
+    assert calls["cwd"] == "/w"
+
+
+@pytest.mark.asyncio
+async def test_launch_pty_ignores_codex_provider():
+    im = InstanceManager(_FakeDBFactory(), MagicMock())
+
+    class ExplodingBackend:
+        async def launch_for_ccm(self, **kwargs):
+            raise AssertionError("PTY backend must not be used for codex")
+
+    im._pty_backend = ExplodingBackend()
+    fake_proc = MagicMock(pid=1)
+    fake_proc.stdout = None
+    with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=fake_proc)):
+        with patch.object(im, "_consume_output", new=AsyncMock()):
+            await im.launch(
+                instance_id=1, prompt="x", provider="codex", cwd="/w",
+            )
+    assert im.processes[1] is fake_proc
+
+
+@pytest.mark.asyncio
+async def test_stop_uses_pty_backend_for_managed_instance():
+    from claude_pty.adapters.ccm import _PTYProcessProxy
+
+    im = InstanceManager(_FakeDBFactory(), MagicMock())
+    im.broadcaster.broadcast = AsyncMock()
+    proxy = _PTYProcessProxy()
+    im.processes[5] = proxy
+    stopped = []
+
+    class FakeBackend:
+        _sessions = {5: object()}
+
+        async def stop(self, instance_id):
+            stopped.append(instance_id)
+            proxy.complete(0)
+
+    im._pty_backend = FakeBackend()
+    ok = await im.stop(5)
+    assert ok is True
+    assert stopped == [5]
+    assert 5 not in im.processes

--- a/backend/tests/test_service_instance_manager.py
+++ b/backend/tests/test_service_instance_manager.py
@@ -1443,6 +1443,7 @@ async def test_launch_delegates_to_pty_backend_for_claude():
             return "sess-1"
 
     im._pty_backend = FakeBackend()
+    im._pty_enabled = True
     pid = await im.launch(
         instance_id=7, prompt="do it", task_id=3, cwd="/w",
         model="default", provider="claude",
@@ -1495,3 +1496,45 @@ async def test_stop_uses_pty_backend_for_managed_instance():
     assert ok is True
     assert stopped == [5]
     assert 5 not in im.processes
+
+
+# ---------- runtime PTY mode toggle ----------
+
+def test_set_pty_mode_runtime_toggle():
+    im = InstanceManager(MagicMock(), MagicMock())
+    assert im.pty_mode_enabled is False
+
+    # enable: lazy-creates backend (claude_pty installed in dev venv)
+    assert im.set_pty_mode(True) is True
+    assert im.pty_mode_enabled is True
+    assert im._pty_backend is not None
+    backend = im._pty_backend
+
+    # disable: flag off, backend retained for in-flight sessions
+    assert im.set_pty_mode(False) is False
+    assert im.pty_mode_enabled is False
+    assert im._pty_backend is backend
+
+    # re-enable reuses the same backend
+    assert im.set_pty_mode(True) is True
+    assert im._pty_backend is backend
+
+
+@pytest.mark.asyncio
+async def test_launch_respects_disabled_pty_mode():
+    """With a backend present but mode disabled, claude goes through -p."""
+    im = InstanceManager(_FakeDBFactory(), MagicMock())
+
+    class ExplodingBackend:
+        async def launch_for_ccm(self, **kwargs):
+            raise AssertionError("PTY backend must not be used when disabled")
+
+    im._pty_backend = ExplodingBackend()
+    im._pty_enabled = False  # toggled off at runtime
+
+    fake_proc = MagicMock(pid=1)
+    fake_proc.stdout = None
+    with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=fake_proc)):
+        with patch.object(im, "_consume_output", new=AsyncMock()):
+            await im.launch(instance_id=1, prompt="x", provider="claude", cwd="/w")
+    assert im.processes[1] is fake_proc

--- a/dev-review-issues.md
+++ b/dev-review-issues.md
@@ -1,0 +1,175 @@
+# Dev 环境 Monitor Sub-Agent 代码审查
+
+审查时间: 2026-06-09
+
+---
+
+## 严重问题（必须修）
+
+### 1. 进程退出后用过期数据判断状态
+- **文件**: `backend/services/dispatcher.py:1652`
+- `_monitor_session_lifecycle` 在进程退出后检查 `ms.status == "running"` 来决定是否标记 failed
+- 但 `ms` 是在启动进程之前从 DB 读的，子 Agent 在运行期间可能已经通过 `mark_complete` 把状态改成了 completed
+- **结果**: 子 Agent 正确调了 `mark_complete`，但 lifecycle 拿着旧数据覆写成 failed
+
+### 2. `create_monitor_check` 的 checks_done 非原子递增
+- **文件**: `backend/api/monitor.py:153`
+- `ms.checks_done += 1` 是 read → increment → write，并发请求可能丢失计数
+- 影响 `max_checks` 的自动完成判断
+
+### 3. 自动完成后子进程继续空转
+- **文件**: `backend/api/monitor.py:157-170`
+- `checks_done >= max_checks` 时只改 DB 状态为 completed，但子 Agent 进程继续运行直到 4 小时超时
+- 没有机制通知子进程停下来
+
+### 4. `proc.kill()` 后没有 `await proc.wait()`
+- **文件**: `backend/api/monitor.py:111`, `backend/api/tasks.py:186`
+- 会留下僵尸进程
+
+---
+
+## 高危问题
+
+### 5. task 取消时不等待 monitor 任务结束
+- **文件**: `backend/api/tasks.py:181-186`
+- `atask.cancel()` 没有 await，立刻返回，monitor 可能正在写 DB
+
+### 6. 子 Agent 遇到 404/400 会无限重试
+- **文件**: `backend/mcp/ccm_monitor_agent_server.py`
+- session 被删除后，`report_status` 返回 404，子 Agent 不知道该停止，一直重试到 4 小时超时
+
+### 7. 日志文件句柄泄漏
+- **文件**: `backend/services/dispatcher.py:1734-1748`
+- `_launch_monitor_agent` 里如果 `create_subprocess_exec` 失败，`log_fh` 虽然在 except 里关闭了，但正常路径下 `log_fh.close()` 后文件描述符虽然关了，log 文件本身在 finally 里才删除；如果 finally 没执行到就泄漏
+
+---
+
+## 中等问题
+
+### 8. MCP config 里含 auth token 写入 `/tmp`
+- **文件**: `backend/services/mcp_config.py:51`
+- 文件是 world-readable，共享系统上有 token 泄漏风险
+
+### 9. `max_checks` 和 `interval` 没有校验
+- **文件**: `backend/api/monitor.py:23-57`
+- 传 0 或负数会导致立刻完成或 CPU 空转
+
+### 10. `/tmp/ccm_monitor_*.log` 不会被主动清理
+- 依赖 OS 清理 `/tmp`，长期运行会堆积磁盘
+
+---
+
+## 修复优先级
+
+| 优先级 | 问题 | 原因 |
+|--------|------|------|
+| P0 | #1 过期数据覆写状态 | 子 Agent 完成了但被标成 failed，用户可见 bug |
+| P0 | #3 自动完成后进程空转 | 浪费 API 费用 |
+| P0 | #4 proc.kill() 不 await | 僵尸进程堆积 |
+| P1 | #2 非原子递增 | 并发低时不易触发，但逻辑有隐患 |
+| P1 | #5 取消不等待 | 可能导致 DB 不一致 |
+| P1 | #6 子 Agent 无限重试 | 浪费资源 |
+| P2 | #7-#10 | 长期运行才显现 |
+
+---
+---
+
+# 第二轮审查
+
+审查时间: 2026-06-09（未提交的工作区变更）
+
+主要新增: per-task message queue、chat.py 重构为入队模式、monitor 汇报转发主 Agent、子 Agent prompt 强化、disallowedTools 动态生成
+
+---
+
+## 第一轮问题修复情况
+
+| # | 问题 | 状态 | 说明 |
+|---|------|------|------|
+| 1 | 过期数据覆写状态 | **已修** | 进程退出后重新 `db.get(MonitorSession)` |
+| 2 | checks_done 非原子递增 | **未修** | 并发低暂可接受 |
+| 3 | 自动完成后进程空转 | **已修** | auto_complete 时 `sub_proc.kill()` + `await sub_proc.wait()` |
+| 4 | proc.kill() 不 await | **已修** | monitor.py:112, tasks.py:186 均加了 `await proc.wait()` |
+| 5 | task 取消不等待 | **已修** | tasks.py 先 kill+wait 再 cancel |
+| 6 | 子 Agent 无限重试 | **已修** | 400/404 返回 `session_ended: true` |
+| 7 | 日志文件句柄泄漏 | **部分修** | log_fh 存入 `_monitor_log_fhs` 在 finally 关闭，但日志文件不再主动删除 |
+| 8 | MCP config 权限 | **已修** | `os.open(..., 0o600)` |
+| 9 | 参数校验 | **已修** | `interval >= 5`, `max_checks >= 1` |
+| 10 | log 文件清理 | **未修** | finally 里删除逻辑被移除了，只关闭 fh |
+
+---
+
+## 新代码发现的问题
+
+### P0: `_process_queued_message` 和 `_consume_output` 双重管理 task 状态
+- **文件**: `backend/services/dispatcher.py:1964-1968`
+- `_process_queued_message` 在 `process.wait()` 后检查 `task.status == "executing"` 就改成 completed
+- 但 `instance_manager._consume_output`（`chat_initiated=True`）已经在做同样的事
+- **风险**: 如果 `_consume_output` 把 task 改成 failed（exit_code != 0），但 `_process_queued_message` 的 `db.refresh` 在 `_consume_output` commit 之前执行，会读到 `executing` 并覆写成 completed，**吞掉 failed 状态**
+- **建议**: 去掉 `_process_queued_message` 里的状态管理，完全交给 `_consume_output`
+
+### P0: DB session 贯穿整个进程生命周期
+- **文件**: `backend/services/dispatcher.py:1868`
+- `async with self.db_factory() as db:` 打开后，在里面 `await process.wait()`，进程可能运行数分钟
+- SQLite 连接被长期占用；长时间闲置后 `db.refresh(task)` 可能遇到连接池问题
+- **建议**: launch 后关闭 session，`process.wait()` 完成后重新开一个
+
+### P1: chat.py 不再返回 409，前端状态不同步
+- **文件**: `backend/api/chat.py:27-107`
+- 旧代码在 task 忙时返回 409，前端据此显示"任务执行中"
+- 新代码直接入队返回 `{"ok": true, "queued": true}`，但前端 `handleSend` 仍 `setSending(true)` 等待 `process_exit`
+- **结果**: 如果消息排队等了很久才处理，用户看到的是一直在"思考中"；如果前面有多条排队，等待时间更长
+- **建议**: 前端需要适配入队模式——收到 `queued: true` 时不进入 sending 状态，或显示"已排队"
+
+### P1: 消息忙碌超时后被丢弃而非重新入队
+- **文件**: `backend/services/dispatcher.py:1887`
+- 等待 task 空闲的 for 循环超 60 轮（120s）后直接 `return`，消息丢失
+- 没有 idle instance 时会重新入队（line 1896），但 busy timeout 不会
+- 用户消息和 monitor 重要汇报都可能被静默丢弃
+- **建议**: busy timeout 也应该重新入队，或者至少通知前端消息发送失败
+
+### P1: `complete_monitor_session` 的 is_important 改成了 False
+- **文件**: `backend/api/monitor.py:280`
+- 子 Agent 调 `mark_complete` 时 WebSocket 广播的 `is_important` 从 True 改成 False
+- `mark_complete` 通常代表监控目标完成/失败，是最重要的事件
+- **影响**: 前端可能不会突出显示这个关键消息
+
+### P2: `instance_id=1` 硬编码
+- **文件**: `backend/api/monitor.py:178`, `backend/api/chat.py:73`
+- `LogEntry(instance_id=1, ...)` 硬编码。如果 id=1 的 instance 被删，外键约束可能失败
+- **建议**: 用实际的 instance id 或设为 nullable
+
+### P2: SubSessionIndicator.tsx 被清空但没删除
+- **文件**: `frontend/src/components/Chat/SubSessionIndicator.tsx`
+- 内容清空成 0 字节但文件还在，应该 `git rm`
+
+---
+
+## 新架构评价
+
+### 做得好的地方
+- **per-task message queue** 是正确的架构方向，解决了 chat 和 monitor 汇报的串行化问题
+- **QueuedMessage 优先级** 设计合理：用户消息 > monitor 完成通知 > monitor 重要汇报
+- **disallowedTools 动态生成**（`SKILL_DISALLOWED_BUILTINS`）比硬编码更灵活
+- **子 Agent prompt 强化** 明确禁止用内置 Agent/Monitor 工具，用 python sleep 替代 bash sleep
+- **monitor 汇报转发主 Agent** 通过 `enqueue_message` 实现，让主 Agent 能向用户转达监控结果
+- **chat history 的 source 标记** 可以区分普通消息和 monitor 来源的消息
+
+### 需要改进的地方
+- 前后端对"入队模式"的适配还不完整（前端仍按即时发送设计）
+- `_process_queued_message` 和 `_consume_output` 的职责边界需要厘清
+- DB session 生命周期管理需要拆分
+
+---
+
+## 修复优先级总览
+
+| 优先级 | 问题 | 原因 |
+|--------|------|------|
+| P0 | 双重 task 状态管理 | 可能吞掉 failed 状态 |
+| P0 | DB session 跨进程生命周期 | 连接池问题、长期占用 |
+| P1 | 前端未适配入队模式 | 用户体验：一直显示"思考中" |
+| P1 | 消息 busy timeout 被丢弃 | 用户消息静默丢失 |
+| P1 | mark_complete is_important=False | 关键事件不被突出显示 |
+| P2 | instance_id=1 硬编码 | 外键约束风险 |
+| P2 | SubSessionIndicator.tsx 残留 | 代码卫生 |

--- a/docs/monitor-mode-design.md
+++ b/docs/monitor-mode-design.md
@@ -1,0 +1,466 @@
+# Monitor 功能设计方案
+
+## 概述
+
+为 CCM 新增 Monitor（监控）功能，解决长时间运行任务无法主动汇报进度的问题。Monitor 通过**独立的 Claude session** 定期轮询检查任务进展并向用户汇报，与主任务并行运行、互不干扰。
+
+Monitor 包含两个层面：
+
+1. **Monitor 模式** — 与 loop/goal 并列的新任务模式，适用于"启动一个长任务然后定期检查"的场景
+2. **监控叠加** — loop 和 goal 模式可选开启监控，为已有模式附加定期汇报能力
+
+## 核心设计
+
+### 架构：双 Session 并行
+
+```
+┌─────────────────────────────────────────────────┐
+│  Task (monitor_enabled = true)                  │
+│                                                 │
+│  ┌──────────────┐    ┌────────────────────────┐ │
+│  │  主 Session   │    │  Monitor Session (独立) │ │
+│  │  执行任务     │    │  定期检查 + 汇报        │ │
+│  │  (loop/goal/  │    │  每隔 interval 唤醒     │ │
+│  │   monitor)    │    │  只读，不修改文件       │ │
+│  └──────────────┘    └────────────────────────┘ │
+│        ↓ 共享项目目录、日志文件 ↑                  │
+└─────────────────────────────────────────────────┘
+```
+
+- **主 Session**：按原有模式逻辑执行任务（loop 的信号文件、goal 的评估器等）
+- **Monitor Session**：完全独立的 Claude 进程，每隔 `monitor_interval` 秒启动一次，检查项目目录下的日志、进程状态、文件变化等，向用户汇报进展
+- 两者**并行运行**，Monitor 从主 Session 启动的同时就开始轮询
+
+### 各模式下的行为差异
+
+| | 主 Session 完成判断 | Monitor 角色 | 主 Session 额外提示 |
+|---|---|---|---|
+| **Monitor 模式** | 由轮询 Session 判断 | 汇报 + 判断完成 | "尽量后台运行后退出，保持日志输出" |
+| **Loop + 监控** | Signal file（原逻辑不变） | 仅汇报，不影响流程 | "已开启监控，请保持充分日志输出" |
+| **Goal + 监控** | 评估器（原逻辑不变） | 仅汇报，不影响流程 | "已开启监控，请保持充分日志输出" |
+| **Auto 模式** | 不可开启监控 | — | — |
+
+### 监控开启规则
+
+- **Monitor 模式**：默认开启监控，必须配置 `monitor_interval`
+- **Loop / Goal 模式**：可选开启，开启后需配置 `monitor_interval`
+- **Auto 模式**：不允许开启监控（单轮执行，无长任务语义）
+
+## 数据模型变更
+
+### Task 模型新增字段
+
+```python
+# backend/models/task.py
+
+# mode 字段扩展：新增 "monitor" 选项
+mode: Mapped[str] = mapped_column(String(20), default="auto")
+# 可选值: "auto", "plan", "loop", "goal", "monitor"
+
+# Monitor 相关字段
+monitor_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+monitor_interval: Mapped[int | None] = mapped_column(Integer, nullable=True)  # 轮询间隔（秒）
+monitor_model: Mapped[str | None] = mapped_column(String(100), nullable=True)  # 轮询用模型（默认 haiku）
+monitor_max_checks: Mapped[int] = mapped_column(Integer, default=100)  # 最大检查次数（兜底）
+monitor_checks_done: Mapped[int] = mapped_column(Integer, default=0)  # 已完成检查次数
+monitor_last_summary: Mapped[str | None] = mapped_column(Text, nullable=True)  # 最近一次汇报摘要
+```
+
+### Schema 变更
+
+```python
+# backend/schemas/task.py
+
+class TaskCreate(BaseModel):
+    # ... 现有字段 ...
+    monitor_enabled: bool = False
+    monitor_interval: int | None = None      # 秒，如 300 = 5 分钟
+    monitor_model: str | None = None         # 默认 claude-haiku-4-5
+    monitor_max_checks: int = 100
+
+    @model_validator(mode="after")
+    def validate_monitor(self):
+        if self.mode == "monitor":
+            self.monitor_enabled = True
+            if not self.monitor_interval:
+                raise ValueError("monitor 模式必须配置 monitor_interval")
+        if self.monitor_enabled and not self.monitor_interval:
+            raise ValueError("开启监控必须配置 monitor_interval")
+        if self.monitor_enabled and self.mode == "auto":
+            raise ValueError("auto 模式不支持开启监控")
+        return self
+```
+
+### TaskResponse 新增字段
+
+```python
+class TaskResponse(BaseModel):
+    # ... 现有字段 ...
+    monitor_enabled: bool
+    monitor_interval: int | None
+    monitor_model: str | None
+    monitor_max_checks: int
+    monitor_checks_done: int
+    monitor_last_summary: str | None
+```
+
+## 后端实现
+
+### Dispatcher 变更
+
+#### 1. 主流程入口（_execute_task_on_instance）
+
+在现有模式分发逻辑后，启动 monitor 并行循环：
+
+```python
+# dispatcher.py
+
+async def _execute_task_on_instance(self, instance_id, task, ...):
+    monitor_task = None
+
+    # 如果开启了监控，启动并行轮询
+    if task.monitor_enabled and task.monitor_interval:
+        monitor_task = asyncio.create_task(
+            self._run_monitor_loop(task)
+        )
+
+    # 按原有模式执行主任务
+    if task.mode == "monitor":
+        await self._run_monitor_main_session(instance_id, task, cwd, ...)
+    elif task.mode == "loop":
+        await self._run_loop_lifecycle(instance_id, task, cwd, ...)
+    elif task.mode == "goal":
+        await self._run_goal_lifecycle(instance_id, task, cwd, ...)
+    else:
+        # auto / plan
+        ...
+
+    # 主任务结束后，如果是 loop/goal 模式，取消 monitor
+    if monitor_task and task.mode != "monitor":
+        monitor_task.cancel()
+```
+
+#### 2. Monitor 模式主 Session
+
+```python
+async def _run_monitor_main_session(self, instance_id, task, cwd, ...):
+    """Monitor 模式：执行用户的任务（启动脚本等），主 session 结束后
+    不标记 completed，等轮询 session 判断。"""
+
+    prompt = self._build_monitor_main_prompt(task)
+
+    await self.instance_manager.launch(
+        instance_id=instance_id,
+        prompt=prompt,
+        task_id=task.id,
+        cwd=cwd,
+        model=task.model,
+        ...
+    )
+
+    # 等待主进程结束
+    process = self.instance_manager.processes.get(instance_id)
+    if process:
+        await process.wait()
+
+    # 注意：不标记 completed，保持 executing 状态
+    # 任务完成由 _run_monitor_loop 中的轮询 session 判断
+```
+
+#### 3. Monitor 轮询循环（核心）
+
+```python
+async def _run_monitor_loop(self, task: Task):
+    """独立的监控轮询循环，与主任务并行运行。
+    每隔 interval 秒启动一个新的 Claude session 检查进度。"""
+
+    signal_path = Path(cwd) / ".claude-manager" / f"monitor_signal_{task.id}.json"
+    signal_path.parent.mkdir(parents=True, exist_ok=True)
+    checks_done = 0
+
+    while checks_done < task.monitor_max_checks:
+        await asyncio.sleep(task.monitor_interval)
+
+        # 检查 task 是否已被取消/删除/完成（loop/goal 模式可能已结束）
+        async with self.db_factory() as db:
+            t = await db.get(Task, task.id)
+            if not t or t.status in ("cancelled", "completed", "failed"):
+                return
+
+        # 清除 signal file
+        signal_path.unlink(missing_ok=True)
+
+        # 构建轮询 prompt
+        prompt = self._build_monitor_check_prompt(task, checks_done, signal_path)
+
+        # 启动独立 Claude 进程（不复用主 session）
+        monitor_model = task.monitor_model or "claude-haiku-4-5"
+        # 用 instance_manager 或直接起子进程
+        # 这里需要一个不占用 instance 的轻量调用方式
+        result = await self._run_monitor_subprocess(
+            prompt=prompt,
+            cwd=task.last_cwd or task.target_repo,
+            model=monitor_model,
+            task_id=task.id,
+        )
+
+        checks_done += 1
+
+        # 读取 signal file 判断是否完成（仅 monitor 模式）
+        if task.mode == "monitor":
+            signal = self._read_monitor_signal(signal_path)
+            if signal.get("status") == "done":
+                # 标记任务完成
+                async with self.db_factory() as db:
+                    queue = TaskQueue(db)
+                    await queue.mark_completed(task.id)
+                # 广播
+                await self.broadcaster.broadcast("tasks", {
+                    "event": "status_change",
+                    "task_id": task.id,
+                    "new_status": "completed",
+                })
+                return
+
+        # 更新检查计数和摘要
+        async with self.db_factory() as db:
+            await db.execute(
+                update(Task)
+                .where(Task.id == task.id)
+                .values(
+                    monitor_checks_done=checks_done,
+                    monitor_last_summary=signal.get("summary", ""),
+                )
+            )
+            await db.commit()
+
+        # 广播监控汇报
+        await self.broadcaster.broadcast(f"task:{task.id}", {
+            "event_type": "monitor_check",
+            "check_number": checks_done,
+            "summary": signal.get("summary", ""),
+            "status": signal.get("status", "running"),
+        })
+```
+
+#### 4. Monitor 轮询子进程
+
+```python
+async def _run_monitor_subprocess(self, prompt, cwd, model, task_id):
+    """启动一个独立的轻量 Claude 进程进行监控检查。
+    不占用 instance，不使用 --resume。"""
+
+    cmd = [
+        settings.claude_binary,
+        "-p", prompt,
+        "--model", model,
+        "--output-format", "stream-json",
+        "--dangerously-skip-permissions",
+    ]
+
+    env = {
+        k: v for k, v in os.environ.items()
+        if k.upper() not in ("CLAUDECODE", "CLAUDE_CODE")
+    }
+
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=cwd,
+        env=env,
+    )
+
+    # 消费输出并广播到前端（标记为 monitor 输出）
+    await self._consume_monitor_output(process, task_id)
+
+    await asyncio.wait_for(process.wait(), timeout=120)
+```
+
+### Prompt 构建
+
+#### Monitor 模式主 Session Prompt
+
+```python
+def _build_monitor_main_prompt(self, task: Task) -> str:
+    return (
+        "请阅读项目根目录的 CLAUDE.md 了解项目规范。\n\n"
+        "【监控模式】这是一个监控任务。请执行用户的任务后尽量让自己退出：\n"
+        "- 对于需要长时间运行的进程（训练、构建等），请放到后台运行"
+        "（nohup/tmux/screen），确保日志输出到文件\n"
+        "- 如果任务确实需要你持续操作，可以继续运行\n"
+        "- 确保有清晰的日志文件，监控进程会依据日志判断任务进展\n\n"
+        f"任务:\n{task.description}"
+    )
+```
+
+#### Monitor 轮询 Prompt
+
+```python
+def _build_monitor_check_prompt(self, task, check_number, signal_path):
+    return (
+        f"你是一个监控进程，这是第 {check_number + 1} 次检查。\n\n"
+        f"需要监控的任务:\n{task.description}\n\n"
+        "请检查这个任务的执行进展：\n"
+        "1. 检查相关进程是否还在运行（ps aux）\n"
+        "2. 查看日志文件的最新内容\n"
+        "3. 判断任务完成度\n\n"
+        "【重要】你是只读的监控者，不要修改任何文件或执行任何会影响任务的操作。\n\n"
+        "检查完毕后，将结果写入 signal file：\n"
+        f"echo '{{\"status\": \"running 或 done\", \"summary\": \"简短进度摘要\"}}' > {signal_path}\n"
+        "- status: 任务还在进行写 running，已完成写 done\n"
+        "- summary: 一句话描述当前进度"
+    )
+```
+
+#### Loop/Goal + 监控的额外提示
+
+在现有的 `_build_loop_prompt` 和 `_build_goal_initial_prompt` 中追加：
+
+```python
+def _get_monitor_hint(self, task: Task) -> str:
+    if not task.monitor_enabled:
+        return ""
+    return (
+        "\n\n【监控已开启】有独立的监控进程会每隔 "
+        f"{task.monitor_interval} 秒检查任务进展。"
+        "请在执行过程中保持充分的日志输出（进度、状态、关键结果），"
+        "方便监控进程判断进展并向用户汇报。"
+    )
+```
+
+## 中断逻辑
+
+### 用户点击中断时需要停止的内容
+
+| 模式 | 停止主 Session | 停止 Monitor 轮询 |
+|---|---|---|
+| Monitor 模式 | 如果还在跑，kill 掉 | 取消轮询循环 |
+| Loop + 监控 | kill 当前迭代进程 | 取消轮询循环 |
+| Goal + 监控 | kill 当前 turn 进程 | 取消轮询循环 |
+
+### 实现
+
+```python
+async def cancel_task(self, task_id: int):
+    # 现有逻辑：停止主进程
+    ...
+
+    # 新增：取消 monitor 循环
+    monitor_handle = self._monitor_tasks.get(task_id)
+    if monitor_handle:
+        monitor_handle.cancel()
+        del self._monitor_tasks[task_id]
+```
+
+Dispatcher 需要维护一个 `_monitor_tasks: dict[int, asyncio.Task]` 来追踪活跃的 monitor 循环。
+
+## 前端变更
+
+### 1. TaskForm — 新增 Monitor 相关控件
+
+**模式选择扩展：**
+
+```
+Mode: [auto] [plan] [loop] [goal] [monitor]  ← 新增
+```
+
+**Monitor 模式选中时显示：**
+
+```
+┌─────────────────────────────────────┐
+│ 轮询间隔:  [300] 秒 (5 分钟)         │
+│ 监控模型:  [claude-haiku-4-5  ▼]    │
+│ 最大检查次数: [100]                   │
+└─────────────────────────────────────┘
+```
+
+**Loop / Goal 模式时显示可选监控开关：**
+
+```
+┌─────────────────────────────────────┐
+│ ☐ 开启监控                          │
+│   （勾选后展开 interval/model 配置）  │
+└─────────────────────────────────────┘
+```
+
+### 2. ChatView — 监控输出折叠区域
+
+在 Chat 主区域之外，新增一个可折叠的监控面板：
+
+```
+┌─────────────────────────────────────────────┐
+│  Chat 主区域（主 Session 输出）               │
+│  [User] 运行训练脚本 train.py                │
+│  [Claude] 已启动训练，日志输出到 train.log... │
+│  ...                                        │
+├─────────────────────────────────────────────┤
+│  ▼ 监控汇报 (3/100)          下次检查: 2:34  │
+│  ┌─────────────────────────────────────────┐│
+│  │ [#3] 训练进行中，epoch 45/100，          ││
+│  │      loss=0.23，预计还需 40 分钟          ││
+│  ├─────────────────────────────────────────┤│
+│  │ [#2] 训练进行中，epoch 30/100，          ││
+│  │      loss=0.31                           ││
+│  ├─────────────────────────────────────────┤│
+│  │ [#1] 训练已启动，epoch 5/100，           ││
+│  │      loss=1.24                           ││
+│  └─────────────────────────────────────────┘│
+└─────────────────────────────────────────────┘
+```
+
+**关键 UI 元素：**
+
+- **折叠标题**：显示已检查次数 / 最大次数，下次检查倒计时
+- **汇报列表**：最新的在最上面，每条显示检查编号 + 摘要
+- **展开详情**：点击单条可展开完整的 monitor session 输出
+- **视觉区分**：用不同背景色或边框与主 Chat 输出区分
+
+### 3. WebSocket 事件
+
+新增 `monitor_check` 事件类型：
+
+```typescript
+interface MonitorCheckEvent {
+    event_type: "monitor_check";
+    check_number: number;
+    summary: string;
+    status: "running" | "done";
+}
+```
+
+前端在 `task:{id}` channel 上监听此事件，更新折叠面板内容。
+
+## Alembic Migration
+
+```python
+"""add monitor fields to task
+
+Revision ID: xxxx
+"""
+
+def upgrade():
+    op.add_column('tasks', sa.Column('monitor_enabled', sa.Boolean(), default=False))
+    op.add_column('tasks', sa.Column('monitor_interval', sa.Integer(), nullable=True))
+    op.add_column('tasks', sa.Column('monitor_model', sa.String(100), nullable=True))
+    op.add_column('tasks', sa.Column('monitor_max_checks', sa.Integer(), default=100))
+    op.add_column('tasks', sa.Column('monitor_checks_done', sa.Integer(), default=0))
+    op.add_column('tasks', sa.Column('monitor_last_summary', sa.Text(), nullable=True))
+
+def downgrade():
+    op.drop_column('tasks', 'monitor_last_summary')
+    op.drop_column('tasks', 'monitor_checks_done')
+    op.drop_column('tasks', 'monitor_max_checks')
+    op.drop_column('tasks', 'monitor_model')
+    op.drop_column('tasks', 'monitor_interval')
+    op.drop_column('tasks', 'monitor_enabled')
+```
+
+## 实现顺序建议
+
+1. **Phase 1 — 数据层**：Task 模型 + Schema + Migration
+2. **Phase 2 — 后端核心**：Dispatcher monitor 轮询循环 + 子进程调用 + Prompt 构建
+3. **Phase 3 — 前端 TaskForm**：Monitor 模式选项 + 监控开关 + 配置表单
+4. **Phase 4 — 前端 ChatView**：监控折叠面板 + WebSocket 事件处理
+5. **Phase 5 — 中断逻辑**：取消时同时停止主进程 + monitor 循环
+6. **Phase 6 — 测试**：各模式组合测试（monitor 单独、loop+监控、goal+监控）

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -38,6 +38,11 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   return res.json();
 }
 
+export interface RuntimeSettings {
+  use_pty_mode: boolean;
+  pty_available: boolean;
+}
+
 export interface GlobalSettings {
   git_author_name: string | null;
   git_author_email: string | null;
@@ -341,6 +346,9 @@ export const api = {
     }),
 
   // Global Settings
+  getRuntimeSettings: () => request<RuntimeSettings>('/api/settings/runtime'),
+  updateRuntimeSettings: (data: { use_pty_mode: boolean }) =>
+    request<RuntimeSettings>('/api/settings/runtime', { method: 'PUT', body: JSON.stringify(data) }),
   getGitSettings: () => request<GlobalSettings>('/api/settings/git'),
   updateGitSettings: (data: Partial<GlobalSettings>) =>
     request<GlobalSettings>('/api/settings/git', { method: 'PUT', body: JSON.stringify(data) }),

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Sun, Moon, Globe, Menu, X } from 'lucide-react';
+import { api } from '../../api/client';
+import type { RuntimeSettings } from '../../api/client';
 import { isCapacitor } from '../../config/server';
 import { getTheme, toggleTheme } from '../../config/theme';
 import { getTimezone, setTimezone, TIMEZONE_OPTIONS } from '../../config/timezone';
@@ -13,6 +15,25 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
   const [theme, setTheme] = useState(getTheme());
   const [tz, setTz] = useState(getTimezone());
   const [menuOpen, setMenuOpen] = useState(false);
+  const [runtime, setRuntime] = useState<RuntimeSettings | null>(null);
+  const [switching, setSwitching] = useState(false);
+
+  useEffect(() => {
+    api.getRuntimeSettings().then(setRuntime).catch(() => setRuntime(null));
+  }, []);
+
+  const togglePtyMode = useCallback(async () => {
+    if (!runtime || switching || !runtime.pty_available) return;
+    setSwitching(true);
+    try {
+      const updated = await api.updateRuntimeSettings({ use_pty_mode: !runtime.use_pty_mode });
+      setRuntime(updated);
+    } catch {
+      // keep previous state on failure
+    } finally {
+      setSwitching(false);
+    }
+  }, [runtime, switching]);
 
   const pages = [
     { key: 'dashboard', label: 'Dashboard' },
@@ -50,6 +71,35 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
           ))}
         </nav>
         <div className="ml-auto flex items-center gap-1">
+          {runtime && (
+            <div
+              className="flex items-center gap-1.5 mr-1 px-2 py-1 rounded bg-gray-800 border border-gray-700"
+              title={
+                !runtime.pty_available
+                  ? 'claude_pty 未安装，PTY 模式不可用'
+                  : runtime.use_pty_mode
+                    ? 'PTY 常驻会话模式：开（多轮免冷启动；切换仅影响新任务）'
+                    : 'PTY 常驻会话模式：关（使用 claude -p 一次性进程）'
+              }
+            >
+              <span className={`text-xs font-medium ${runtime.use_pty_mode ? 'text-green-400' : 'text-gray-400'}`}>
+                PTY
+              </span>
+              <button
+                onClick={togglePtyMode}
+                disabled={!runtime.pty_available || switching}
+                className={`relative inline-flex h-4 w-8 items-center rounded-full transition-colors disabled:opacity-50 ${
+                  runtime.use_pty_mode ? 'bg-green-500' : 'bg-gray-600'
+                }`}
+              >
+                <span
+                  className={`inline-block h-3 w-3 transform rounded-full bg-white transition-transform ${
+                    runtime.use_pty_mode ? 'translate-x-4' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            </div>
+          )}
           <div className="relative flex items-center">
             <Globe size={16} className="absolute left-2 text-gray-500 pointer-events-none" />
             <select

--- a/plans/pr-monitor.md
+++ b/plans/pr-monitor.md
@@ -1,0 +1,406 @@
+# GitHub PR Monitor — 实现方案
+
+## 概述
+
+为 CCM 新增 GitHub PR 自动审核功能。通过 GitHub Webhook 实时接收 PR 事件，自动创建 CCM task 让 Claude 审核代码，根据审核结果自动执行操作（merge / 写批注 / 修复代码）。
+
+纯事件驱动，不轮询。
+
+## 流程
+
+```
+GitHub PR created/updated
+  → POST /api/github/webhook
+  → HMAC-SHA256 验签
+  → 创建 PRReview 记录
+  → 自动创建 CCM task（Claude 审核）
+  → Claude 读取 PR diff，审核代码
+  → 根据结果执行操作：
+      - 代码没问题 + auto_merge → approve + merge
+      - 代码没问题 + 不 auto_merge → approve + LGTM 评论
+      - 代码有问题 + auto_merge → 修复代码 + push + merge
+      - 代码有问题 + 不 auto_merge → request-changes 批注
+  → 更新 PRReview 状态
+```
+
+## 1. 数据库模型
+
+### MonitoredRepo — 监控配置
+
+```python
+class MonitoredRepo(Base):
+    __tablename__ = "monitored_repos"
+
+    id              = Column(Integer, primary_key=True, autoincrement=True)
+    repo_full_name  = Column(String(200), unique=True, nullable=False)   # "owner/repo"
+    project_id      = Column(Integer, nullable=True)                     # 关联 CCM project（可选）
+    enabled         = Column(Boolean, default=True)                      # 开关
+    auto_merge      = Column(Boolean, default=False)                     # 自动 merge 还是只审核
+    webhook_secret  = Column(String(200), nullable=False)                # HMAC 验签密钥
+    review_model    = Column(String(100), nullable=True)                 # 审核用的模型
+    default_branch  = Column(String(100), default="main")               # 只监控目标为此分支的 PR
+    status          = Column(String(20), default="active")               # active / error
+    error_message   = Column(Text, nullable=True)
+    created_at      = Column(DateTime, default=func.now())
+    updated_at      = Column(DateTime, nullable=True, onupdate=func.now())
+```
+
+### PRReview — 审核记录
+
+```python
+class PRReview(Base):
+    __tablename__ = "pr_reviews"
+
+    id              = Column(Integer, primary_key=True, autoincrement=True)
+    repo_id         = Column(Integer, ForeignKey("monitored_repos.id"), nullable=False, index=True)
+    pr_number       = Column(Integer, nullable=False)
+    pr_title        = Column(String(500), nullable=True)
+    pr_author       = Column(String(200), nullable=True)
+    pr_url          = Column(String(500), nullable=True)
+    task_id         = Column(Integer, ForeignKey("tasks.id"), nullable=True, index=True)
+    status          = Column(String(30), default="pending")
+    # pending → reviewing → approved / merged / commented / fix_pushed / error
+    review_summary  = Column(Text, nullable=True)                       # Claude 的审核摘要
+    action_taken    = Column(String(50), nullable=True)
+    # approved_merged / lgtm_comment / fix_pushed_merged / review_comments / error
+    created_at      = Column(DateTime, default=func.now())
+    completed_at    = Column(DateTime, nullable=True)
+```
+
+### 索引
+
+- `monitored_repos.repo_full_name` — unique
+- `pr_reviews.repo_id` — 查询某仓库的审核历史
+- `pr_reviews.task_id` — 关联 CCM task
+- `pr_reviews(repo_id, pr_number)` — 去重检查
+
+## 2. API 端点
+
+### 仓库管理 `/api/pr-monitor/repos`
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/` | 列出所有监控仓库 |
+| POST | `/` | 添加仓库（自动生成 webhook_secret） |
+| GET | `/{id}` | 获取单个仓库配置 |
+| PUT | `/{id}` | 更新配置 |
+| DELETE | `/{id}` | 删除仓库 |
+| POST | `/{id}/toggle` | 快速开关切换 |
+
+### 审核记录
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/{id}/reviews` | 该仓库的审核历史（分页） |
+| GET | `/reviews/{review_id}` | 单条审核详情 |
+
+### Webhook 接收
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| POST | `/api/github/webhook` | GitHub 推送入口，公开无 Bearer auth |
+
+## 3. Webhook 处理
+
+### 验签流程
+
+```python
+@router.post("/api/github/webhook")
+async def github_webhook(request: Request, db: AsyncSession = Depends(get_db)):
+    body = await request.body()
+    signature = request.headers.get("X-Hub-Signature-256", "")
+    payload = json.loads(body)
+
+    repo_name = payload.get("repository", {}).get("full_name", "")
+    repo = await db.scalar(select(MonitoredRepo).where(MonitoredRepo.repo_full_name == repo_name))
+
+    if not repo:
+        return {"ok": False, "reason": "repo not monitored"}
+
+    # HMAC-SHA256 验签
+    expected = "sha256=" + hmac.new(
+        repo.webhook_secret.encode(), body, hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(signature, expected):
+        raise HTTPException(403, "Invalid signature")
+```
+
+### 事件过滤
+
+- `X-GitHub-Event` header 必须是 `pull_request`
+- `action` 只处理 `opened`（新 PR）和 `synchronize`（PR 有新 commit）
+- 忽略 `pull_request.draft == true`
+- PR 目标分支必须匹配 `repo.default_branch`
+- 仓库 `enabled` 必须为 True
+
+### 去重
+
+查询 `PRReview` 是否已有同一 `repo_id + pr_number` 且 `status` 不是 `error` 的记录：
+- 如果有且状态是 `reviewing` → 对于 `synchronize` 事件，取消旧 task，创建新审核
+- 如果有且状态是终态（merged/approved/commented）→ 对于 `synchronize` 事件，创建新审核
+- 如果没有 → 创建新审核
+
+### 安全
+
+- Webhook 路径加入 `backend/middleware/auth.py` 的 `PUBLIC_PATHS`
+- 用 HMAC-SHA256 替代 Bearer token 认证
+- 用 `hmac.compare_digest` 防时序攻击
+
+## 4. 审核 Task 创建
+
+### 服务层
+
+新文件 `backend/services/pr_review_service.py`：
+
+```python
+async def create_pr_review_task(
+    db_factory,
+    repo: MonitoredRepo,
+    pr_data: dict,         # webhook payload 中的 pull_request 对象
+) -> PRReview:
+    """检测到新 PR 后创建审核 task。"""
+
+    pr_review = PRReview(
+        repo_id=repo.id,
+        pr_number=pr_data["number"],
+        pr_title=pr_data["title"],
+        pr_author=pr_data["user"]["login"],
+        pr_url=pr_data["html_url"],
+        status="pending",
+    )
+
+    # 构建 prompt
+    prompt = build_review_prompt(repo, pr_data)
+
+    # 创建 CCM task
+    task = Task(
+        title=f"PR Review: {repo.repo_full_name}#{pr_data['number']} - {pr_data['title'][:80]}",
+        description=prompt,
+        project_id=repo.project_id,
+        priority=5,
+        mode="auto",
+        model=repo.review_model,
+        tags=["pr-review"],
+        metadata_={"pr_review_id": pr_review.id, "repo_full_name": repo.repo_full_name},
+    )
+
+    pr_review.task_id = task.id
+    pr_review.status = "reviewing"
+
+    return pr_review
+```
+
+### Prompt 设计
+
+```python
+def build_review_prompt(repo: MonitoredRepo, pr_data: dict) -> str:
+    pr_number = pr_data["number"]
+    repo_name = repo.repo_full_name
+
+    auto_merge_instructions = """
+代码没有问题：
+  gh pr review {pr_number} --repo {repo_name} --approve --body "LGTM - 代码审核通过"
+  gh pr merge {pr_number} --repo {repo_name} --merge
+
+代码有问题但可以修复：
+  1. gh pr checkout {pr_number} --repo {repo_name}
+  2. 修复问题
+  3. git add + git commit + git push
+  4. gh pr review {pr_number} --repo {repo_name} --approve --body "已修复问题并合并"
+  5. gh pr merge {pr_number} --repo {repo_name} --merge
+
+代码有严重问题无法自动修复：
+  gh pr review {pr_number} --repo {repo_name} --request-changes --body "具体问题描述..."
+""" if repo.auto_merge else """
+代码没有问题：
+  gh pr review {pr_number} --repo {repo_name} --approve --body "LGTM - 代码审核通过"
+
+代码有问题：
+  gh pr review {pr_number} --repo {repo_name} --request-changes --body "具体问题描述..."
+"""
+
+    return f"""你正在审核 {repo_name} 的 Pull Request #{pr_number}。
+
+PR 标题: {pr_data["title"]}
+PR 作者: {pr_data["user"]["login"]}
+PR URL: {pr_data["html_url"]}
+目标分支: {pr_data["base"]["ref"]}
+
+## 步骤
+
+### 1. 读取 PR 内容
+
+gh pr view {pr_number} --repo {repo_name} --json title,body,files,additions,deletions,headRefName,baseRefName
+gh pr diff {pr_number} --repo {repo_name}
+
+### 2. 审核代码
+
+检查以下方面：
+- 正确性：逻辑错误、边界条件
+- 安全性：注入、XSS、敏感信息泄露
+- 性能：明显的性能问题
+- 代码质量：可读性、命名、重复代码
+- 测试：是否缺少必要的测试
+
+### 3. 根据审核结果操作
+
+{auto_merge_instructions}
+
+### 4. 输出审核结果
+
+操作完成后，在最后一行输出（必须严格遵循格式）：
+PR_REVIEW_RESULT: <action>
+
+action 取值：
+- approved_merged — 审核通过并已合并
+- lgtm_comment — 审核通过，已写 approve 评论
+- fix_pushed_merged — 已修复问题并合并
+- review_comments — 已写 request-changes 批注
+- error — 操作失败
+"""
+```
+
+## 5. Task 完成回调
+
+在 `backend/services/dispatcher.py` 的 task 完成流程中添加钩子：
+
+```python
+async def _on_task_completed(self, task: Task):
+    """Task 完成后检查是否是 PR 审核 task。"""
+    metadata = task.metadata_ or {}
+    pr_review_id = metadata.get("pr_review_id")
+    if not pr_review_id:
+        return
+
+    async with self.db_factory() as db:
+        review = await db.get(PRReview, pr_review_id)
+        if not review:
+            return
+
+        # 从 task 输出中解析 PR_REVIEW_RESULT
+        result = await self._parse_pr_review_result(task.id, db)
+
+        review.status = {
+            "approved_merged": "merged",
+            "lgtm_comment": "approved",
+            "fix_pushed_merged": "merged",
+            "review_comments": "commented",
+            "error": "error",
+        }.get(result, "error")
+        review.action_taken = result
+        review.completed_at = datetime.utcnow()
+        await db.commit()
+
+async def _parse_pr_review_result(self, task_id: int, db: AsyncSession) -> str:
+    """从 task 的最后几条日志中提取 PR_REVIEW_RESULT。"""
+    logs = await db.execute(
+        select(LogEntry.content)
+        .where(LogEntry.task_id == task_id, LogEntry.event_type.in_(["message", "result"]))
+        .order_by(LogEntry.id.desc())
+        .limit(5)
+    )
+    for row in logs.scalars():
+        if row and "PR_REVIEW_RESULT:" in row:
+            return row.split("PR_REVIEW_RESULT:")[-1].strip()
+    return "error"
+```
+
+## 6. 前端
+
+### 页面：PRMonitorPage
+
+路径：`frontend/src/pages/PRMonitorPage.tsx`
+
+**列表视图**：
+- 所有监控仓库，每行显示：仓库名、状态灯、开关、最近审核时间
+- "添加仓库" 按钮
+
+**仓库详情**（点击进入或右侧面板）：
+
+配置区：
+- auto_merge 开关
+- review_model 选择器
+- default_branch 输入
+- Webhook 信息框：
+  - URL：`https://youchengsong.claude-code-manager.com/api/github/webhook`（只读，带复制按钮）
+  - Secret：遮掩显示，带复制按钮和重新生成按钮
+  - 提示："请将以上 URL 和 Secret 配置到 GitHub 仓库的 Settings → Webhooks，事件选择 Pull requests"
+
+审核历史表：
+- 列：PR 号、标题、作者、状态 badge、操作结果、关联 task 链接、时间
+- 状态颜色：pending=黄、reviewing=蓝、merged=绿、approved=绿、commented=橙、error=红
+
+### 导航注册
+
+- `Header.tsx`：添加 `{ key: 'pr-monitor', label: 'PR Monitor' }`
+- `App.tsx`：添加页面路由
+
+### API Client
+
+```typescript
+interface MonitoredRepo {
+  id: number;
+  repo_full_name: string;
+  project_id: number | null;
+  enabled: boolean;
+  auto_merge: boolean;
+  webhook_secret: string;
+  review_model: string | null;
+  default_branch: string;
+  status: string;
+  error_message: string | null;
+  created_at: string;
+}
+
+interface PRReview {
+  id: number;
+  repo_id: number;
+  pr_number: number;
+  pr_title: string;
+  pr_author: string;
+  pr_url: string;
+  task_id: number | null;
+  status: string;
+  review_summary: string | null;
+  action_taken: string | null;
+  created_at: string;
+  completed_at: string | null;
+}
+```
+
+## 7. 涉及的文件
+
+### 新建
+
+| 文件 | 说明 |
+|------|------|
+| `backend/models/pr_monitor.py` | MonitoredRepo + PRReview 模型 |
+| `backend/schemas/pr_monitor.py` | Pydantic schemas |
+| `backend/api/pr_monitor.py` | CRUD + Webhook API |
+| `backend/services/pr_review_service.py` | 审核 task 创建逻辑 + prompt 构建 |
+| `alembic/versions/xxx_add_pr_monitor.py` | 数据库 migration |
+| `frontend/src/pages/PRMonitorPage.tsx` | 前端页面 |
+
+### 修改
+
+| 文件 | 改动 |
+|------|------|
+| `backend/main.py` | 注册 pr_monitor router |
+| `backend/middleware/auth.py` | webhook 路径加入 PUBLIC_PATHS |
+| `backend/services/dispatcher.py` | task 完成回调钩子 |
+| `alembic/env.py` | 注册新 model |
+| `frontend/src/api/client.ts` | 添加接口和 API 方法 |
+| `frontend/src/App.tsx` | 注册页面路由 |
+| `frontend/src/components/Layout/Header.tsx` | 添加导航项 |
+
+## 8. 实现顺序
+
+| 阶段 | 内容 | 预估 |
+|------|------|------|
+| Phase 1 | 数据库模型 + migration | 小 |
+| Phase 2 | Schemas + CRUD API | 小 |
+| Phase 3 | Webhook 处理器 + 验签 + auth 白名单 | 中 |
+| Phase 4 | 审核 task 创建 + prompt 构建 | 中 |
+| Phase 5 | Task 完成回调 | 小 |
+| Phase 6 | 前端页面 | 大 |
+| Phase 7 | 边界情况（PR 更新取消旧 task、WebSocket 实时推送） | 中 |

--- a/scripts/pty_smoke.py
+++ b/scripts/pty_smoke.py
@@ -1,0 +1,124 @@
+"""Phase 2 smoke: InstanceManager in PTY mode end-to-end with real CC.
+
+Verifies: launch -> CCMBackend -> channel injection -> JSONL events ->
+_process_event (DB writes absorbed by fake) -> broadcaster -> proxy exit.
+"""
+import asyncio, os, sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, "/home/ubuntu/Claude-Code-Manager-dev")
+os.environ["USE_PTY_MODE"] = "true"
+os.environ["PATH"] = "/home/ubuntu/Claude-Code-Manager-dev/.venv/bin:" + os.environ["PATH"]
+
+
+class FakeDB:
+    def __init__(self, log):
+        self.log = log
+
+    async def execute(self, stmt):
+        return MagicMock(rowcount=1)
+
+    async def commit(self):
+        pass
+
+    async def get(self, model, pk):
+        m = MagicMock(); m.current_task_id = 3; return m
+
+    def add(self, obj):
+        self.log.append(obj)
+
+    async def refresh(self, obj):
+        obj.id = len(self.log)
+
+    async def flush(self):
+        pass
+
+
+class FakeDBFactory:
+    def __init__(self):
+        self.entries = []
+
+    def __call__(self):
+        return self
+
+    async def __aenter__(self):
+        return FakeDB(self.entries)
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+async def main():
+    from backend.services.instance_manager import InstanceManager
+
+    dbf = FakeDBFactory()
+    broadcaster = MagicMock()
+    broadcasts = []
+
+    async def record(channel, data):
+        broadcasts.append((channel, data.get("event_type") or data.get("event")))
+
+    broadcaster.broadcast = record
+
+    im = InstanceManager(dbf, broadcaster)
+    assert im._pty_backend is not None, "PTY backend not initialized!"
+    print("PTY backend active:", type(im._pty_backend).__name__)
+
+    cwd = "/tmp/pty-spikes/p2_smoke_ws"
+    os.makedirs(cwd, exist_ok=True)
+
+    pid = await im.launch(
+        instance_id=1,
+        prompt="Run `echo p2-smoke-ok` with the Bash tool and report the output.",
+        task_id=3,
+        cwd=cwd,
+        model="claude-haiku-4-5",
+        provider="claude",
+    )
+    print("launched, proxy pid:", pid)
+
+    process = im.processes[1]
+    exit_code = await asyncio.wait_for(process.wait(), timeout=180)
+    print("turn finished, exit_code:", exit_code)
+
+    ev_types = [b[1] for b in broadcasts]
+    print("broadcast events:", ev_types)
+    print("log entries written:", len(dbf.entries))
+
+    assert exit_code == 0
+    assert "tool_use" in ev_types, "no tool_use broadcast"
+    assert any(t == "message" for t in ev_types), "no assistant message broadcast"
+    assert len(dbf.entries) >= 3, "log entries missing"
+
+    # --- second turn: hot session reuse via resume_session_id ---
+    pool_sessions = im._pty_backend._pool._sessions
+    sid = next(iter(pool_sessions))
+    sess = pool_sessions[sid]
+    print("pool session alive after turn 1:", sess.is_alive, "sid:", sid[:8])
+    pid_before = sess._process.pid
+
+    import time
+    t0 = time.monotonic()
+    await im.launch(
+        instance_id=1,
+        prompt="Reply with exactly: second-turn-ok",
+        task_id=3,
+        cwd=cwd,
+        model="claude-haiku-4-5",
+        provider="claude",
+        resume_session_id=sid,
+        chat_initiated=True,
+    )
+    exit2 = await asyncio.wait_for(im.processes[1].wait(), timeout=120)
+    dt = time.monotonic() - t0
+    sess2 = im._pty_backend._pool._sessions.get(sid)
+    same_proc = sess2 is not None and sess2._process.pid == pid_before
+    print("turn2 exit:", exit2, "elapsed: %.1fs" % dt, "same process:", same_proc)
+    texts = [b for b in broadcasts if "second-turn-ok" in str(b)]
+
+    await im._pty_backend.shutdown()
+    ok = exit2 == 0 and same_proc
+    print("SMOKE RESULT:", "PASS" if ok else "FAIL",
+          "(events=%d, hot_reuse=%s, turn2=%.1fs)" % (len(dbf.entries), same_proc, dt))
+
+asyncio.run(main())


### PR DESCRIPTION
## 内容

用常驻交互式 Claude Code 进程替代 `claude -p` 一次性调用（feature flag 控制，**默认关闭，main 行为零变化**）。

- `use_pty_mode` 配置 + 导航栏运行时开关（DB 持久化，无需重启生效）
- claude 任务分流到 claude_pty CCMBackend：channel 注入输入 + JSONL 事件流，事件结构与 StreamParser 对齐，下游 DB/WebSocket/dispatcher 无感知
- stop/超时/关停全路径会话回收；关闭开关自动回收 idle 会话；防 orphan
- 额度显示按模型回填 context window；claude_pty 日志可观测
- 端到端冒烟 `scripts/pty_smoke.py`（热复用第二轮 7.8s）
- migration: global_settings.use_pty_mode（nullable，可安全回滚）
- gitignore uploads/ 与 SQLite WAL（本次发现用户上传文件曾被误提交，已重写剥离）

## 已知限制（beta，默认关）

- PTY 模式撞限不自动换号（Phase 3）；cost 不统计；loop 无逐轮进度；thinking 不可见（JSONL 加密）

依赖：claude_pty（github.com/zjw49246/Claude-Code-PTY @ 30b6588，venv editable 安装）。
完整技术文档：Claude-Code-PTY/docs/pty-solution.md

注：取代 #23（远端 dev 分支上的过时早期尝试）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)