### PR TITLE
feat: PTY 模式 loop 热会话复用（一个迭代一个 turn）

### DIFF
--- a/.env.b
+++ b/.env.b
@@ -1,0 +1,6 @@
+AUTH_TOKEN=bcIljazMC2dHJdgw7ENwxenCdNbtAyVn
+DATABASE_URL=sqlite+aiosqlite:///./claude_manager_b.db
+WORKSPACE_DIR=/home/ubuntu/Projects
+AUTO_START_DISPATCHER=true
+PORT=8002
+POOL_ENABLED=true

--- a/.env.backup
+++ b/.env.backup
@@ -1,0 +1,11 @@
+AUTH_TOKEN=ycs_ccm_2026_secure
+DATABASE_URL=sqlite+aiosqlite:///./claude_manager_b.db
+WORKSPACE_DIR=/home/ubuntu/Projects
+AUTO_START_DISPATCHER=true
+PORT=8000
+CODEX_BINARY=/usr/bin/codex
+DEFAULT_CODEX_MODEL=gpt-5.5
+CODEX_MODEL_OPTIONS=default,gpt-5.5,gpt-5.4,gpt-5.4-mini,gpt-5.3-codex-spark
+CODEX_EFFORT_OPTIONS=low,medium,high,xhigh
+DEFAULT_CODEX_GOAL_EVALUATOR_MODEL=gpt-5.4-mini
+POOL_ENABLED=true

--- a/.env.c.backup
+++ b/.env.c.backup
@@ -1,0 +1,13 @@
+AUTH_TOKEN=codex123
+DATABASE_URL=sqlite+aiosqlite:///./claude_manager_c.db
+WORKSPACE_DIR=/home/ubuntu/Projects
+AUTO_START_DISPATCHER=true
+PORT=8004
+POOL_ENABLED=false
+DEFAULT_PROVIDER=codex
+PROVIDER_OPTIONS=claude,codex
+CODEX_BINARY=/home/ubuntu/.local/bin/codex
+DEFAULT_CODEX_MODEL=gpt-5.5
+CODEX_MODEL_OPTIONS=default,gpt-5.5,gpt-5.4,gpt-5.4-mini,gpt-5.3-codex-spark
+CODEX_EFFORT_OPTIONS=low,medium,high,xhigh
+DEFAULT_CODEX_GOAL_EVALUATOR_MODEL=gpt-5.4-mini

--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -914,6 +914,32 @@ class GlobalDispatcher:
         })
 
     async def _run_loop_lifecycle(self, instance_id: int, task: Task, cwd: str, git_env: dict | None = None, effort_level: str | None = None):
