### PR TITLE
Add selectable semantic frontend themes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ claude-manager/
 - **认证**: 除 `/api/system/health`、`/api/auth/login`、`/api/github/webhook` 外，所有 API 需要 `Authorization: Bearer <token>`
 - **前端 type 导入**: 用 `import type { X }` 导入类型，`import { api }` 导入值（Vite 会去除 type-only exports）
 - **Tailwind v4**: 用 `@import "tailwindcss"` + `@tailwindcss/vite` 插件，无 tailwind.config
-- **主题**: 深色/浅色切换通过覆盖 `--color-gray-*` CSS 变量实现灰度反转，内容文字用 `text-foreground`（随主题变化），按钮文字保持 `text-white`
+- **主题**: 语义 token 系统（VS Code 风格）。`config/theme.ts` 的 `THEMES` 注册表为每个主题定义 22 个语义角色，`applyTheme` 按 `data-theme` 把它们写成 `--ccm-*` 变量到 `<html>` 上；`index.css` 的 `@theme` 把 Tailwind `--color-*` 别名（`bg-app/surface/chrome/accent`、`text-muted/subtle/success/danger` 等）映射到 `--ccm-*`。已迁移组件用语义类，**未迁移组件仍用 `bg-gray-*` 硬编码类**，靠每个主题的 `html[data-theme=...]` 兼容块覆盖 `--color-gray-*` 兜底跟随主题（组件全迁移后可删）。当前全是深色系主题（深色/海蓝/森林/莓红/One Dark/Dracula/Nord/Tokyo Night）；**light 主题被刻意移除**——反转灰阶会让满屏 `text-white`/`bg-white` 字面量变成白底白字。`:root` 硬编码一份 dark 值作为 JS 加载前 fallback，改 dark 值须与 `THEMES.dark` 同步
 - **Android App**: Capacitor 打包，API/WS 地址通过 `config/server.ts` 动态获取，LoginPage 可展开配置 Server URL
 - **Goal 模式**: `mode="goal"` 任务使用自然语言完成条件（`goal_condition`），每 turn 后由独立评估器（默认 Haiku）判断是否达成。使用 `--resume` 保持同一 session 的连续上下文。评估器通过 `claude -p` 子进程调用，不需要额外 API key
 - **Goal 评估器**: `GoalEvaluator`（`backend/services/goal_evaluator.py`）读取对话日志摘要，发给轻量模型判断条件是否满足。默认模型 `claude-haiku-4-5`，可通过 `goal_evaluator_model` 覆盖

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,11 +68,12 @@ function updateHash(page: string, chatTaskId: number | null) {
 
 function App() {
   const initial = parseHash();
+  const initialNeedsServerConfig = isCapacitor() && !getServerUrl();
   const [page, setPage] = useState(initial.page);
   const [chatTaskId, setChatTaskId] = useState<number | null>(initial.chatTaskId);
   const [authenticated, setAuthenticated] = useState(false);
-  const [checking, setChecking] = useState(true);
-  const [needsServerConfig, setNeedsServerConfig] = useState(false);
+  const [checking, setChecking] = useState(!initialNeedsServerConfig);
+  const [needsServerConfig, setNeedsServerConfig] = useState(initialNeedsServerConfig);
 
   useEffect(() => {
     updateHash(page, chatTaskId);
@@ -94,12 +95,7 @@ function App() {
   };
 
   useEffect(() => {
-    // In Capacitor, require server URL to be configured first
-    if (isCapacitor() && !getServerUrl()) {
-      setNeedsServerConfig(true);
-      setChecking(false);
-      return;
-    }
+    if (needsServerConfig) return;
 
     const base = getApiBase();
     // Check if auth is required
@@ -124,7 +120,7 @@ function App() {
         // Server down, show login anyway
       })
       .finally(() => setChecking(false));
-  }, []);
+  }, [needsServerConfig]);
 
   if (needsServerConfig) {
     return (
@@ -137,8 +133,8 @@ function App() {
 
   if (checking) {
     return (
-      <div className="min-h-screen bg-gray-950 flex items-center justify-center">
-        <p className="text-gray-400">Connecting...</p>
+      <div className="min-h-screen bg-app flex items-center justify-center">
+        <p className="text-subtle">Connecting...</p>
       </div>
     );
   }
@@ -149,7 +145,7 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <div className="min-h-screen bg-gray-900 text-foreground flex flex-col overflow-x-clip">
+      <div className="min-h-screen bg-app text-foreground flex flex-col overflow-x-clip">
         <Header currentPage={page} onNavigate={handleNavigate} />
         <main className={`flex-1 mx-auto w-full p-4 ${page === 'tasks' && chatTaskId ? 'max-w-[1400px]' : 'max-w-6xl'}`}>
           {page === 'dashboard' && <Dashboard />}

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -111,7 +111,7 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
   }, []);
 
   return (
-    <header className="bg-gray-900 border-b border-gray-700 px-4 py-2 pt-[max(0.5rem,env(safe-area-inset-top))]">
+    <header className="bg-chrome border-b border-chrome-border px-4 py-2 pt-[max(0.5rem,env(safe-area-inset-top))]">
       <div ref={rowRef} className="relative flex items-center gap-3">
         <h1 ref={titleRef} className="text-base font-bold text-foreground whitespace-nowrap shrink-0">Claude Manager</h1>
         {/* 隐藏测量 nav：始终渲染完整按钮以计算所需宽度 */}
@@ -131,8 +131,8 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
                 onClick={() => onNavigate(p.key)}
                 className={`px-3 py-1.5 min-h-[36px] rounded text-sm font-medium whitespace-nowrap transition-colors ${
                   currentPage === p.key
-                    ? 'bg-indigo-600 text-white'
-                    : 'text-gray-300 hover:bg-gray-800'
+                    ? 'bg-accent text-accent-foreground'
+                    : 'text-muted hover:text-foreground hover:bg-surface-hover'
                 }`}
               >
                 {p.label}
@@ -145,7 +145,7 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
           <PoolDrawer />
           {runtime && (
             <div
-              className="flex items-center gap-1.5 mr-1 px-2 py-1 rounded bg-gray-800 border border-gray-700"
+              className="flex items-center gap-1.5 mr-1 px-2 py-1 rounded bg-surface border border-border"
               title={
                 !runtime.pty_available
                   ? 'claude_pty 未安装，PTY 模式不可用'
@@ -154,14 +154,14 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
                     : 'PTY 常驻会话模式：关（使用 claude -p 一次性进程）'
               }
             >
-              <span className={`text-xs font-medium ${runtime.use_pty_mode ? 'text-green-400' : 'text-gray-400'}`}>
+              <span className={`text-xs font-medium ${runtime.use_pty_mode ? 'text-success' : 'text-subtle'}`}>
                 PTY
               </span>
               <button
                 onClick={togglePtyMode}
                 disabled={!runtime.pty_available || switching}
                 className={`relative inline-flex h-4 w-8 items-center rounded-full transition-colors disabled:opacity-50 ${
-                  runtime.use_pty_mode ? 'bg-green-500' : 'bg-gray-600'
+                  runtime.use_pty_mode ? 'bg-success' : 'bg-input-border'
                 }`}
               >
                 <span
@@ -176,19 +176,19 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
           <div className="relative shrink-0" ref={prefsRef}>
             <button
               onClick={() => setPrefsOpen(!prefsOpen)}
-              className={`p-2 rounded transition-colors ${prefsOpen ? 'text-foreground bg-gray-800' : 'text-gray-400 hover:text-foreground hover:bg-gray-800'}`}
+              className={`p-2 rounded transition-colors ${prefsOpen ? 'text-foreground bg-surface' : 'text-subtle hover:text-foreground hover:bg-surface'}`}
               title="偏好设置（时区 / 主题）"
             >
               <Settings size={18} />
             </button>
             {prefsOpen && (
-              <div className="absolute top-full right-0 mt-1 bg-gray-800 border border-gray-600 rounded-lg shadow-lg z-30 p-3 min-w-[210px] space-y-3">
+              <div className="absolute top-full right-0 mt-1 bg-surface border border-input-border rounded-lg shadow-lg z-30 p-3 min-w-[210px] space-y-3">
                 <div className="flex items-center justify-between gap-3">
-                  <span className="text-xs text-gray-400 flex items-center gap-1.5"><Globe size={13} /> 时区</span>
+                  <span className="text-xs text-subtle flex items-center gap-1.5"><Globe size={13} /> 时区</span>
                   <select
                     value={tz}
                     onChange={(e) => { setTimezone(e.target.value); setTz(e.target.value); }}
-                    className="bg-gray-700 text-gray-200 text-xs rounded px-2 py-1 border border-gray-600 focus:outline-none focus:ring-1 focus:ring-indigo-500 cursor-pointer"
+                    className="bg-input text-muted text-xs rounded px-2 py-1 border border-input-border focus:outline-none focus:ring-1 focus:ring-focus cursor-pointer"
                   >
                     {TIMEZONE_OPTIONS.map((opt) => (
                       <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -196,11 +196,11 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
                   </select>
                 </div>
                 <div className="flex items-center justify-between gap-3">
-                  <span className="text-xs text-gray-400 flex items-center gap-1.5"><Palette size={13} /> 主题</span>
+                  <span className="text-xs text-subtle flex items-center gap-1.5"><Palette size={13} /> 主题</span>
                   <select
                     value={theme}
                     onChange={(e) => handleThemeChange(e.target.value as Theme)}
-                    className="bg-gray-700 text-gray-200 text-xs rounded px-2 py-1 border border-gray-600 focus:outline-none focus:ring-1 focus:ring-indigo-500 cursor-pointer"
+                    className="bg-input text-muted text-xs rounded px-2 py-1 border border-input-border focus:outline-none focus:ring-1 focus:ring-focus cursor-pointer"
                   >
                     {THEME_OPTIONS.map((opt) => (
                       <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -209,12 +209,12 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
                 </div>
                 {runtime && (
                   <div className="flex items-center justify-between gap-3">
-                    <span className="text-xs text-gray-400">访问置顶</span>
+                    <span className="text-xs text-subtle">访问置顶</span>
                     <button
                       onClick={toggleAutoSort}
                       disabled={switching}
                       className={`relative inline-flex h-4 w-8 items-center rounded-full transition-colors disabled:opacity-50 ${
-                        runtime.auto_sort_on_access ? 'bg-green-500' : 'bg-gray-600'
+                        runtime.auto_sort_on_access ? 'bg-success' : 'bg-input-border'
                       }`}
                       title={runtime.auto_sort_on_access ? '开启：打开聊天自动置顶任务' : '关闭：打开聊天不改变排序'}
                     >
@@ -227,22 +227,22 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
                   </div>
                 )}
                 {/* Feishu binding */}
-                <div className="border-t border-gray-700 pt-2 mt-1">
+                <div className="border-t border-border pt-2 mt-1">
                   <div className="flex items-center justify-between gap-3">
-                    <span className="text-xs text-gray-400">飞书</span>
+                    <span className="text-xs text-subtle">飞书</span>
                     {feishuStatus?.bound ? (
                       <div className="flex items-center gap-1.5">
                         {feishuStatus.avatar_url && <img src={feishuStatus.avatar_url} className="w-4 h-4 rounded-full" alt="" />}
-                        <span className="text-xs text-gray-300">{feishuStatus.name}</span>
+                        <span className="text-xs text-muted">{feishuStatus.name}</span>
                         <button
                           onClick={async () => { if (confirm('解绑飞书？')) { await api.unbindFeishu(); setFeishuStatus({ bound: false }); }}}
-                          className="text-xs text-red-400 hover:text-red-300 ml-1"
+                          className="text-xs text-danger hover:text-red-300 ml-1"
                         >解绑</button>
                       </div>
                     ) : feishuStatus !== null ? (
                       <button
                         onClick={async () => { const { url } = await api.getFeishuAuthUrl(); window.location.href = url; }}
-                        className="text-xs px-2 py-0.5 rounded bg-blue-600/20 text-blue-300 hover:bg-blue-600/30"
+                        className="text-xs px-2 py-0.5 rounded bg-accent-muted text-accent-muted-foreground hover:bg-accent hover:text-accent-foreground"
                       >绑定</button>
                     ) : null}
                   </div>
@@ -254,7 +254,7 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
           {collapsed && (
             <button
               onClick={() => setMenuOpen(!menuOpen)}
-              className="shrink-0 p-2 rounded text-gray-400 hover:text-foreground hover:bg-gray-800 transition-colors"
+              className="shrink-0 p-2 rounded text-subtle hover:text-foreground hover:bg-surface transition-colors"
             >
               {menuOpen ? <X size={18} /> : <Menu size={18} />}
             </button>
@@ -270,8 +270,8 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
               onClick={() => { onNavigate(p.key); setMenuOpen(false); }}
               className={`px-3 py-2 rounded text-sm font-medium text-left transition-colors ${
                 currentPage === p.key
-                  ? 'bg-indigo-600 text-white'
-                  : 'text-gray-300 hover:bg-gray-800'
+                  ? 'bg-accent text-accent-foreground'
+                  : 'text-muted hover:text-foreground hover:bg-surface-hover'
               }`}
             >
               {p.label}

--- a/frontend/src/components/Tasks/TaskForm.tsx
+++ b/frontend/src/components/Tasks/TaskForm.tsx
@@ -314,8 +314,8 @@ export function TaskForm({ onCreated }: TaskFormProps) {
   };
 
   return (
-    <form ref={formRef} onSubmit={handleSubmit} className="bg-gray-800 rounded-lg p-4 space-y-3 overflow-visible">
-      <h3 className="text-sm font-semibold text-gray-300">New Task</h3>
+    <form ref={formRef} onSubmit={handleSubmit} className="bg-surface rounded-lg p-4 space-y-3 overflow-visible">
+      <h3 className="text-sm font-semibold text-muted">New Task</h3>
       {dropError && (
         <div className="bg-yellow-900/50 border border-yellow-700 text-yellow-300 text-xs rounded px-3 py-2 flex items-center justify-between">
           <span>{dropError}</span>
@@ -334,7 +334,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
       )}
       <div className="flex gap-2">
         <textarea
-          className="flex-1 bg-gray-700 text-foreground rounded px-3 py-2 text-sm h-24 resize-none focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          className="flex-1 bg-input text-foreground rounded px-3 py-2 text-sm h-24 resize-none focus:outline-none focus:ring-2 focus:ring-focus"
           placeholder={mode === 'loop' ? 'Background / context (optional)' : `Prompt / Description (this will be sent to ${provider === 'codex' ? 'Codex' : 'Claude Code'})`}
           value={description}
           onChange={(e) => setDescription(e.target.value)}
@@ -353,13 +353,13 @@ export function TaskForm({ onCreated }: TaskFormProps) {
         />
         <SecretPicker selectedIds={selectedSecretIds} onChange={setSelectedSecretIds} />
         {fileUpload.uploads.map((upload) => (
-          <div key={upload.id} className="relative rounded overflow-hidden border border-gray-600">
+          <div key={upload.id} className="relative rounded overflow-hidden border border-input-border">
             {upload.preview ? (
               <div className="w-12 h-12">
                 <img src={upload.preview} alt="" className="w-full h-full object-cover" />
               </div>
             ) : (
-              <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-gray-800 text-xs text-gray-300 max-w-[120px]">
+              <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-input text-xs text-muted max-w-[120px]">
                 <Paperclip size={12} className="shrink-0" />
                 <span className="truncate">{upload.file.name}</span>
               </div>
@@ -377,7 +377,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
             <button
               type="button"
               onClick={() => fileUpload.removeFile(upload.id)}
-              className="absolute top-0 right-0 bg-gray-900/80 rounded-bl p-0.5 text-gray-300 hover:text-white"
+              className="absolute top-0 right-0 bg-surface-raised/80 rounded-bl p-0.5 text-muted hover:text-foreground"
             >
               <X size={10} />
             </button>
@@ -398,14 +398,14 @@ export function TaskForm({ onCreated }: TaskFormProps) {
         {isNewProject && (
           <div className="flex flex-col sm:flex-row gap-2">
             <input
-              className="flex-1 bg-gray-700 text-foreground rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="flex-1 bg-input text-foreground rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-focus"
               placeholder="Project name (required)"
               value={newProjectName}
               onChange={(e) => setNewProjectName(e.target.value)}
               required
             />
             <input
-              className="flex-1 min-w-0 bg-gray-700 text-foreground rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="flex-1 min-w-0 bg-input text-foreground rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-focus"
               placeholder="Remote repo URL (optional)"
               value={newProjectUrl}
               onChange={(e) => setNewProjectUrl(e.target.value)}
@@ -415,9 +415,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
       </div>
       {contextTasks.length > 0 && (
         <div className="flex items-center gap-2 min-w-0">
-          <label className="text-sm text-gray-400 whitespace-nowrap shrink-0">Copy context from:</label>
+          <label className="text-sm text-subtle whitespace-nowrap shrink-0">Copy context from:</label>
           <select
-            className="flex-1 min-w-0 bg-gray-700 text-foreground rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="flex-1 min-w-0 bg-input text-foreground rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-focus"
             value={cloneFromTaskId}
             onChange={(e) => setCloneFromTaskId(e.target.value ? Number(e.target.value) : '')}
           >
@@ -435,17 +435,17 @@ export function TaskForm({ onCreated }: TaskFormProps) {
       {mode === 'loop' && (
         <div className="flex items-center gap-2 flex-wrap">
           <input
-            className="flex-1 min-w-0 bg-gray-700 text-foreground rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="flex-1 min-w-0 bg-input text-foreground rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-focus"
             placeholder="Todo file path (e.g. TODO.md)"
             value={todoFilePath}
             onChange={(e) => setTodoFilePath(e.target.value)}
             required
           />
-          <label className="text-xs text-gray-400 whitespace-nowrap">Max iter:</label>
+          <label className="text-xs text-subtle whitespace-nowrap">Max iter:</label>
           <input
             type="text"
             inputMode="numeric"
-            className="w-16 bg-gray-700 text-foreground rounded px-2 py-1.5 text-sm"
+            className="w-16 bg-input text-foreground rounded px-2 py-1.5 text-sm"
             value={maxIterations}
             onChange={(e) => setMaxIterations(e.target.value.replace(/[^0-9]/g, ''))}
             onBlur={() => {
@@ -453,12 +453,12 @@ export function TaskForm({ onCreated }: TaskFormProps) {
               setMaxIterations(String((!n || n < 1) ? 1 : n));
             }}
           />
-          <label className="flex items-center gap-1 text-xs text-gray-400 whitespace-nowrap cursor-pointer">
+          <label className="flex items-center gap-1 text-xs text-subtle whitespace-nowrap cursor-pointer">
             <input
               type="checkbox"
               checked={mustComplete}
               onChange={(e) => setMustComplete(e.target.checked)}
-              className="accent-indigo-500"
+              className="accent-accent"
             />
             Must complete
           </label>
@@ -467,17 +467,17 @@ export function TaskForm({ onCreated }: TaskFormProps) {
       {mode === 'goal' && (
         <div className="flex items-center gap-2 flex-wrap">
           <input
-            className="flex-1 min-w-0 bg-gray-700 text-foreground rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="flex-1 min-w-0 bg-input text-foreground rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-focus"
             placeholder="Goal condition (e.g. all tests pass and lint is clean)"
             value={goalCondition}
             onChange={(e) => setGoalCondition(e.target.value)}
             required
           />
-          <label className="text-xs text-gray-400 whitespace-nowrap">Max turns:</label>
+          <label className="text-xs text-subtle whitespace-nowrap">Max turns:</label>
           <input
             type="text"
             inputMode="numeric"
-            className="w-16 bg-gray-700 text-foreground rounded px-2 py-1.5 text-sm"
+            className="w-16 bg-input text-foreground rounded px-2 py-1.5 text-sm"
             value={goalMaxTurns}
             onChange={(e) => setGoalMaxTurns(e.target.value.replace(/[^0-9]/g, ''))}
             onBlur={() => {
@@ -494,7 +494,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
           type="button"
           onClick={() => fileInputRef.current?.click()}
           disabled={fileUpload.uploads.length >= 10}
-          className="flex items-center gap-1 text-xs px-2 py-1.5 rounded border transition-colors bg-gray-700 text-gray-400 border-gray-600 hover:bg-gray-600 hover:text-gray-300 disabled:opacity-40"
+          className="flex items-center gap-1 text-xs px-2 py-1.5 rounded border transition-colors bg-input text-subtle border-input-border hover:bg-surface-hover hover:text-muted disabled:opacity-40"
         >
           <Paperclip size={13} />
           <span className="hidden sm:inline">{fileUpload.uploads.length > 0 ? `${fileUpload.uploads.length}/10 files` : 'Attach files'}</span>
@@ -508,18 +508,18 @@ export function TaskForm({ onCreated }: TaskFormProps) {
             className={`flex items-center gap-1 text-xs px-2 py-1.5 rounded border transition-colors ${
               hasNonDefaultConfig
                 ? 'bg-amber-600/30 text-amber-300 border-amber-500/50 hover:bg-amber-600/40'
-                : 'bg-gray-700 text-gray-400 border-gray-600 hover:bg-gray-600 hover:text-gray-300'
+                : 'bg-input text-subtle border-input-border hover:bg-surface-hover hover:text-muted'
             }`}
           >
             <Settings size={13} />
             <span className="hidden sm:inline">Config</span>
           </button>
           {showConfigPanel && (
-            <div className="absolute top-full mt-1 left-0 bg-gray-800 border border-gray-600 rounded shadow-lg z-20 p-3 min-w-[280px]">
+            <div className="absolute top-full mt-1 left-0 bg-surface border border-input-border rounded shadow-lg z-20 p-3 min-w-[280px]">
               <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-2 items-center text-xs">
-                <span className="text-gray-400">Priority</span>
+                <span className="text-subtle">Priority</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={priority}
                   onChange={(e) => setPriority(Number(e.target.value))}
                 >
@@ -528,9 +528,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                   ))}
                 </select>
 
-                <span className="text-gray-400">Mode</span>
+                <span className="text-subtle">Mode</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={mode}
                   onChange={(e) => setMode(e.target.value)}
                 >
@@ -540,9 +540,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                   <option value="goal">Goal</option>
                 </select>
 
-                <span className="text-gray-400">Run on</span>
+                <span className="text-subtle">Run on</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={workerId}
                   onChange={(e) => setWorkerId(e.target.value)}
                 >
@@ -554,9 +554,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                   ))}
                 </select>
 
-                <span className="text-gray-400">CLI</span>
+                <span className="text-subtle">CLI</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={provider}
                   onChange={(e) => {
                     setProvider(e.target.value);
@@ -569,9 +569,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                   ))}
                 </select>
 
-                <span className="text-gray-400">Model</span>
+                <span className="text-subtle">Model</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={model}
                   onChange={(e) => setModel(e.target.value)}
                 >
@@ -581,9 +581,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                   ))}
                 </select>
 
-                <span className="text-gray-400">Effort</span>
+                <span className="text-subtle">Effort</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={effort}
                   onChange={(e) => setEffort(e.target.value)}
                 >
@@ -593,9 +593,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                   ))}
                 </select>
 
-                <span className="text-gray-400">Thinking</span>
+                <span className="text-subtle">Thinking</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={thinkingBudget}
                   onChange={(e) => setThinkingBudget(e.target.value)}
                 >
@@ -608,9 +608,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                   <option value="131072">128k</option>
                 </select>
 
-                <span className="text-gray-400">Timeout</span>
+                <span className="text-subtle">Timeout</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={timeoutHours}
                   onChange={(e) => setTimeoutHours(e.target.value)}
                 >
@@ -625,9 +625,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                   <option value="0">No limit</option>
                 </select>
 
-                <span className="text-gray-400">System Prompt</span>
+                <span className="text-subtle">System Prompt</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={systemPromptMode}
                   onChange={(e) => setSystemPromptMode(e.target.value)}
                 >
@@ -664,7 +664,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
           className={`flex items-center gap-1 text-xs px-2 py-1.5 rounded border transition-colors ${
             starOnCreate
               ? 'bg-yellow-600/30 text-yellow-300 border-yellow-500/50 hover:bg-yellow-600/40'
-              : 'bg-gray-700 text-gray-400 border-gray-600 hover:bg-gray-600 hover:text-gray-300'
+              : 'bg-input text-subtle border-input-border hover:bg-surface-hover hover:text-muted'
           }`}
         >
           <Star size={13} fill={starOnCreate ? 'currentColor' : 'none'} />
@@ -677,7 +677,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
               className={`flex items-center gap-1 text-xs px-2 py-1.5 rounded border transition-colors ${
                 enabledUserSkillCount > 0
                   ? 'bg-green-600/30 text-green-300 border-green-500/50 hover:bg-green-600/40'
-                  : 'bg-gray-700 text-gray-400 border-gray-600 hover:bg-gray-600 hover:text-gray-300'
+                  : 'bg-input text-subtle border-input-border hover:bg-surface-hover hover:text-muted'
               }`}
             >
               <span className="text-xs">📝</span>
@@ -685,13 +685,13 @@ export function TaskForm({ onCreated }: TaskFormProps) {
               {enabledUserSkillCount > 0 && <span className="sm:hidden">{enabledUserSkillCount}</span>}
             </button>
             {showSkillsDropdown && (
-              <div className="absolute top-full mt-1 left-0 bg-gray-800 border border-gray-600 rounded shadow-lg z-20 min-w-[180px]">
+              <div className="absolute top-full mt-1 left-0 bg-surface border border-input-border rounded shadow-lg z-20 min-w-[180px]">
                 {userSkills.length === 0 ? (
-                  <div className="px-3 py-2 text-xs text-gray-500">暂无 Skill，去 Skills 页面创建</div>
+                  <div className="px-3 py-2 text-xs text-subtle">暂无 Skill，去 Skills 页面创建</div>
                 ) : userSkills.map((skill) => (
                   <label
                     key={skill.id}
-                    className="flex items-center gap-2 px-3 py-2 text-xs text-gray-300 hover:bg-gray-700 cursor-pointer"
+                    className="flex items-center gap-2 px-3 py-2 text-xs text-muted hover:bg-surface-hover cursor-pointer"
                     title={skill.description}
                   >
                     <input
@@ -714,8 +714,8 @@ export function TaskForm({ onCreated }: TaskFormProps) {
               onClick={() => setShowPluginsDropdown(!showPluginsDropdown)}
               className={`flex items-center gap-1 text-xs px-2 py-1.5 rounded border transition-colors ${
                 enabledPluginCount > 0
-                  ? 'bg-indigo-600/30 text-indigo-300 border-indigo-500/50 hover:bg-indigo-600/40'
-                  : 'bg-gray-700 text-gray-400 border-gray-600 hover:bg-gray-600 hover:text-gray-300'
+                  ? 'bg-accent-muted text-accent-muted-foreground border-focus hover:bg-accent hover:text-accent-foreground'
+                  : 'bg-input text-subtle border-input-border hover:bg-surface-hover hover:text-muted'
               }`}
             >
               <Wrench size={13} />
@@ -723,13 +723,13 @@ export function TaskForm({ onCreated }: TaskFormProps) {
               {enabledPluginCount > 0 && <span className="sm:hidden">{enabledPluginCount}</span>}
             </button>
             {showPluginsDropdown && (
-              <div className="absolute top-full mt-1 left-0 bg-gray-800 border border-gray-600 rounded shadow-lg z-20 min-w-[180px]">
+              <div className="absolute top-full mt-1 left-0 bg-surface border border-input-border rounded shadow-lg z-20 min-w-[180px]">
                 {AVAILABLE_PLUGINS.map((tool) => {
                   const locked = false;
                   return (
                     <label
                       key={tool.key}
-                      className={`flex items-center gap-2 px-3 py-2 text-xs transition-colors ${locked ? 'text-gray-500 cursor-default' : 'text-gray-300 hover:bg-gray-700 cursor-pointer'}`}
+                      className={`flex items-center gap-2 px-3 py-2 text-xs transition-colors ${locked ? 'text-subtle cursor-default' : 'text-muted hover:bg-surface-hover cursor-pointer'}`}
                       title={tool.description}
                     >
                       <input
@@ -737,7 +737,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                         checked={!!enabledPlugins[tool.key]}
                         onChange={(e) => !locked && setEnabledPlugins((prev) => ({ ...prev, [tool.key]: e.target.checked }))}
                         disabled={locked}
-                        className="accent-indigo-500"
+                        className="accent-accent"
                       />
                       {tool.label}
                     </label>
@@ -751,7 +751,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
         <button
           type="submit"
           disabled={loading || !canSubmit}
-          className="flex items-center gap-1 bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-1.5 rounded text-xs font-medium disabled:opacity-50 ml-auto"
+          className="flex items-center gap-1 bg-accent hover:bg-accent-hover text-accent-foreground px-4 py-1.5 rounded text-xs font-medium disabled:opacity-50 ml-auto"
         >
           <Plus size={14} />
           <span className="hidden sm:inline">{loading ? 'Creating...' : 'Create'}</span>

--- a/frontend/src/components/Tasks/TaskList.tsx
+++ b/frontend/src/components/Tasks/TaskList.tsx
@@ -110,7 +110,7 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
   const { draggingId, overIndex, targetProps, pointerHandleProps, ghost } = useTaskReorder(tasks, onRefresh, autoSortOnAccess);
 
   if (tasks.length === 0) {
-    return <p className="text-gray-500 text-sm text-center py-8">No tasks yet</p>;
+    return <p className="text-subtle text-sm text-center py-8">No tasks yet</p>;
   }
 
   return (
@@ -123,15 +123,15 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
           {...targetProps(t, idx)}
           className={`relative rounded-lg p-3 transition-opacity ${
             draggingId === t.id ? 'opacity-40' : ''
-          } ${overIndex === idx && draggingId !== null && draggingId !== t.id ? 'ring-2 ring-indigo-400' : ''} ${
-            activeTaskId === t.id ? 'bg-indigo-900/60 ring-1 ring-indigo-400/60' : t.has_unread ? 'bg-indigo-900/50 ring-1 ring-indigo-500/50' : 'bg-gray-800'
+          } ${overIndex === idx && draggingId !== null && draggingId !== t.id ? 'ring-2 ring-focus' : ''} ${
+            activeTaskId === t.id ? 'bg-accent-muted ring-1 ring-focus' : t.has_unread ? 'bg-accent-muted ring-1 ring-focus' : 'bg-surface'
           }`}
         >
           {/* 拖拽手柄（右下角，空间更宽裕）：卡片正文是可选中文字，整卡
               draggable 会被文本选择手势抢走，必须用显式手柄拖动 */}
           <span
             {...pointerHandleProps(t, idx)}
-            className="absolute bottom-1.5 right-1.5 p-1 cursor-grab active:cursor-grabbing text-gray-600 hover:text-gray-400 select-none"
+            className="absolute bottom-1.5 right-1.5 p-1 cursor-grab active:cursor-grabbing text-subtle hover:text-muted select-none"
             title="按住拖动排序"
           >
             <GripVertical size={16} />
@@ -140,7 +140,7 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
           <div className="flex items-center gap-2">
             <span className={`w-2.5 h-2.5 rounded-full shrink-0 self-start mt-[9px] ${statusColors[t.status] || 'bg-gray-500'}`} />
             <div className="flex items-center gap-2 flex-wrap flex-1 min-w-0 min-h-[28px]">
-              <span className="text-xs text-gray-500">#{t.id}</span>
+              <span className="text-xs text-subtle">#{t.id}</span>
               {t.shared_from_id && (
                 <span className="text-xs bg-orange-600/30 text-orange-300 px-1.5 rounded font-medium">Shared</span>
               )}
@@ -152,9 +152,9 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
                 return <span className={`text-xs ${bg} ${text} px-1.5 rounded font-medium whitespace-nowrap`}>{proj.name}</span>;
               })()}
               {t.priority > 0 && (
-                <span className="text-xs bg-indigo-600/30 text-indigo-300 px-1.5 rounded">P{t.priority}</span>
+                <span className="text-xs bg-accent-muted text-accent-muted-foreground px-1.5 rounded">P{t.priority}</span>
               )}
-              <span className="hidden sm:inline text-xs text-gray-500 capitalize">{t.status.replace('_', ' ')}</span>
+              <span className="hidden sm:inline text-xs text-subtle capitalize">{t.status.replace('_', ' ')}</span>
               <span className={`hidden sm:inline text-xs px-1.5 rounded font-medium ${t.provider === 'codex' ? 'bg-green-600/30 text-green-300' : 'bg-blue-600/30 text-blue-300'}`}>
                 {t.provider === 'codex' ? 'Codex' : 'Claude'}
               </span>
@@ -166,14 +166,14 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
             <div className="flex gap-1 shrink-0 items-center">
               <button
                 onClick={() => handleStar(t.id)}
-                className={`p-1.5 transition-colors ${t.starred ? 'text-yellow-400 hover:text-yellow-300' : 'text-gray-600 hover:text-yellow-400'}`}
+                className={`p-1.5 transition-colors ${t.starred ? 'text-warning hover:text-yellow-300' : 'text-subtle hover:text-warning'}`}
                 title={t.starred ? "Unstar" : "Star"}
               >
                 <Star size={16} fill={t.starred ? 'currentColor' : 'none'} />
               </button>
               <button
                 onClick={() => handleToggleUnread(t.id, t.has_unread)}
-                className={`p-1.5 transition-colors ${t.has_unread ? 'text-indigo-400 hover:text-indigo-300' : 'text-gray-600 hover:text-indigo-400'}`}
+                className={`p-1.5 transition-colors ${t.has_unread ? 'text-accent-muted-foreground hover:text-foreground' : 'text-subtle hover:text-accent-muted-foreground'}`}
                 title={t.has_unread ? "Mark as read" : "Mark as unread"}
               >
                 {t.has_unread ? <MailOpen size={16} /> : <Mail size={16} />}
@@ -181,7 +181,7 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
               {t.session_id && (
                 <button
                   onClick={() => onOpenChat(t)}
-                  className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium bg-indigo-600/20 text-indigo-400 hover:bg-indigo-600/30"
+                  className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium bg-accent-muted text-accent-muted-foreground hover:bg-accent hover:text-accent-foreground"
                   title="Chat"
                 >
                   <MessageCircle size={14} /><span className="hidden sm:inline"> Chat</span>
@@ -189,10 +189,10 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
               )}
               <button
                 onClick={() => handleCopy(t)}
-                className="p-1.5 text-gray-600 hover:text-gray-300 transition-colors"
+                className="p-1.5 text-subtle hover:text-muted transition-colors"
                 title="Copy prompt"
               >
-                {copiedId === t.id ? <Check size={16} className="text-green-400" /> : <Copy size={16} />}
+                {copiedId === t.id ? <Check size={16} className="text-success" /> : <Copy size={16} />}
               </button>
               {/* Overflow menu */}
               <div className="relative">
@@ -200,16 +200,16 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
                   onClick={() => {
                     setMenuOpenId(menuOpenId === t.id ? null : t.id);
                   }}
-                  className="p-1.5 text-gray-600 hover:text-gray-300 transition-colors"
+                  className="p-1.5 text-subtle hover:text-muted transition-colors"
                   title="More actions"
                 >
                   <MoreVertical size={16} />
                 </button>
                 {menuOpenId === t.id && (
-                  <div ref={menuRef} className="absolute top-full mt-1 right-0 bg-gray-900 border border-gray-700 rounded-lg shadow-xl z-20 py-1 min-w-[140px]">
+                  <div ref={menuRef} className="absolute top-full mt-1 right-0 bg-surface-raised border border-border rounded-lg shadow-xl z-20 py-1 min-w-[140px]">
                     <button
                       onClick={() => { setTitleDraft(t.title || ''); setEditingTitleId(t.id); setMenuOpenId(null); }}
-                      className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-gray-300 hover:bg-gray-800 text-left"
+                      className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-muted hover:bg-surface-hover text-left"
                     >
                       <Pencil size={14} /> Edit title
                     </button>
@@ -219,14 +219,14 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
                         setMenuOpenId(null);
                         window.dispatchEvent(new CustomEvent('ccm-share-task', { detail: { task: t } }));
                       }}
-                      className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-gray-300 hover:bg-gray-800 text-left"
+                      className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-muted hover:bg-surface-hover text-left"
                     >
                       <Share2 size={14} /> Share
                     </button>
                     {['in_progress', 'executing'].includes(t.status) && (
                       <button
                         onClick={() => { handleCancel(t.id); setMenuOpenId(null); }}
-                        className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-yellow-400 hover:bg-gray-800 text-left"
+                        className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-warning hover:bg-surface-hover text-left"
                       >
                         <XCircle size={14} /> Cancel
                       </button>
@@ -234,14 +234,14 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
                     {t.status === 'failed' && (
                       <button
                         onClick={() => { handleRetry(t.id); setMenuOpenId(null); }}
-                        className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-blue-400 hover:bg-gray-800 text-left"
+                        className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-info hover:bg-surface-hover text-left"
                       >
                         <RotateCcw size={14} /> Retry
                       </button>
                     )}
                     <button
                       onClick={() => { handleArchive(t.id); setMenuOpenId(null); }}
-                      className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-amber-400 hover:bg-gray-800 text-left"
+                      className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-warning hover:bg-surface-hover text-left"
                     >
                       {t.archived ? <ArchiveRestore size={14} /> : <Archive size={14} />}
                       {t.archived ? 'Unarchive' : 'Archive'}
@@ -249,7 +249,7 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
                     {['pending', 'failed', 'cancelled', 'completed'].includes(t.status) && (
                       <button
                         onClick={() => { handleDelete(t.id); setMenuOpenId(null); }}
-                        className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-red-400 hover:bg-gray-800 text-left"
+                        className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-danger hover:bg-surface-hover text-left"
                       >
                         <Trash2 size={14} /> Delete
                       </button>
@@ -272,7 +272,7 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
                   if (e.key === 'Enter') handleTitleSave(t);
                   if (e.key === 'Escape') setEditingTitleId(null);
                 }}
-                className="w-full bg-gray-700 text-foreground text-sm rounded px-2 py-0.5 mt-0.5 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full bg-input text-foreground text-sm rounded px-2 py-0.5 mt-0.5 focus:outline-none focus:ring-1 focus:ring-focus"
                 placeholder="Enter title..."
               />
             ) : (
@@ -282,37 +282,37 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
             )}
             {/* Description (expandable) */}
             {t.mode === 'loop' && !t.description ? (
-              <p className="text-sm mt-0.5 text-gray-500 italic">{t.todo_file_path}</p>
+              <p className="text-sm mt-0.5 text-subtle italic">{t.todo_file_path}</p>
             ) : t.description ? (
               <ExpandableText
                 text={t.description}
                 collapsedLines={2}
-                className={`text-sm mt-0.5 ${t.title ? 'text-gray-400' : 'text-foreground'}`}
+                className={`text-sm mt-0.5 ${t.title ? 'text-muted' : 'text-foreground'}`}
               />
             ) : null}
             {t.mode === 'goal' && t.goal_condition && (
-              <p className="text-emerald-500/70 text-xs mt-0.5 line-clamp-1">Goal: {t.goal_condition}</p>
+              <p className="text-success text-xs mt-0.5 line-clamp-1">Goal: {t.goal_condition}</p>
             )}
             {t.mode === 'loop' && t.loop_progress && (
-              <p className="text-indigo-400 text-xs mt-0.5">⟳ {t.loop_progress}</p>
+              <p className="text-accent-muted-foreground text-xs mt-0.5">⟳ {t.loop_progress}</p>
             )}
             {t.mode === 'goal' && t.goal_turns_used > 0 && (
-              <p className="text-emerald-400 text-xs mt-0.5">
+              <p className="text-success text-xs mt-0.5">
                 ◎ Turn {t.goal_turns_used}/{t.goal_max_turns}
-                {t.goal_last_reason && <span className="text-gray-500 ml-1">— {t.goal_last_reason}</span>}
+                {t.goal_last_reason && <span className="text-subtle ml-1">— {t.goal_last_reason}</span>}
               </p>
             )}
             {t.target_repo && (
-              <p className="text-gray-600 text-xs mt-0.5 truncate">{t.target_repo}</p>
+              <p className="text-subtle text-xs mt-0.5 truncate">{t.target_repo}</p>
             )}
             {t.created_at && (
-              <p className="text-gray-600 text-xs mt-0.5 flex items-center gap-1">
+              <p className="text-subtle text-xs mt-0.5 flex items-center gap-1">
                 <Clock size={10} className="shrink-0" />
                 {formatDateTime(t.created_at)}
               </p>
             )}
             {t.error_message && (
-              <p className="text-red-400 text-xs mt-1">{t.error_message}</p>
+              <p className="text-danger text-xs mt-1">{t.error_message}</p>
             )}
           </div>
         </div>

--- a/frontend/src/config/theme.ts
+++ b/frontend/src/config/theme.ts
@@ -1,15 +1,308 @@
 const STORAGE_KEY = 'cc_theme';
 
-export const THEME_OPTIONS = [
-  { value: 'dark', label: '深色' },
-  { value: 'ocean', label: '海蓝' },
-  { value: 'forest', label: '森林' },
-  { value: 'rose', label: '莓红' },
-] as const;
+// Follow-up (semantic-theme migration, from PR #29 review):
+//  - Task status dots in TaskList (`statusColors[t.status] || 'bg-gray-500'`) and
+//    provider/shared badges (green=Codex, blue=Claude, orange=Shared) still use raw
+//    Tailwind accent classes. They currently follow the theme only via the
+//    --color-gray-*/accent compat overrides in index.css. Fold them into the
+//    semantic token set (success/danger/warning/info) once those roles cover the
+//    status palette, then the per-theme compat blocks can start shrinking.
 
-export type Theme = typeof THEME_OPTIONS[number]['value'];
+type ThemeToken =
+  | 'appBackground'
+  | 'foreground'
+  | 'muted'
+  | 'subtle'
+  | 'chromeBackground'
+  | 'chromeBorder'
+  | 'surfaceBackground'
+  | 'surfaceRaised'
+  | 'surfaceHover'
+  | 'border'
+  | 'inputBackground'
+  | 'inputBorder'
+  | 'accentBackground'
+  | 'accentHover'
+  | 'accentForeground'
+  | 'accentMutedBackground'
+  | 'accentMutedForeground'
+  | 'focusRing'
+  | 'successForeground'
+  | 'warningForeground'
+  | 'dangerForeground'
+  | 'infoForeground';
 
-const THEME_VALUES = new Set<Theme>(THEME_OPTIONS.map((t) => t.value));
+type ThemeDefinition = {
+  label: string;
+  colorScheme: 'dark' | 'light';
+  tokens: Record<ThemeToken, string>;
+};
+
+const TOKEN_VARIABLES: Record<ThemeToken, `--ccm-${string}`> = {
+  appBackground: '--ccm-app-background',
+  foreground: '--ccm-foreground',
+  muted: '--ccm-muted',
+  subtle: '--ccm-subtle',
+  chromeBackground: '--ccm-chrome-background',
+  chromeBorder: '--ccm-chrome-border',
+  surfaceBackground: '--ccm-surface-background',
+  surfaceRaised: '--ccm-surface-raised',
+  surfaceHover: '--ccm-surface-hover',
+  border: '--ccm-border',
+  inputBackground: '--ccm-input-background',
+  inputBorder: '--ccm-input-border',
+  accentBackground: '--ccm-accent-background',
+  accentHover: '--ccm-accent-hover',
+  accentForeground: '--ccm-accent-foreground',
+  accentMutedBackground: '--ccm-accent-muted-background',
+  accentMutedForeground: '--ccm-accent-muted-foreground',
+  focusRing: '--ccm-focus-ring',
+  successForeground: '--ccm-success-foreground',
+  warningForeground: '--ccm-warning-foreground',
+  dangerForeground: '--ccm-danger-foreground',
+  infoForeground: '--ccm-info-foreground',
+};
+
+// Cached at module load — TOKEN_VARIABLES is const, so this never changes.
+const TOKEN_ENTRIES = Object.entries(TOKEN_VARIABLES) as Array<[ThemeToken, `--ccm-${string}`]>;
+
+export const THEMES = {
+  // NOTE: The dark theme's token values are duplicated in index.css `:root`, which
+  // acts as the pre-JS fallback. Keep the two in sync when editing dark values.
+  dark: {
+    label: '深色',
+    colorScheme: 'dark',
+    tokens: {
+      appBackground: '#030712',
+      foreground: '#f9fafb',
+      muted: '#d1d5db',
+      subtle: '#9ca3af',
+      chromeBackground: '#111827',
+      chromeBorder: '#374151',
+      surfaceBackground: '#1f2937',
+      surfaceRaised: '#111827',
+      surfaceHover: '#374151',
+      border: '#374151',
+      inputBackground: '#374151',
+      inputBorder: '#4b5563',
+      accentBackground: '#4f46e5',
+      accentHover: '#6366f1',
+      accentForeground: '#ffffff',
+      accentMutedBackground: '#312e81',
+      accentMutedForeground: '#c7d2fe',
+      focusRing: '#6366f1',
+      successForeground: '#4ade80',
+      warningForeground: '#facc15',
+      dangerForeground: '#f87171',
+      infoForeground: '#60a5fa',
+    },
+  },
+  ocean: {
+    label: '海蓝',
+    colorScheme: 'dark',
+    tokens: {
+      appBackground: '#06131f',
+      foreground: '#e8f6ff',
+      muted: '#bed0d9',
+      subtle: '#91aebd',
+      chromeBackground: '#0b1f30',
+      chromeBorder: '#1c4562',
+      surfaceBackground: '#123047',
+      surfaceRaised: '#0b1f30',
+      surfaceHover: '#1c4562',
+      border: '#1c4562',
+      inputBackground: '#123047',
+      inputBorder: '#2f5f7c',
+      accentBackground: '#0891b2',
+      accentHover: '#06b6d4',
+      accentForeground: '#ecfeff',
+      accentMutedBackground: '#164e63',
+      accentMutedForeground: '#a5f3fc',
+      focusRing: '#22d3ee',
+      successForeground: '#86efac',
+      warningForeground: '#fcd34d',
+      dangerForeground: '#fda4af',
+      infoForeground: '#7dd3fc',
+    },
+  },
+  forest: {
+    label: '森林',
+    colorScheme: 'dark',
+    tokens: {
+      appBackground: '#07130d',
+      foreground: '#f0f8ef',
+      muted: '#c2cdbc',
+      subtle: '#9aab98',
+      chromeBackground: '#102015',
+      chromeBorder: '#29472f',
+      surfaceBackground: '#1a3221',
+      surfaceRaised: '#102015',
+      surfaceHover: '#29472f',
+      border: '#29472f',
+      inputBackground: '#1a3221',
+      inputBorder: '#3f6046',
+      accentBackground: '#15803d',
+      accentHover: '#16a34a',
+      accentForeground: '#f0fdf4',
+      accentMutedBackground: '#14532d',
+      accentMutedForeground: '#bbf7d0',
+      focusRing: '#4ade80',
+      successForeground: '#86efac',
+      warningForeground: '#fde047',
+      dangerForeground: '#fca5a5',
+      infoForeground: '#93c5fd',
+    },
+  },
+  rose: {
+    label: '莓红',
+    colorScheme: 'dark',
+    tokens: {
+      appBackground: '#1a0b12',
+      foreground: '#fff1f5',
+      muted: '#dcc0c9',
+      subtle: '#bd95a4',
+      chromeBackground: '#2a121d',
+      chromeBorder: '#55283c',
+      surfaceBackground: '#3d1c2b',
+      surfaceRaised: '#2a121d',
+      surfaceHover: '#55283c',
+      border: '#55283c',
+      inputBackground: '#3d1c2b',
+      inputBorder: '#71384f',
+      accentBackground: '#db2777',
+      accentHover: '#ec4899',
+      accentForeground: '#fff1f5',
+      accentMutedBackground: '#831843',
+      accentMutedForeground: '#fbcfe8',
+      focusRing: '#f472b6',
+      successForeground: '#6ee7b7',
+      warningForeground: '#fcd34d',
+      dangerForeground: '#fda4af',
+      infoForeground: '#c4b5fd',
+    },
+  },
+  onedark: {
+    label: 'One Dark',
+    colorScheme: 'dark',
+    tokens: {
+      appBackground: '#21252b',
+      foreground: '#d7dae0',
+      muted: '#abb2bf',
+      subtle: '#7f848e',
+      chromeBackground: '#21252b',
+      chromeBorder: '#181a1f',
+      surfaceBackground: '#282c34',
+      surfaceRaised: '#21252b',
+      surfaceHover: '#2c313c',
+      border: '#3e4451',
+      inputBackground: '#1d2026',
+      inputBorder: '#3e4451',
+      accentBackground: '#4577e6',
+      accentHover: '#528bff',
+      accentForeground: '#ffffff',
+      accentMutedBackground: '#2b3a54',
+      accentMutedForeground: '#9cc0f5',
+      focusRing: '#61afef',
+      successForeground: '#98c379',
+      warningForeground: '#e5c07b',
+      dangerForeground: '#e06c75',
+      infoForeground: '#61afef',
+    },
+  },
+  dracula: {
+    label: 'Dracula',
+    colorScheme: 'dark',
+    tokens: {
+      appBackground: '#21222c',
+      foreground: '#f8f8f2',
+      muted: '#d4d6e4',
+      subtle: '#6272a4',
+      chromeBackground: '#282a36',
+      chromeBorder: '#191a21',
+      surfaceBackground: '#343645',
+      surfaceRaised: '#282a36',
+      surfaceHover: '#44475a',
+      border: '#44475a',
+      inputBackground: '#21222c',
+      inputBorder: '#44475a',
+      accentBackground: '#7c5cc7',
+      accentHover: '#9070d8',
+      accentForeground: '#ffffff',
+      accentMutedBackground: '#3b2f5e',
+      accentMutedForeground: '#d6bcfd',
+      focusRing: '#bd93f9',
+      successForeground: '#50fa7b',
+      warningForeground: '#f1fa8c',
+      dangerForeground: '#ff5555',
+      infoForeground: '#8be9fd',
+    },
+  },
+  nord: {
+    label: 'Nord',
+    colorScheme: 'dark',
+    tokens: {
+      appBackground: '#242933',
+      foreground: '#eceff4',
+      muted: '#d8dee9',
+      subtle: '#7b88a1',
+      chromeBackground: '#2e3440',
+      chromeBorder: '#3b4252',
+      surfaceBackground: '#3b4252',
+      surfaceRaised: '#2e3440',
+      surfaceHover: '#434c5e',
+      border: '#434c5e',
+      inputBackground: '#2e3440',
+      inputBorder: '#4c566a',
+      accentBackground: '#5e81ac',
+      accentHover: '#81a1c1',
+      accentForeground: '#eceff4',
+      accentMutedBackground: '#3b4a5e',
+      accentMutedForeground: '#a3c1e0',
+      focusRing: '#88c0d0',
+      successForeground: '#a3be8c',
+      warningForeground: '#ebcb8b',
+      dangerForeground: '#bf616a',
+      infoForeground: '#88c0d0',
+    },
+  },
+  tokyonight: {
+    label: 'Tokyo Night',
+    colorScheme: 'dark',
+    tokens: {
+      appBackground: '#16161e',
+      foreground: '#c0caf5',
+      muted: '#a9b1d6',
+      subtle: '#565f89',
+      chromeBackground: '#1a1b26',
+      chromeBorder: '#292e42',
+      surfaceBackground: '#1f2335',
+      surfaceRaised: '#1a1b26',
+      surfaceHover: '#292e42',
+      border: '#292e42',
+      inputBackground: '#1a1b26',
+      inputBorder: '#3b4261',
+      accentBackground: '#4d62a6',
+      accentHover: '#7aa2f7',
+      accentForeground: '#ffffff',
+      accentMutedBackground: '#2a3158',
+      accentMutedForeground: '#a9c0ff',
+      focusRing: '#7aa2f7',
+      successForeground: '#9ece6a',
+      warningForeground: '#e0af68',
+      dangerForeground: '#f7768e',
+      infoForeground: '#7dcfff',
+    },
+  },
+} as const satisfies Record<string, ThemeDefinition>;
+
+export type Theme = keyof typeof THEMES;
+
+export const THEME_OPTIONS = Object.entries(THEMES).map(([value, theme]) => ({
+  value: value as Theme,
+  label: theme.label,
+}));
+
+const THEME_VALUES = new Set<Theme>(Object.keys(THEMES) as Theme[]);
 
 export function getTheme(): Theme {
   const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
@@ -23,6 +316,14 @@ export function setTheme(theme: Theme) {
 
 export function applyTheme(theme?: Theme) {
   const t = theme || getTheme();
-  document.documentElement.classList.remove('light');
-  document.documentElement.dataset.theme = t;
+  const definition = THEMES[t];
+  const root = document.documentElement;
+
+  root.classList.remove('light');
+  root.dataset.theme = t;
+  root.style.colorScheme = definition.colorScheme;
+
+  for (const [token, variable] of TOKEN_ENTRIES) {
+    root.style.setProperty(variable, definition.tokens[token]);
+  }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,19 +1,77 @@
 @import "tailwindcss";
 
 @theme {
-  --color-foreground: #ffffff;
+  --color-app: var(--ccm-app-background);
+  --color-foreground: var(--ccm-foreground);
+  --color-muted: var(--ccm-muted);
+  --color-subtle: var(--ccm-subtle);
+  --color-chrome: var(--ccm-chrome-background);
+  --color-chrome-border: var(--ccm-chrome-border);
+  --color-surface: var(--ccm-surface-background);
+  --color-surface-raised: var(--ccm-surface-raised);
+  --color-surface-hover: var(--ccm-surface-hover);
+  --color-border: var(--ccm-border);
+  --color-input: var(--ccm-input-background);
+  --color-input-border: var(--ccm-input-border);
+  --color-accent: var(--ccm-accent-background);
+  --color-accent-hover: var(--ccm-accent-hover);
+  --color-accent-foreground: var(--ccm-accent-foreground);
+  --color-accent-muted: var(--ccm-accent-muted-background);
+  --color-accent-muted-foreground: var(--ccm-accent-muted-foreground);
+  --color-focus: var(--ccm-focus-ring);
+  --color-success: var(--ccm-success-foreground);
+  --color-warning: var(--ccm-warning-foreground);
+  --color-danger: var(--ccm-danger-foreground);
+  --color-info: var(--ccm-info-foreground);
+}
+
+:root {
+  color-scheme: dark;
+  --ccm-app-background: #030712;
+  --ccm-foreground: #f9fafb;
+  --ccm-muted: #d1d5db;
+  --ccm-subtle: #9ca3af;
+  --ccm-chrome-background: #111827;
+  --ccm-chrome-border: #374151;
+  --ccm-surface-background: #1f2937;
+  --ccm-surface-raised: #111827;
+  --ccm-surface-hover: #374151;
+  --ccm-border: #374151;
+  --ccm-input-background: #374151;
+  --ccm-input-border: #4b5563;
+  --ccm-accent-background: #4f46e5;
+  --ccm-accent-hover: #6366f1;
+  --ccm-accent-foreground: #ffffff;
+  --ccm-accent-muted-background: #312e81;
+  --ccm-accent-muted-foreground: #c7d2fe;
+  --ccm-focus-ring: #6366f1;
+  --ccm-success-foreground: #4ade80;
+  --ccm-warning-foreground: #facc15;
+  --ccm-danger-foreground: #f87171;
+  --ccm-info-foreground: #60a5fa;
 }
 
 html {
-  background-color: #030712;
+  background-color: var(--ccm-app-background);
   touch-action: manipulation;
   overflow-x: clip;
 }
 
-
+/*
+ * Compat layer for components not yet migrated to semantic tokens.
+ * Migrated components consume semantic aliases (bg-surface, text-muted, …) which
+ * resolve from the JS-applied --ccm- vars. Everything else still uses raw
+ * bg-gray and text-gray classes; these per-theme blocks re-map Tailwind's
+ * --color-gray- scale (+ a few accents) so those components keep following the theme.
+ * Remove a theme's block only once every component reads semantic tokens.
+ *
+ * NOTE: only dark-family themes are shipped. A light theme is intentionally NOT
+ * included: inverting the gray scale leaves the many `text-white`/`bg-white`
+ * literals across the app (ProjectSelect, Files tabs, Chat, badges, …) as
+ * white-on-light and unreadable. Re-add light only after those components move
+ * off raw white/gray classes onto semantic tokens.
+ */
 html[data-theme='ocean'] {
-  background-color: #06131f;
-
   --color-foreground: #e8f6ff;
 
   --color-gray-950: #06131f;
@@ -51,8 +109,6 @@ html[data-theme='ocean'] {
 }
 
 html[data-theme='forest'] {
-  background-color: #07130d;
-
   --color-foreground: #f0f8ef;
 
   --color-gray-950: #07130d;
@@ -90,8 +146,6 @@ html[data-theme='forest'] {
 }
 
 html[data-theme='rose'] {
-  background-color: #1a0b12;
-
   --color-foreground: #fff1f5;
 
   --color-gray-950: #1a0b12;
@@ -126,6 +180,154 @@ html[data-theme='rose'] {
   --color-red-300: #fda4af;
 
   --color-emerald-300: #6ee7b7;
+}
+
+html[data-theme='onedark'] {
+  --color-foreground: #d7dae0;
+
+  --color-gray-950: #21252b;
+  --color-gray-900: #282c34;
+  --color-gray-800: #2c313c;
+  --color-gray-700: #3e4451;
+  --color-gray-600: #4b5263;
+  --color-gray-500: #5c6370;
+  --color-gray-400: #7f848e;
+  --color-gray-300: #abb2bf;
+  --color-gray-200: #c5cad3;
+  --color-gray-100: #d7dae0;
+  --color-gray-50: #e8eaed;
+
+  --color-blue-600: #4577e6;
+  --color-blue-400: #61afef;
+  --color-blue-300: #83c0f2;
+
+  --color-indigo-600: #4577e6;
+  --color-indigo-500: #528bff;
+  --color-indigo-400: #6ea3ff;
+  --color-indigo-300: #9cc0f5;
+
+  --color-green-500: #98c379;
+  --color-green-400: #a9d08a;
+  --color-green-300: #b8d99c;
+
+  --color-yellow-400: #e5c07b;
+  --color-yellow-300: #edcf98;
+
+  --color-red-400: #e06c75;
+  --color-red-300: #e88b92;
+
+  --color-emerald-300: #56b6c2;
+}
+
+html[data-theme='dracula'] {
+  --color-foreground: #f8f8f2;
+
+  --color-gray-950: #21222c;
+  --color-gray-900: #282a36;
+  --color-gray-800: #343645;
+  --color-gray-700: #44475a;
+  --color-gray-600: #565972;
+  --color-gray-500: #6272a4;
+  --color-gray-400: #7d88b8;
+  --color-gray-300: #c9cbe0;
+  --color-gray-200: #e2e3ef;
+  --color-gray-100: #f0f0f6;
+  --color-gray-50: #f8f8f2;
+
+  --color-blue-600: #6272a4;
+  --color-blue-400: #8be9fd;
+  --color-blue-300: #a5eefb;
+
+  --color-indigo-600: #7c5cc7;
+  --color-indigo-500: #bd93f9;
+  --color-indigo-400: #caa6fb;
+  --color-indigo-300: #ddc7fc;
+
+  --color-green-500: #50fa7b;
+  --color-green-400: #6ffb92;
+  --color-green-300: #8dfcaa;
+
+  --color-yellow-400: #f1fa8c;
+  --color-yellow-300: #f5fca8;
+
+  --color-red-400: #ff5555;
+  --color-red-300: #ff7b7b;
+
+  --color-emerald-300: #8be9fd;
+}
+
+html[data-theme='nord'] {
+  --color-foreground: #eceff4;
+
+  --color-gray-950: #242933;
+  --color-gray-900: #2e3440;
+  --color-gray-800: #3b4252;
+  --color-gray-700: #434c5e;
+  --color-gray-600: #4c566a;
+  --color-gray-500: #616e88;
+  --color-gray-400: #7b88a1;
+  --color-gray-300: #d8dee9;
+  --color-gray-200: #e5e9f0;
+  --color-gray-100: #eceff4;
+  --color-gray-50: #f4f6f9;
+
+  --color-blue-600: #5e81ac;
+  --color-blue-400: #81a1c1;
+  --color-blue-300: #88c0d0;
+
+  --color-indigo-600: #5e81ac;
+  --color-indigo-500: #81a1c1;
+  --color-indigo-400: #88c0d0;
+  --color-indigo-300: #a3c1e0;
+
+  --color-green-500: #a3be8c;
+  --color-green-400: #b5cca0;
+  --color-green-300: #c6d7b5;
+
+  --color-yellow-400: #ebcb8b;
+  --color-yellow-300: #f0d8a5;
+
+  --color-red-400: #bf616a;
+  --color-red-300: #d08088;
+
+  --color-emerald-300: #8fbcbb;
+}
+
+html[data-theme='tokyonight'] {
+  --color-foreground: #c0caf5;
+
+  --color-gray-950: #16161e;
+  --color-gray-900: #1a1b26;
+  --color-gray-800: #1f2335;
+  --color-gray-700: #292e42;
+  --color-gray-600: #3b4261;
+  --color-gray-500: #565f89;
+  --color-gray-400: #737aa2;
+  --color-gray-300: #a9b1d6;
+  --color-gray-200: #c0caf5;
+  --color-gray-100: #d5d9f0;
+  --color-gray-50: #ebedf9;
+
+  --color-blue-600: #4d62a6;
+  --color-blue-400: #7aa2f7;
+  --color-blue-300: #9db3f9;
+
+  --color-indigo-600: #5e46a8;
+  --color-indigo-500: #bb9af7;
+  --color-indigo-400: #cbb0f9;
+  --color-indigo-300: #d5bffb;
+
+  --color-green-500: #9ece6a;
+  --color-green-400: #b0d97f;
+  --color-green-300: #c1e195;
+
+  --color-yellow-400: #e0af68;
+  --color-yellow-300: #ebc488;
+
+  --color-red-400: #f7768e;
+  --color-red-300: #f994a6;
+
+  --color-emerald-300: #7dcfff;
 }
 
 /* Markdown body styles */
@@ -187,14 +389,14 @@ html[data-theme='rose'] {
 .markdown-body blockquote {
   margin: 0.5em 0;
   padding: 0.25em 0.75em;
-  border-left: 3px solid #4b5563;
-  color: #9ca3af;
+  border-left: 3px solid var(--ccm-input-border);
+  color: var(--ccm-subtle);
 }
 
 .markdown-body hr {
   margin: 0.75em 0;
   border: none;
-  border-top: 1px solid #374151;
+  border-top: 1px solid var(--ccm-border);
 }
 
 .markdown-body img {


### PR DESCRIPTION
## Summary

Selectable **semantic frontend themes** (VS Code-style token model), rebased onto latest `main` and with @youchengsong's review addressed.

- `config/theme.ts` owns a `THEMES` registry; each theme defines 22 semantic roles. `applyTheme` writes them as `--ccm-*` vars on `<html>` keyed by `data-theme`.
- `index.css` `@theme` maps Tailwind `--color-*` aliases (`bg-app/surface/chrome/accent`, `text-muted/subtle/success/danger`, …) to those vars. App shell / Header / TaskForm / TaskList consume the semantic classes.
- **Themes:** 深色 / 海蓝 / 森林 / 莓红 + **One Dark / Dracula / Nord / Tokyo Night** (all dark-family).

## Review responses (thanks @youchengsong)

- **#1 (方案A):** kept the per-theme `--color-gray-*`/accent compat blocks so components not yet migrated to semantic tokens still follow the theme — **no coverage regression**.
- **#2:** `:root` hard-codes the dark values as a pre-JS fallback; commented that it must stay in sync with `THEMES.dark` (verified identical).
- **#3 (contrast):** **dropped the `light` theme.** Inverting the gray scale leaves the many `text-white`/`bg-white` literals across ~27 files (ProjectSelect, Files tabs, Chat, badges) as white-on-light and unreadable. This matches `main`, which already removed light. Shipped themes are all dark-family.
- **#4 / #5:** status dots + provider/shared badges still use raw accent classes — recorded as a follow-up note in `theme.ts`; covered for now by the compat layer.
- **#6:** cache `Object.entries(TOKEN_VARIABLES)` as module-level `TOKEN_ENTRIES`.
- **#7:** fixed the goal-condition input indentation in `TaskForm`.

## Rebase note

Conflict resolutions preserve `main`'s newer features (hook-based file upload with status/retry, Skills dropdown, Tools→Plugins rename, Feishu binding, portal-free overflow menu) and apply only the semantic color classes on top.

## Validation

- `npx tsc --noEmit` ✅
- `npm run build` ✅
- Headless-Chrome screenshots of every theme confirm both the `--ccm-*` semantic tokens and the `--color-gray-*` compat layer apply per theme.