+        """Loop entry: run iterations, then always release the PTY session.
+
+        In PTY mode the whole loop shares one hot session (one iteration ==
+        one turn); releasing it afterwards keeps the pool free of one-shot
+        leftovers. No-op in -p mode.
+        """
+        try:
+            await self._run_loop_iterations(
+                instance_id, task, cwd, git_env, effort_level=effort_level
+            )
+        finally:
+            try:
+                async with self.db_factory() as db:
+                    t = await db.get(Task, task.id)
+                    sid = t.session_id if t else None
+                if sid:
+                    release = getattr(self.instance_manager, "release_pty_session", None)
+                    if release is not None:
+                        result = release(sid)
+                        import inspect as _inspect
+                        if _inspect.isawaitable(result):
+                            await result
+            except Exception:
+                logger.exception("Failed to release loop PTY session for task %d", task.id)
+
+    async def _run_loop_iterations(self, instance_id: int, task: Task, cwd: str, git_env: dict | None = None, effort_level: str | None = None):
         """Loop: repeatedly invoke Claude Code until it signals done or abort.
 
         Each iteration starts a fresh Claude Code subprocess. Claude reads the todo
@@ -971,12 +997,22 @@ class GlobalDispatcher:
                 task, iteration, str(signal_path), history, anchored_total, plan,
             )
 
+            # PTY mode: iterations after the first reuse the same hot session
+            # (one iteration == one turn) — no cold start, continuous context.
+            # -p mode keeps its stateless-per-iteration semantics (no resume).
+            resume_sid = None
+            if iteration > 0 and getattr(self.instance_manager, "pty_mode_enabled", False):
+                async with self.db_factory() as db:
+                    t = await db.get(Task, task.id)
+                    resume_sid = t.session_id if t else None
+
             await self.instance_manager.launch(
                 instance_id=instance_id,
                 prompt=prompt,
                 task_id=task.id,
                 cwd=cwd,
                 model=task.model,
+                resume_session_id=resume_sid,
                 loop_iteration=iteration,
                 git_env=git_env or {},
                 thinking_budget=task.thinking_budget,

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -48,6 +48,17 @@ class InstanceManager:
     def pty_mode_enabled(self) -> bool:
         return self._pty_enabled and self._pty_backend is not None
 
+    async def release_pty_session(self, session_id: str) -> None:
+        """Return a PTY session to nothing — stop it and remove from the pool.
+        Used when a workload (e.g. a loop task) is finished with its session.
+        No-op when PTY mode is not in use."""
+        if self._pty_backend is None or not session_id:
+            return
+        try:
+            await self._pty_backend._pool.remove(session_id)
+        except Exception:
+            logger.exception("Failed to release PTY session %s", session_id)
+
     async def drain_idle_pty_sessions(self) -> int:
         """Stop idle PTY sessions (called after PTY mode is switched off).
         In-flight turns are untouched and finish on the PTY path."""

--- a/backend/tests/test_service_dispatcher.py
+++ b/backend/tests/test_service_dispatcher.py
@@ -2494,3 +2494,68 @@ async def test_goal_deleted_during_execution(db_factory):
     async with db_factory() as db:
         t = await db.get(Task, task_obj.id)
         assert t is None
+
+
+# ---------- PTY 模式 loop：同一热会话，一个迭代一个 turn ----------
+
+async def _run_two_iteration_loop(d, db_factory, tmp_path, *, pty_enabled):
+    """Helper: run a loop that signals continue then done; capture launches."""
+    async with db_factory() as db:
+        inst = Instance(name="loop-pty-worker")
+        db.add(inst)
+        task = _make_loop_task(db, tmp_path)
+        db.add(task)
+        await db.commit()
+        await db.refresh(inst)
+        await db.refresh(task)
+        inst_id, task_obj = inst.id, task
+
+    signal_path = tmp_path / ".claude-manager" / f"loop_signal_{task_obj.id}.json"
+    launches = []
+
+    async def fake_launch(*args, **kwargs):
+        launches.append(kwargs)
+        # 第一轮写 continue，第二轮写 done；并模拟 session_id 入库
+        signal_path.parent.mkdir(parents=True, exist_ok=True)
+        action = "continue" if len(launches) == 1 else "done"
+        _write_signal(signal_path, action, "step", f"{len(launches)}/2")
+        async with db_factory() as db:
+            t = await db.get(Task, task_obj.id)
+            t.session_id = "loop-sid-1"
+            await db.commit()
+        return 12345
+
+    mock_proc = MagicMock()
+    mock_proc.returncode = 0
+    mock_proc.wait = AsyncMock(return_value=0)
+    d.instance_manager.launch = AsyncMock(side_effect=fake_launch)
+    d.instance_manager.processes = {inst_id: mock_proc}
+    d.instance_manager.pty_mode_enabled = pty_enabled
+    d.instance_manager.release_pty_session = AsyncMock()
+
+    await d._run_loop_lifecycle(inst_id, task_obj, str(tmp_path))
+    return launches, d
+
+
+@pytest.mark.asyncio
+async def test_loop_pty_mode_reuses_session_per_iteration(db_factory, tmp_path):
+    d = _make_dispatcher(db_factory)
+    launches, d = await _run_two_iteration_loop(d, db_factory, tmp_path, pty_enabled=True)
+
+    assert len(launches) == 2
+    # 迭代 0 全新会话；迭代 1 复用同一会话（一个迭代一个 turn）
+    assert launches[0].get("resume_session_id") is None
+    assert launches[1].get("resume_session_id") == "loop-sid-1"
+    # loop 结束后会话归还，不污染池
+    d.instance_manager.release_pty_session.assert_awaited_once_with("loop-sid-1")
+
+
+@pytest.mark.asyncio
+async def test_loop_p_mode_stays_stateless(db_factory, tmp_path):
+    d = _make_dispatcher(db_factory)
+    launches, d = await _run_two_iteration_loop(d, db_factory, tmp_path, pty_enabled=False)
+
+    assert len(launches) == 2
+    # -p 模式语义不变：每轮无 resume
+    assert launches[0].get("resume_session_id") is None
+    assert launches[1].get("resume_session_id") is None

--- a/backend/tests/test_service_instance_manager.py
+++ b/backend/tests/test_service_instance_manager.py
@@ -1538,3 +1538,25 @@ async def test_launch_respects_disabled_pty_mode():
         with patch.object(im, "_consume_output", new=AsyncMock()):
             await im.launch(instance_id=1, prompt="x", provider="claude", cwd="/w")
     assert im.processes[1] is fake_proc
+
+
+@pytest.mark.asyncio
+async def test_release_pty_session():
+    im = InstanceManager(MagicMock(), MagicMock())
+    # no backend -> no-op
+    await im.release_pty_session("sid-x")
+
+    class FakePool:
+        removed = []
+
+        async def remove(self, sid):
+            FakePool.removed.append(sid)
+
+    class FakeBackend:
+        _pool = FakePool()
+
+    im._pty_backend = FakeBackend()
+    await im.release_pty_session("sid-x")
+    assert FakePool.removed == ["sid-x"]
+    await im.release_pty_session("")  # empty -> no-op
+    assert FakePool.removed == ["sid-x"]


### PR DESCRIPTION
## 内容

PTY 模式下 loop 任务的全部迭代共享同一常驻会话：

- 迭代 0 新建会话，迭代 >0 传 `resume_session_id` 热复用 → **一个迭代 = 一个 turn**，免每轮 ~10s 冷启动，上下文跨迭代连续（不再依赖 prompt 重塞 history）
- loop 结束（done/abort/失败/取消任一出口）finally 归还会话到池外，修复一次性会话污染 LRU 池的问题
- **-p 模式语义零变化**（无 resume、每轮独立进程）；进度机制（signal 文件 + loop_iteration_end 广播）两种模式都原样保留
- 上下文随迭代累积由 CC auto-compact 兜底；超长 loop 的接力策略留 Phase 3

测试：dispatcher 77（含 2 个新用例：PTY 复用断言 + -p 不变断言）+ instance_manager 65 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)