### PR TITLE
Add project todo task flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ claude-manager/
 - **认证**: 除 `/api/system/health`、`/api/auth/login`、`/api/github/webhook` 外，所有 API 需要 `Authorization: Bearer <token>`
 - **前端 type 导入**: 用 `import type { X }` 导入类型，`import { api }` 导入值（Vite 会去除 type-only exports）
 - **Tailwind v4**: 用 `@import "tailwindcss"` + `@tailwindcss/vite` 插件，无 tailwind.config
-- **主题**: 深色/浅色切换通过覆盖 `--color-gray-*` CSS 变量实现灰度反转，内容文字用 `text-foreground`（随主题变化），按钮文字保持 `text-white`
+- **主题**: 语义 token 系统（VS Code 风格）。`config/theme.ts` 的 `THEMES` 注册表为每个主题定义 22 个语义角色，`applyTheme` 按 `data-theme` 把它们写成 `--ccm-*` 变量到 `<html>` 上；`index.css` 的 `@theme` 把 Tailwind `--color-*` 别名（`bg-app/surface/chrome/accent`、`text-muted/subtle/success/danger` 等）映射到 `--ccm-*`。已迁移组件用语义类，**未迁移组件仍用 `bg-gray-*` 硬编码类**，靠每个主题的 `html[data-theme=...]` 兼容块覆盖 `--color-gray-*` 兜底跟随主题（组件全迁移后可删）。当前全是深色系主题（深色/海蓝/森林/莓红/One Dark/Dracula/Nord/Tokyo Night）；**light 主题被刻意移除**——反转灰阶会让满屏 `text-white`/`bg-white` 字面量变成白底白字。`:root` 硬编码一份 dark 值作为 JS 加载前 fallback，改 dark 值须与 `THEMES.dark` 同步
 - **Android App**: Capacitor 打包，API/WS 地址通过 `config/server.ts` 动态获取，LoginPage 可展开配置 Server URL
 - **Goal 模式**: `mode="goal"` 任务使用自然语言完成条件（`goal_condition`），每 turn 后由独立评估器（默认 Haiku）判断是否达成。使用 `--resume` 保持同一 session 的连续上下文。评估器通过 `claude -p` 子进程调用，不需要额外 API key
 - **Goal 评估器**: `GoalEvaluator`（`backend/services/goal_evaluator.py`）读取对话日志摘要，发给轻量模型判断条件是否满足。默认模型 `claude-haiku-4-5`，可通过 `goal_evaluator_model` 覆盖

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Web 端调度和管理多个 Claude Code 实例并行工作。灵感来自胡渊
 - **Claude Code 完全自主** — Claude Code 自主完成 worktree 创建、commit、fetch、merge、push、冲突解决和清理，Dispatcher 只负责分配任务和判断成败
 - **9 步任务生命周期** — 领取 → 创建工作区 → 实现 → 提交 → merge + 测试 → 合并到 main → 标记完成 → 清理 → 经验沉淀
 - **项目管理** — 支持 clone 已有仓库（有 remote）和本地 git init（无 remote），创建任务时可直接新建项目
+- **项目 Todo 清单** — 每个项目维护一个可折叠的待办清单（prompt 模板），一键「▶ Run」直接创建 Task 并跳转 Chat；创建后 Todo 自动标记完成并记录派生的 task。支持归档/恢复/永久删除
 - **任务队列** — 创建任务，按优先级自动调度（数字越小优先级越高）
 - **多实例并行** — 同时运行多个 Claude Code 实例，各自处理不同任务
 - **Git Worktree** — 每个实例在独立的 worktree 中工作，互不干扰
@@ -218,6 +219,9 @@ PR Monitor 的审核流程会在后端 shell out 调用 `gh pr view` / `gh pr re
 | Projects | `GET/POST /api/projects` | 项目列表/创建 |
 | | `GET/PUT/DELETE /api/projects/{id}` | 项目详情/更新/删除 |
 | | `POST /api/projects/{id}/reclone` | 重新 clone |
+| Project Todos | `GET/POST /api/projects/{id}/todos` | 项目待办列表/创建 |
+| | `PATCH /api/projects/{id}/todos/{todo_id}` | 更新（含归档/恢复/排序） |
+| | `DELETE /api/projects/{id}/todos/{todo_id}` | 永久删除 |
 | Tasks | `GET/POST /api/tasks` | 任务列表/创建 |
 | | `GET/PUT/DELETE /api/tasks/{id}` | 任务详情/更新/删除 |
 | | `POST /api/tasks/{id}/cancel` | 取消任务 |

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -12,6 +12,7 @@ if config.config_file_name is not None:
 # New models must be imported here for autogenerate to work.
 from backend.models.instance import Instance   # noqa: F401
 from backend.models.project import Project     # noqa: F401
+from backend.models.project_todo import ProjectTodo  # noqa: F401
 from backend.models.task import Task           # noqa: F401
 from backend.models.log_entry import LogEntry  # noqa: F401
 from backend.models.worktree import Worktree   # noqa: F401

--- a/alembic/versions/f2a3b4c5d6e7_add_project_todos.py
+++ b/alembic/versions/f2a3b4c5d6e7_add_project_todos.py
@@ -1,0 +1,44 @@
+"""add project todos
+
+Revision ID: f2a3b4c5d6e7
+Revises: a2628601782f
+Create Date: 2026-06-22 10:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "f2a3b4c5d6e7"
+# NOTE: rebased onto the current head. The user_skills migrations
+# (a70ee5479e2e → a2628601782f) landed after this branch was first cut, so this
+# must chain off a2628601782f — otherwise two heads and `upgrade head` fails.
+down_revision = "a2628601782f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "project_todos",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("project_id", sa.Integer(), sa.ForeignKey("projects.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("prompt", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="open"),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+        # Soft provenance link to the spawned task (no FK; SQLite FKs are off).
+        sa.Column("created_task_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+    )
+    op.create_index("ix_project_todos_project_id", "project_todos", ["project_id"])
+    op.create_index(
+        "ix_project_todos_project_status_sort",
+        "project_todos",
+        ["project_id", "status", "sort_order"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_project_todos_project_status_sort", table_name="project_todos")
+    op.drop_index("ix_project_todos_project_id", table_name="project_todos")
+    op.drop_table("project_todos")

--- a/backend/api/project_todos.py
+++ b/backend/api/project_todos.py
@@ -1,0 +1,120 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.database import get_db
+from backend.models.project import Project
+from backend.models.project_todo import ProjectTodo
+from backend.schemas.project_todo import ProjectTodoCreate, ProjectTodoResponse, ProjectTodoUpdate
+
+router = APIRouter(prefix="/api/projects/{project_id}/todos", tags=["project-todos"])
+
+
+async def _require_project(project_id: int, db: AsyncSession) -> Project:
+    project = await db.get(Project, project_id)
+    if not project:
+        raise HTTPException(404, "Project not found")
+    return project
+
+
+async def _require_todo(project_id: int, todo_id: int, db: AsyncSession) -> ProjectTodo:
+    result = await db.execute(
+        select(ProjectTodo).where(ProjectTodo.id == todo_id, ProjectTodo.project_id == project_id)
+    )
+    todo = result.scalar_one_or_none()
+    if not todo:
+        raise HTTPException(404, "Todo not found")
+    return todo
+
+
+@router.get("", response_model=list[ProjectTodoResponse])
+async def list_project_todos(
+    project_id: int,
+    include_archived: bool = False,
+    db: AsyncSession = Depends(get_db),
+):
+    await _require_project(project_id, db)
+    stmt = select(ProjectTodo).where(ProjectTodo.project_id == project_id)
+    if not include_archived:
+        stmt = stmt.where(ProjectTodo.status != "archived")
+    result = await db.execute(
+        stmt.order_by(desc(ProjectTodo.sort_order), desc(ProjectTodo.id))
+    )
+    return list(result.scalars().all())
+
+
+@router.post("", response_model=ProjectTodoResponse, status_code=201)
+async def create_project_todo(
+    project_id: int,
+    body: ProjectTodoCreate,
+    db: AsyncSession = Depends(get_db),
+):
+    await _require_project(project_id, db)
+    title = body.title.strip()
+    prompt = body.prompt.strip()
+    if not title or not prompt:
+        raise HTTPException(400, "Title and prompt are required")
+
+    # New todos go to the top: one step above the current max sort_order.
+    max_sort_order = await db.scalar(
+        select(func.coalesce(func.max(ProjectTodo.sort_order), 0)).where(ProjectTodo.project_id == project_id)
+    )
+    todo = ProjectTodo(
+        project_id=project_id,
+        title=title,
+        prompt=prompt,
+        status="open",
+        sort_order=(max_sort_order or 0) + 100,
+    )
+    db.add(todo)
+    await db.commit()
+    await db.refresh(todo)
+    return todo
+
+
+@router.patch("/{todo_id}", response_model=ProjectTodoResponse)
+async def update_project_todo(
+    project_id: int,
+    todo_id: int,
+    body: ProjectTodoUpdate,
+    db: AsyncSession = Depends(get_db),
+):
+    """Partial update. Also the canonical way to archive (status='archived')
+    or restore (status='open') — DELETE is reserved for permanent removal."""
+    todo = await _require_todo(project_id, todo_id, db)
+    updates = body.model_dump(exclude_unset=True)
+
+    if "title" in updates and updates["title"] is not None:
+        title = updates["title"].strip()
+        if not title:
+            raise HTTPException(400, "Title is required")
+        todo.title = title
+    if "prompt" in updates and updates["prompt"] is not None:
+        prompt = updates["prompt"].strip()
+        if not prompt:
+            raise HTTPException(400, "Prompt is required")
+        todo.prompt = prompt
+    if "status" in updates and updates["status"] is not None:
+        todo.status = updates["status"]
+    if "sort_order" in updates and updates["sort_order"] is not None:
+        todo.sort_order = updates["sort_order"]
+    if "created_task_id" in updates:
+        todo.created_task_id = updates["created_task_id"]
+    # updated_at is bumped automatically by the model's onupdate=_utcnow on flush.
+
+    await db.commit()
+    await db.refresh(todo)
+    return todo
+
+
+@router.delete("/{todo_id}")
+async def delete_project_todo(
+    project_id: int,
+    todo_id: int,
+    db: AsyncSession = Depends(get_db),
+):
+    """Permanently delete a todo. To hide without destroying, PATCH status='archived'."""
+    todo = await _require_todo(project_id, todo_id, db)
+    await db.delete(todo)
+    await db.commit()
+    return {"ok": True}

--- a/backend/api/projects.py
+++ b/backend/api/projects.py
@@ -5,12 +5,13 @@ import pathlib
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import select, update
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.config import settings
 from backend.database import get_db, async_session
 from backend.models.project import Project
+from backend.models.project_todo import ProjectTodo
 from backend.models.tag import Tag
 from backend.models.global_settings import GlobalSettings
 from backend.schemas.project import ProjectCreate, ProjectUpdate, ProjectResponse, ProjectReorderItem
@@ -155,6 +156,10 @@ async def delete_project(project_id: int, db: AsyncSession = Depends(get_db)):
     project = await db.get(Project, project_id)
     if not project:
         raise HTTPException(404, "Project not found")
+    # project_todos declares ON DELETE CASCADE, but SQLite does not enforce FKs
+    # (no `PRAGMA foreign_keys=ON` in database.py), so the DB won't cascade.
+    # Delete the todos explicitly so this works on SQLite too.
+    await db.execute(delete(ProjectTodo).where(ProjectTodo.project_id == project_id))
     await db.delete(project)
     await db.commit()
     return {"ok": True}

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,6 +21,7 @@ from backend.api.voice import router as voice_router
 from backend.api.auth import router as auth_router
 from backend.api.chat import router as chat_router
 from backend.api.projects import router as projects_router
+from backend.api.project_todos import router as project_todos_router
 from backend.api.settings import router as settings_router
 from backend.api.uploads import router as uploads_router
 from backend.api.secrets import router as secrets_router
@@ -313,6 +314,7 @@ app.include_router(voice_router)
 app.include_router(auth_router)
 app.include_router(chat_router)
 app.include_router(projects_router)
+app.include_router(project_todos_router)
 app.include_router(settings_router)
 app.include_router(dispatcher_router)
 app.include_router(uploads_router)

--- a/backend/models/project_todo.py
+++ b/backend/models/project_todo.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database import Base
+
+
+def _utcnow() -> datetime:
+    """Naive UTC now. Avoids the deprecated datetime.utcnow() while staying naive
+    like every other model's timestamps (so cross-model comparisons don't hit the
+    aware/naive TypeError)."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class ProjectTodo(Base):
+    __tablename__ = "project_todos"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    project_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    prompt: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="open", server_default="open")
+    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    # Provenance link: the task this todo spawned (via "Run"). Soft link (no FK
+    # constraint — SQLite doesn't enforce FKs here; see database.py). Enables a
+    # future "task completed → mark todo done" sync by looking up created_task_id.
+    created_task_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow, onupdate=_utcnow)

--- a/backend/schemas/project_todo.py
+++ b/backend/schemas/project_todo.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+ProjectTodoStatus = Literal["open", "done", "archived"]
+
+
+class ProjectTodoCreate(BaseModel):
+    title: str = Field(min_length=1, max_length=200)
+    prompt: str = Field(min_length=1)
+
+
+class ProjectTodoUpdate(BaseModel):
+    title: str | None = Field(default=None, min_length=1, max_length=200)
+    prompt: str | None = Field(default=None, min_length=1)
+    status: ProjectTodoStatus | None = None
+    sort_order: int | None = None
+    created_task_id: int | None = None
+
+
+class ProjectTodoResponse(BaseModel):
+    id: int
+    project_id: int
+    title: str
+    prompt: str
+    status: ProjectTodoStatus
+    sort_order: int
+    created_task_id: int | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -13,6 +13,7 @@ from backend.database import Base
 import backend.models.task  # noqa: F401
 import backend.models.instance  # noqa: F401
 import backend.models.project  # noqa: F401
+import backend.models.project_todo  # noqa: F401
 import backend.models.log_entry  # noqa: F401
 import backend.models.worktree  # noqa: F401
 import backend.models.global_settings  # noqa: F401

--- a/backend/tests/test_alembic_migrations.py
+++ b/backend/tests/test_alembic_migrations.py
@@ -20,6 +20,7 @@ from backend.database import Base
 import backend.models.task  # noqa: F401
 import backend.models.instance  # noqa: F401
 import backend.models.project  # noqa: F401
+import backend.models.project_todo  # noqa: F401
 import backend.models.log_entry  # noqa: F401
 import backend.models.worktree  # noqa: F401
 import backend.models.global_settings  # noqa: F401
@@ -273,7 +274,7 @@ class TestFreshMigration:
 
         engine = create_engine(f"sqlite:///{db_path}")
         tables = _get_all_tables(engine)
-        expected_tables = {"instances", "projects", "tasks", "log_entries", "worktrees", "global_settings", "secrets", "tags", "discussions", "discussion_messages", "discussion_agents", "discussion_events", "quick_phrases", "sub_agent_sessions", "sub_agent_reports", "pr_reviews", "monitored_repos", "workers", "skill_lessons", "skill_usage", "feishu_user_binding", "org_members", "org_teams", "org_team_members", "task_shares", "project_shares", "shared_tasks_received", "user_skills"}
+        expected_tables = {"instances", "projects", "project_todos", "tasks", "log_entries", "worktrees", "global_settings", "secrets", "tags", "discussions", "discussion_messages", "discussion_agents", "discussion_events", "quick_phrases", "sub_agent_sessions", "sub_agent_reports", "pr_reviews", "monitored_repos", "workers", "skill_lessons", "skill_usage", "feishu_user_binding", "org_members", "org_teams", "org_team_members", "task_shares", "project_shares", "shared_tasks_received", "user_skills"}
         assert tables == expected_tables, f"Missing tables: {expected_tables - tables}"
 
         # Verify all columns from latest migration exist

--- a/backend/tests/test_api_project_todos.py
+++ b/backend/tests/test_api_project_todos.py
@@ -1,0 +1,117 @@
+"""Tests for project todo API endpoints."""
+import pytest
+import pytest_asyncio
+from sqlalchemy import func, select
+
+from backend.models.project import Project
+from backend.models.project_todo import ProjectTodo
+
+
+@pytest_asyncio.fixture
+async def project_id(session_factory):
+    async with session_factory() as session:
+        project = Project(name="todo-proj", has_remote=False, status="ready")
+        session.add(project)
+        await session.commit()
+        await session.refresh(project)
+        return project.id
+
+
+@pytest.mark.asyncio
+async def test_project_todo_lifecycle(client, project_id):
+    resp = await client.get(f"/api/projects/{project_id}/todos")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+    resp = await client.post(
+        f"/api/projects/{project_id}/todos",
+        json={"title": "  Refactor auth  ", "prompt": "  Inspect auth module first.  "},
+    )
+    assert resp.status_code == 201
+    todo = resp.json()
+    assert todo["title"] == "Refactor auth"
+    assert todo["prompt"] == "Inspect auth module first."
+    assert todo["status"] == "open"
+    assert todo["sort_order"] == 100
+
+    resp = await client.patch(
+        f"/api/projects/{project_id}/todos/{todo['id']}",
+        json={"title": "Refactor auth plan", "prompt": "Write a plan.", "status": "done", "created_task_id": 42},
+    )
+    assert resp.status_code == 200
+    updated = resp.json()
+    assert updated["title"] == "Refactor auth plan"
+    assert updated["prompt"] == "Write a plan."
+    assert updated["status"] == "done"
+    assert updated["created_task_id"] == 42
+
+    # Archiving is a soft hide via PATCH (not DELETE).
+    resp = await client.patch(
+        f"/api/projects/{project_id}/todos/{todo['id']}",
+        json={"status": "archived"},
+    )
+    assert resp.status_code == 200
+
+    resp = await client.get(f"/api/projects/{project_id}/todos")
+    assert resp.status_code == 200
+    assert resp.json() == []  # archived hidden by default
+
+    resp = await client.get(f"/api/projects/{project_id}/todos?include_archived=true")
+    assert resp.status_code == 200
+    archived = resp.json()
+    assert len(archived) == 1
+    assert archived[0]["status"] == "archived"
+
+    # DELETE permanently removes the todo, even from the archived view.
+    resp = await client.delete(f"/api/projects/{project_id}/todos/{todo['id']}")
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+    resp = await client.get(f"/api/projects/{project_id}/todos?include_archived=true")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_project_todo_rejects_blank_fields(client, project_id):
+    resp = await client.post(
+        f"/api/projects/{project_id}/todos",
+        json={"title": "   ", "prompt": "Do work"},
+    )
+    assert resp.status_code == 400
+
+    resp = await client.post(
+        f"/api/projects/{project_id}/todos",
+        json={"title": "Do work", "prompt": "   "},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_project_todos_require_existing_project(client):
+    resp = await client.get("/api/projects/9999/todos")
+    assert resp.status_code == 404
+
+    resp = await client.post(
+        "/api/projects/9999/todos",
+        json={"title": "Missing", "prompt": "Missing project"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_project_removes_project_todos(client, project_id, session_factory):
+    resp = await client.post(
+        f"/api/projects/{project_id}/todos",
+        json={"title": "Clean up", "prompt": "Remove with project"},
+    )
+    assert resp.status_code == 201
+
+    resp = await client.delete(f"/api/projects/{project_id}")
+    assert resp.status_code == 200
+
+    async with session_factory() as session:
+        count = await session.scalar(
+            select(func.count()).select_from(ProjectTodo).where(ProjectTodo.project_id == project_id)
+        )
+    assert count == 0

--- a/docs/plans/project-todo-design.md
+++ b/docs/plans/project-todo-design.md
@@ -1,0 +1,139 @@
+# Project Todo List 设计方案（定稿）
+
+> 本文档为 PR #30 的定稿设计，已纳入 code review（youchengsong）意见与实现期的取舍。
+
+## 概述
+
+每个 Project 维护一个 Todo List，用来管理待执行的任务 prompt。Todo 可以一键创建 Task 并跳转到 Chat，创建成功后该 Todo 自动标记为 done 并记录它派生的 task。参数全部使用系统默认值，创建后可在 Task 详情里修改。
+
+## 数据模型
+
+### 新增表：`project_todos`
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | INTEGER PK | 自增主键 |
+| project_id | INTEGER FK | 关联 projects(id)，ON DELETE CASCADE（见下方级联说明） |
+| title | VARCHAR(200) NOT NULL | 标题 |
+| prompt | TEXT NOT NULL | 任务 prompt |
+| status | VARCHAR(20) DEFAULT 'open' | open / done / archived |
+| sort_order | INTEGER DEFAULT 0 | 排序，新建置顶（值越大越靠前） |
+| created_task_id | INTEGER NULL | **软关联**：本 Todo 通过 "Run" 派生出的 task id（无 FK 约束） |
+| created_at | DATETIME | 创建时间（naive UTC，非弃用的 datetime.now(timezone.utc) 去 tzinfo，与其它模型一致） |
+| updated_at | DATETIME | 更新时间 |
+
+索引：`(project_id)` + `(project_id, status, sort_order)`
+
+**状态含义与流转**：
+- `open`（待处理，默认）
+- `done`（完成）—— 手动勾选，或从 Todo 创建 Task 后自动置为 done
+- `archived`（归档，默认隐藏）
+
+允许的流转（均通过 `PATCH status`）：
+```
+open ⇄ done          （勾选 / 取消勾选）
+open/done → archived  （归档按钮）
+archived → open       （恢复按钮）
+任意 → 永久删除        （DELETE，不可恢复）
+```
+
+### `created_task_id` 为什么是软关联
+
+不在 `tasks` 表加列、也不加数据库 FK 约束：
+1. SQLite 未启用 FK（`database.py` 无 `PRAGMA foreign_keys=ON`），FK 约束在本项目里本就不生效；
+2. 避免对高频写入的 `tasks` 表做 ALTER；
+3. `created_task_id` 只是 provenance（溯源），悬空无害。
+
+它取代了「靠 title 匹配 completed task」的脆弱方案：未来做「task 完成 → 提示/自动标记对应 Todo done」时，直接按 `created_task_id` 反查即可，稳定可靠。
+
+## API
+
+```
+GET    /api/projects/{project_id}/todos?include_archived=false   列出 todos
+POST   /api/projects/{project_id}/todos                          新建 todo
+PATCH  /api/projects/{project_id}/todos/{id}                     部分更新（含归档/恢复/排序/关联 task）
+DELETE /api/projects/{project_id}/todos/{id}                     永久删除
+```
+
+**语义修正（review #1）**：`DELETE` 是**真删除**（`db.delete`），不再是"软删=归档"的语义欺骗。归档改由 `PATCH {"status":"archived"}` 表达，恢复由 `PATCH {"status":"open"}`。
+
+`PATCH` 支持部分更新，可传字段：`title` / `prompt` / `status` / `sort_order` / `created_task_id`（只更新传入的字段）。
+
+排序：列表按 `sort_order DESC, id DESC`。新建时 `sort_order = max(project 内现有 sort_order) + 100`（置顶）。
+
+## 从 Todo 创建 Task 的流程
+
+不新增专用端点，前端直接调用现有 `POST /api/tasks`：
+
+```
+用户点 Todo 的 "▶ Run" → 弹窗可改 title/prompt → 提交
+  → POST /api/tasks { title, description: prompt, project_id }
+      （target_repo 可选，dispatcher 会用 project_id 自动解析，不会 400）
+      （provider/model/effort/mode 等走 create_task 默认逻辑）
+  → 成功后 best-effort: PATCH todo { status:'done', created_task_id: task.id }
+      （失败不阻断跳转——task 已建成，溯源是 nice-to-have）
+  → 跳转 #/tasks/chat/{task.id}
+```
+
+**幂等（review #4 + 设计闭环）**：创建成功后 Todo 自动置为 `done` 并移出 open 列表，天然避免重复 Run；提交期间弹窗按钮禁用。
+
+## 前端设计
+
+### UI 位置
+
+Todo List 放在 ProjectsPage 每个 Project card 内部，**可折叠**。头部有 open 计数徽标、"Show archived" 切换（有归档项时出现）、"+ Add"。
+
+### 列表项
+
+- 未完成/完成项：勾选圈（open/done）+ title（done 显示删除线）+ prompt 两行预览 + 操作按钮（▶ Run / ✎ Edit / ⌸ Archive）
+- 归档项（仅 "Show archived" 打开时可见）：紧凑一行 + `archived` 标签 + ↺ Restore + 🗑 Delete permanently（review 提出的归档死胡同修复）
+
+### 弹窗（TodoModal）
+
+- 新建 / 从 Todo 创建 Task 共用
+- Title + Prompt 两个输入
+- **Esc 关闭 + 点背景关闭**（review #7），点内容区不关闭（stopPropagation）
+
+### 主题（review #5）
+
+组件全部使用 PR #29 的语义 token 类（`bg-surface` / `text-muted` / `border-border` / `bg-input` / `text-subtle` / `focus:border-focus` / `bg-accent` 等），不用硬编码 `gray-*`。因此本 PR **栈在 #29 之上，应在 #29 之后合并**。
+
+## 级联删除（review #6）
+
+`project_todos.project_id` 声明了 `ON DELETE CASCADE`，但 SQLite 未启用 FK 约束，DB 不会自动级联。故 `projects.py` 删除 project 时**显式删除**其 todos（代码处有注释说明）。此手动删除是必须的，不能因为"已有 CASCADE 声明"而移除。
+
+## 文件
+
+### 新增
+| 文件 | 说明 |
+|------|------|
+| `backend/models/project_todo.py` | ProjectTodo 模型（时区感知时间戳） |
+| `backend/schemas/project_todo.py` | Todo CRUD schema |
+| `backend/api/project_todos.py` | Todo CRUD API |
+| `alembic/versions/f2a3b4c5d6e7_add_project_todos.py` | 建表 migration |
+| `frontend/src/components/Projects/ProjectTodoList.tsx` | Todo 列表组件 |
+
+### 修改
+| 文件 | 说明 |
+|------|------|
+| `backend/main.py` | 注册 todo router |
+| `backend/api/projects.py` | 删除 project 时级联删 todos |
+| `alembic/env.py` | 导入 ProjectTodo 模型 |
+| `frontend/src/api/client.ts` | Todo API 方法 + 类型 |
+| `frontend/src/pages/ProjectsPage.tsx` | 在 project card 中嵌入 ProjectTodoList |
+
+### 不改
+- `tasks` 表 / Task 模型 —— 不加 `source_todo_id`（改为在 `project_todos` 侧记 `created_task_id`）
+- `TaskCreate` schema —— 无需额外字段
+- 现有 Task 创建逻辑 —— 完全复用
+
+## Alembic（review #10）
+
+`f2a3b4c5d6e7.down_revision` 必须指向当前 head `a2628601782f`（user_skills 系列迁移之后）。最初分支基于旧 base 时写的是 `e7f8a9b0c1d2`，rebase 到最新 main 后会与 `a70ee5479e2e` 同父 → 两个 head → `upgrade head` 失败。已修正。
+
+## 后续可扩展（不在本 PR）
+
+- 「task 完成 → 自动提示/标记对应 Todo done」（用 `created_task_id` 反查，已备好数据基础）
+- 拖拽排序 + batch reorder API（`sort_order` 已可通过 PATCH 调整）
+- Todo 级别的 provider/model/mode 配置
+- 负责人（Team CCM 集成）、标签、批量操作

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,11 +68,12 @@ function updateHash(page: string, chatTaskId: number | null) {
 
 function App() {
   const initial = parseHash();
+  const initialNeedsServerConfig = isCapacitor() && !getServerUrl();
   const [page, setPage] = useState(initial.page);
   const [chatTaskId, setChatTaskId] = useState<number | null>(initial.chatTaskId);
   const [authenticated, setAuthenticated] = useState(false);
-  const [checking, setChecking] = useState(true);
-  const [needsServerConfig, setNeedsServerConfig] = useState(false);
+  const [checking, setChecking] = useState(!initialNeedsServerConfig);
+  const [needsServerConfig, setNeedsServerConfig] = useState(initialNeedsServerConfig);
 
   useEffect(() => {
     updateHash(page, chatTaskId);
@@ -94,12 +95,7 @@ function App() {
   };
 
   useEffect(() => {
-    // In Capacitor, require server URL to be configured first
-    if (isCapacitor() && !getServerUrl()) {
-      setNeedsServerConfig(true);
-      setChecking(false);
-      return;
-    }
+    if (needsServerConfig) return;
 
     const base = getApiBase();
     // Check if auth is required
@@ -124,7 +120,7 @@ function App() {
         // Server down, show login anyway
       })
       .finally(() => setChecking(false));
-  }, []);
+  }, [needsServerConfig]);
 
   if (needsServerConfig) {
     return (
@@ -137,8 +133,8 @@ function App() {
 
   if (checking) {
     return (
-      <div className="min-h-screen bg-gray-950 flex items-center justify-center">
-        <p className="text-gray-400">Connecting...</p>
+      <div className="min-h-screen bg-app flex items-center justify-center">
+        <p className="text-subtle">Connecting...</p>
       </div>
     );
   }
@@ -149,7 +145,7 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <div className="min-h-screen bg-gray-900 text-foreground flex flex-col overflow-x-clip">
+      <div className="min-h-screen bg-app text-foreground flex flex-col overflow-x-clip">
         <Header currentPage={page} onNavigate={handleNavigate} />
         <main className={`flex-1 mx-auto w-full p-4 ${page === 'tasks' && chatTaskId ? 'max-w-[1400px]' : 'max-w-6xl'}`}>
           {page === 'dashboard' && <Dashboard />}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -76,6 +76,20 @@ export interface Project {
   created_at: string;
 }
 
+export type ProjectTodoStatus = 'open' | 'done' | 'archived';
+
+export interface ProjectTodo {
+  id: number;
+  project_id: number;
+  title: string;
+  prompt: string;
+  status: ProjectTodoStatus;
+  sort_order: number;
+  created_task_id: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface Task {
   id: number;
   worker_id: number | null;
@@ -549,6 +563,14 @@ export const api = {
     request<{ ok: boolean }>(`/api/projects/${id}`, { method: 'DELETE' }),
   recloneProject: (id: number) =>
     request<{ ok: boolean }>(`/api/projects/${id}/reclone`, { method: 'POST' }),
+  listProjectTodos: (projectId: number, includeArchived = false) =>
+    request<ProjectTodo[]>(`/api/projects/${projectId}/todos${includeArchived ? '?include_archived=true' : ''}`),
+  createProjectTodo: (projectId: number, data: { title: string; prompt: string }) =>
+    request<ProjectTodo>(`/api/projects/${projectId}/todos`, { method: 'POST', body: JSON.stringify(data) }),
+  updateProjectTodo: (projectId: number, todoId: number, data: Partial<Pick<ProjectTodo, 'title' | 'prompt' | 'status' | 'sort_order' | 'created_task_id'>>) =>
+    request<ProjectTodo>(`/api/projects/${projectId}/todos/${todoId}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  deleteProjectTodo: (projectId: number, todoId: number) =>
+    request<{ ok: boolean }>(`/api/projects/${projectId}/todos/${todoId}`, { method: 'DELETE' }),
 
   // Env files
   listEnvFiles: (projectId: number) =>

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -111,7 +111,7 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
   }, []);
 
   return (
-    <header className="bg-gray-900 border-b border-gray-700 px-4 py-2 pt-[max(0.5rem,env(safe-area-inset-top))]">
+    <header className="bg-chrome border-b border-chrome-border px-4 py-2 pt-[max(0.5rem,env(safe-area-inset-top))]">
       <div ref={rowRef} className="relative flex items-center gap-3">
         <h1 ref={titleRef} className="text-base font-bold text-foreground whitespace-nowrap shrink-0">Claude Manager</h1>
         {/* 隐藏测量 nav：始终渲染完整按钮以计算所需宽度 */}
@@ -131,8 +131,8 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
                 onClick={() => onNavigate(p.key)}
                 className={`px-3 py-1.5 min-h-[36px] rounded text-sm font-medium whitespace-nowrap transition-colors ${
                   currentPage === p.key
-                    ? 'bg-indigo-600 text-white'
-                    : 'text-gray-300 hover:bg-gray-800'
+                    ? 'bg-accent text-accent-foreground'
+                    : 'text-muted hover:text-foreground hover:bg-surface-hover'
                 }`}
               >
                 {p.label}
@@ -145,7 +145,7 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
           <PoolDrawer />
           {runtime && (
             <div
-              className="flex items-center gap-1.5 mr-1 px-2 py-1 rounded bg-gray-800 border border-gray-700"
+              className="flex items-center gap-1.5 mr-1 px-2 py-1 rounded bg-surface border border-border"
               title={
                 !runtime.pty_available
                   ? 'claude_pty 未安装，PTY 模式不可用'
@@ -154,14 +154,14 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
                     : 'PTY 常驻会话模式：关（使用 claude -p 一次性进程）'
               }
             >
-              <span className={`text-xs font-medium ${runtime.use_pty_mode ? 'text-green-400' : 'text-gray-400'}`}>
+              <span className={`text-xs font-medium ${runtime.use_pty_mode ? 'text-success' : 'text-subtle'}`}>
                 PTY
               </span>
               <button
                 onClick={togglePtyMode}
                 disabled={!runtime.pty_available || switching}
                 className={`relative inline-flex h-4 w-8 items-center rounded-full transition-colors disabled:opacity-50 ${
-                  runtime.use_pty_mode ? 'bg-green-500' : 'bg-gray-600'
+                  runtime.use_pty_mode ? 'bg-success' : 'bg-input-border'
                 }`}
               >
                 <span
@@ -176,19 +176,19 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
           <div className="relative shrink-0" ref={prefsRef}>
             <button
               onClick={() => setPrefsOpen(!prefsOpen)}
-              className={`p-2 rounded transition-colors ${prefsOpen ? 'text-foreground bg-gray-800' : 'text-gray-400 hover:text-foreground hover:bg-gray-800'}`}
+              className={`p-2 rounded transition-colors ${prefsOpen ? 'text-foreground bg-surface' : 'text-subtle hover:text-foreground hover:bg-surface'}`}
               title="偏好设置（时区 / 主题）"
             >
               <Settings size={18} />
             </button>
             {prefsOpen && (
-              <div className="absolute top-full right-0 mt-1 bg-gray-800 border border-gray-600 rounded-lg shadow-lg z-30 p-3 min-w-[210px] space-y-3">
+              <div className="absolute top-full right-0 mt-1 bg-surface border border-input-border rounded-lg shadow-lg z-30 p-3 min-w-[210px] space-y-3">
                 <div className="flex items-center justify-between gap-3">
-                  <span className="text-xs text-gray-400 flex items-center gap-1.5"><Globe size={13} /> 时区</span>
+                  <span className="text-xs text-subtle flex items-center gap-1.5"><Globe size={13} /> 时区</span>
                   <select
                     value={tz}
                     onChange={(e) => { setTimezone(e.target.value); setTz(e.target.value); }}
-                    className="bg-gray-700 text-gray-200 text-xs rounded px-2 py-1 border border-gray-600 focus:outline-none focus:ring-1 focus:ring-indigo-500 cursor-pointer"
+                    className="bg-input text-muted text-xs rounded px-2 py-1 border border-input-border focus:outline-none focus:ring-1 focus:ring-focus cursor-pointer"
                   >
                     {TIMEZONE_OPTIONS.map((opt) => (
                       <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -196,11 +196,11 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
                   </select>
                 </div>
                 <div className="flex items-center justify-between gap-3">
-                  <span className="text-xs text-gray-400 flex items-center gap-1.5"><Palette size={13} /> 主题</span>
+                  <span className="text-xs text-subtle flex items-center gap-1.5"><Palette size={13} /> 主题</span>
                   <select
                     value={theme}
                     onChange={(e) => handleThemeChange(e.target.value as Theme)}
-                    className="bg-gray-700 text-gray-200 text-xs rounded px-2 py-1 border border-gray-600 focus:outline-none focus:ring-1 focus:ring-indigo-500 cursor-pointer"
+                    className="bg-input text-muted text-xs rounded px-2 py-1 border border-input-border focus:outline-none focus:ring-1 focus:ring-focus cursor-pointer"
                   >
                     {THEME_OPTIONS.map((opt) => (
                       <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -209,12 +209,12 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
                 </div>
                 {runtime && (
                   <div className="flex items-center justify-between gap-3">
-                    <span className="text-xs text-gray-400">访问置顶</span>
+                    <span className="text-xs text-subtle">访问置顶</span>
                     <button
                       onClick={toggleAutoSort}
                       disabled={switching}
                       className={`relative inline-flex h-4 w-8 items-center rounded-full transition-colors disabled:opacity-50 ${
-                        runtime.auto_sort_on_access ? 'bg-green-500' : 'bg-gray-600'
+                        runtime.auto_sort_on_access ? 'bg-success' : 'bg-input-border'
                       }`}
                       title={runtime.auto_sort_on_access ? '开启：打开聊天自动置顶任务' : '关闭：打开聊天不改变排序'}
                     >
@@ -227,22 +227,22 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
                   </div>
                 )}
                 {/* Feishu binding */}
-                <div className="border-t border-gray-700 pt-2 mt-1">
+                <div className="border-t border-border pt-2 mt-1">
                   <div className="flex items-center justify-between gap-3">
-                    <span className="text-xs text-gray-400">飞书</span>
+                    <span className="text-xs text-subtle">飞书</span>
                     {feishuStatus?.bound ? (
                       <div className="flex items-center gap-1.5">
                         {feishuStatus.avatar_url && <img src={feishuStatus.avatar_url} className="w-4 h-4 rounded-full" alt="" />}
-                        <span className="text-xs text-gray-300">{feishuStatus.name}</span>
+                        <span className="text-xs text-muted">{feishuStatus.name}</span>
                         <button
                           onClick={async () => { if (confirm('解绑飞书？')) { await api.unbindFeishu(); setFeishuStatus({ bound: false }); }}}
-                          className="text-xs text-red-400 hover:text-red-300 ml-1"
+                          className="text-xs text-danger hover:text-red-300 ml-1"
                         >解绑</button>
                       </div>
                     ) : feishuStatus !== null ? (
                       <button
                         onClick={async () => { const { url } = await api.getFeishuAuthUrl(); window.location.href = url; }}
-                        className="text-xs px-2 py-0.5 rounded bg-blue-600/20 text-blue-300 hover:bg-blue-600/30"
+                        className="text-xs px-2 py-0.5 rounded bg-accent-muted text-accent-muted-foreground hover:bg-accent hover:text-accent-foreground"
                       >绑定</button>
                     ) : null}
                   </div>
@@ -254,7 +254,7 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
           {collapsed && (
             <button
               onClick={() => setMenuOpen(!menuOpen)}
-              className="shrink-0 p-2 rounded text-gray-400 hover:text-foreground hover:bg-gray-800 transition-colors"
+              className="shrink-0 p-2 rounded text-subtle hover:text-foreground hover:bg-surface transition-colors"
             >
               {menuOpen ? <X size={18} /> : <Menu size={18} />}
             </button>
@@ -270,8 +270,8 @@ export function Header({ currentPage, onNavigate }: HeaderProps) {
               onClick={() => { onNavigate(p.key); setMenuOpen(false); }}
               className={`px-3 py-2 rounded text-sm font-medium text-left transition-colors ${
                 currentPage === p.key
-                  ? 'bg-indigo-600 text-white'
-                  : 'text-gray-300 hover:bg-gray-800'
+                  ? 'bg-accent text-accent-foreground'
+                  : 'text-muted hover:text-foreground hover:bg-surface-hover'
               }`}
             >
               {p.label}

--- a/frontend/src/components/Projects/ProjectTodoList.test.tsx
+++ b/frontend/src/components/Projects/ProjectTodoList.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ProjectTodoList } from './ProjectTodoList';
+
+vi.mock('../../api/client', () => ({
+  api: {
+    listProjectTodos: vi.fn(),
+    createProjectTodo: vi.fn(),
+    updateProjectTodo: vi.fn(),
+    deleteProjectTodo: vi.fn(),
+    createTask: vi.fn(),
+  },
+}));
+
+import { api } from '../../api/client';
+
+const todo = {
+  id: 5,
+  project_id: 7,
+  title: 'Refactor auth',
+  prompt: 'Inspect auth module first.',
+  status: 'open' as const,
+  sort_order: 100,
+  created_task_id: null,
+  created_at: '2026-06-22T00:00:00Z',
+  updated_at: '2026-06-22T00:00:00Z',
+};
+
+describe('ProjectTodoList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.listProjectTodos).mockResolvedValue([]);
+    vi.mocked(api.createProjectTodo).mockResolvedValue(todo);
+    vi.mocked(api.updateProjectTodo).mockResolvedValue({ ...todo, status: 'done' });
+    vi.mocked(api.deleteProjectTodo).mockResolvedValue({ ok: true });
+    vi.mocked(api.createTask).mockResolvedValue({ id: 42 } as Awaited<ReturnType<typeof api.createTask>>);
+    window.location.hash = '';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates a project todo from the add modal', async () => {
+    render(<ProjectTodoList projectId={7} />);
+
+    await userEvent.click(screen.getByTitle('Add todo'));
+    const dialog = screen.getByRole('dialog', { name: 'New todo' });
+    await userEvent.type(within(dialog).getByLabelText('Title'), 'Refactor auth');
+    await userEvent.type(within(dialog).getByLabelText('Prompt'), 'Inspect auth module first.');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Create todo' }));
+
+    await waitFor(() => {
+      expect(api.createProjectTodo).toHaveBeenCalledWith(7, {
+        title: 'Refactor auth',
+        prompt: 'Inspect auth module first.',
+      });
+    });
+  });
+
+  it('surfaces a submit error inside the modal (not hidden behind the overlay)', async () => {
+    vi.mocked(api.createProjectTodo).mockRejectedValue(new Error('Boom: server rejected'));
+    render(<ProjectTodoList projectId={7} />);
+
+    await userEvent.click(screen.getByTitle('Add todo'));
+    const dialog = screen.getByRole('dialog', { name: 'New todo' });
+    await userEvent.type(within(dialog).getByLabelText('Title'), 'X');
+    await userEvent.type(within(dialog).getByLabelText('Prompt'), 'Y');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Create todo' }));
+
+    // The modal stays open AND the error is visible within it.
+    await waitFor(() => {
+      expect(within(dialog).getByText(/Boom: server rejected/)).toBeInTheDocument();
+    });
+  });
+
+  it('creates a task from a todo after allowing prompt edits', async () => {
+    vi.mocked(api.listProjectTodos).mockResolvedValue([todo]);
+    render(<ProjectTodoList projectId={7} />);
+
+    await userEvent.click(screen.getByTitle('Expand todos'));
+    expect(await screen.findByText('Refactor auth')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTitle('Create task'));
+    const dialog = screen.getByRole('dialog', { name: 'Create task' });
+    const prompt = within(dialog).getByLabelText('Prompt');
+    await userEvent.clear(prompt);
+    await userEvent.type(prompt, 'Write a focused patch.');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Create task' }));
+
+    await waitFor(() => {
+      expect(api.createTask).toHaveBeenCalledWith({
+        title: 'Refactor auth',
+        description: 'Write a focused patch.',
+        project_id: 7,
+      });
+    });
+    // Closing the loop: the source todo is marked done + linked to the new task.
+    await waitFor(() => {
+      expect(api.updateProjectTodo).toHaveBeenCalledWith(7, 5, { status: 'done', created_task_id: 42 });
+    });
+    expect(window.location.hash).toBe('#/tasks/chat/42');
+  });
+
+  it('archives todos via a soft status update, not a hard delete', async () => {
+    vi.mocked(api.listProjectTodos).mockResolvedValue([todo]);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<ProjectTodoList projectId={7} />);
+
+    await userEvent.click(screen.getByTitle('Expand todos'));
+    expect(await screen.findByText('Refactor auth')).toBeInTheDocument();
+    await userEvent.click(screen.getByTitle('Archive todo'));
+
+    await waitFor(() => {
+      expect(api.updateProjectTodo).toHaveBeenCalledWith(7, 5, { status: 'archived' });
+      expect(screen.queryByText('Refactor auth')).not.toBeInTheDocument();
+    });
+    expect(api.deleteProjectTodo).not.toHaveBeenCalled();
+  });
+
+  it('reveals archived todos via the toggle even when none are loaded yet', async () => {
+    const archived = { ...todo, id: 9, title: 'Archived item', status: 'archived' as const };
+    // Default view (open/done) is empty; archived list returns the archived todo.
+    vi.mocked(api.listProjectTodos).mockImplementation(async (_projectId, includeArchived) =>
+      includeArchived ? [archived] : [],
+    );
+    render(<ProjectTodoList projectId={7} />);
+
+    await userEvent.click(screen.getByTitle('Expand todos'));
+    // The toggle must be reachable with zero archived todos loaded.
+    const toggle = await screen.findByTitle('Show archived todos');
+    await userEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(api.listProjectTodos).toHaveBeenCalledWith(7, true);
+      expect(screen.getByText('Archived item')).toBeInTheDocument();
+    });
+    // Archived rows expose Restore + Delete-permanently.
+    expect(screen.getByTitle('Restore todo')).toBeInTheDocument();
+    expect(screen.getByTitle('Delete permanently')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Projects/ProjectTodoList.tsx
+++ b/frontend/src/components/Projects/ProjectTodoList.tsx
@@ -1,0 +1,487 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { FormEvent } from 'react';
+import {
+  Archive,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Circle,
+  Pencil,
+  Play,
+  Plus,
+  RotateCcw,
+  Save,
+  Trash2,
+  X,
+} from 'lucide-react';
+import { api } from '../../api/client';
+import type { ProjectTodo } from '../../api/client';
+
+interface ProjectTodoListProps {
+  projectId: number;
+}
+
+interface TodoDraft {
+  title: string;
+  prompt: string;
+}
+
+const emptyDraft: TodoDraft = { title: '', prompt: '' };
+
+export function ProjectTodoList({ projectId }: ProjectTodoListProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [todos, setTodos] = useState<ProjectTodo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [showCreate, setShowCreate] = useState(false);
+  const [showArchived, setShowArchived] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [createDraft, setCreateDraft] = useState<TodoDraft>(emptyDraft);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editDraft, setEditDraft] = useState<TodoDraft>(emptyDraft);
+  const [taskTodo, setTaskTodo] = useState<ProjectTodo | null>(null);
+  const [taskDraft, setTaskDraft] = useState<TodoDraft>(emptyDraft);
+  const [saving, setSaving] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [updatingIds, setUpdatingIds] = useState<Set<number>>(() => new Set());
+
+  const openCount = useMemo(() => todos.filter((todo) => todo.status === 'open').length, [todos]);
+
+  // Track in-flight mutations per row. A single scalar would let one row's
+  // completion clear another row's busy flag mid-flight and allow double-submits.
+  const startBusy = (id: number) => setUpdatingIds((prev) => new Set(prev).add(id));
+  const endBusy = (id: number) =>
+    setUpdatingIds((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+
+  const loadTodos = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      setTodos(await api.listProjectTodos(projectId, showArchived));
+      setHasLoaded(true);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId, showArchived]);
+
+  useEffect(() => {
+    if (expanded) {
+      loadTodos();
+    }
+  }, [expanded, loadTodos]);
+
+  const openCreateModal = () => {
+    setError('');
+    setCreateDraft(emptyDraft);
+    setExpanded(true);
+    setShowCreate(true);
+  };
+
+  const createTodo = async (event: FormEvent) => {
+    event.preventDefault();
+    setSaving(true);
+    setError('');
+    try {
+      await api.createProjectTodo(projectId, createDraft);
+      setShowCreate(false);
+      setCreateDraft(emptyDraft);
+      await loadTodos();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const startEdit = (todo: ProjectTodo) => {
+    setEditingId(todo.id);
+    setEditDraft({ title: todo.title, prompt: todo.prompt });
+  };
+
+  const saveEdit = async (todoId: number) => {
+    startBusy(todoId);
+    setError('');
+    try {
+      const updated = await api.updateProjectTodo(projectId, todoId, editDraft);
+      setTodos((prev) => prev.map((todo) => (todo.id === todoId ? updated : todo)));
+      setEditingId(null);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      endBusy(todoId);
+    }
+  };
+
+  const setStatus = async (todo: ProjectTodo, status: ProjectTodo['status']) => {
+    startBusy(todo.id);
+    setError('');
+    try {
+      const updated = await api.updateProjectTodo(projectId, todo.id, { status });
+      // If the new status falls outside the current view, drop it; else update in place.
+      setTodos((prev) =>
+        status === 'archived' && !showArchived
+          ? prev.filter((item) => item.id !== todo.id)
+          : prev.map((item) => (item.id === todo.id ? updated : item)),
+      );
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      endBusy(todo.id);
+    }
+  };
+
+  const toggleDone = (todo: ProjectTodo) => setStatus(todo, todo.status === 'done' ? 'open' : 'done');
+
+  const archiveTodo = (todo: ProjectTodo) => {
+    if (!confirm('Archive this todo? You can restore it from "Show archived".')) return;
+    setStatus(todo, 'archived');
+  };
+
+  const restoreTodo = (todo: ProjectTodo) => setStatus(todo, 'open');
+
+  const deleteTodo = async (todo: ProjectTodo) => {
+    if (!confirm('Permanently delete this todo? This cannot be undone.')) return;
+    startBusy(todo.id);
+    setError('');
+    try {
+      await api.deleteProjectTodo(projectId, todo.id);
+      setTodos((prev) => prev.filter((item) => item.id !== todo.id));
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      endBusy(todo.id);
+    }
+  };
+
+  const openTaskModal = (todo: ProjectTodo) => {
+    setError('');
+    setTaskTodo(todo);
+    setTaskDraft({ title: todo.title, prompt: todo.prompt });
+  };
+
+  const createTask = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!taskTodo || running) return;
+    setRunning(true);
+    setError('');
+    try {
+      const task = await api.createTask({
+        title: taskDraft.title,
+        description: taskDraft.prompt,
+        project_id: projectId,
+      });
+      if (!task?.id) {
+        throw new Error('Task was created but returned no id');
+      }
+      // Close the loop: mark the source todo done and record which task it spawned.
+      // Best-effort — a failure here must not block navigating to the new chat.
+      try {
+        await api.updateProjectTodo(projectId, taskTodo.id, { status: 'done', created_task_id: task.id });
+      } catch {
+        /* ignore — the task was created; provenance is a nice-to-have */
+      }
+      window.location.hash = `#/tasks/chat/${task.id}`;
+    } catch (e) {
+      setError(String(e));
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="mt-3 border-t border-border pt-3">
+      <div className="flex items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          className="flex h-8 min-w-0 items-center gap-2 rounded px-2 text-sm text-muted hover:bg-surface-hover hover:text-foreground"
+          title={expanded ? 'Collapse todos' : 'Expand todos'}
+        >
+          {expanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+          <span className="font-medium">To-dos</span>
+          {hasLoaded && (
+            <span className="rounded bg-surface-hover px-1.5 py-0.5 text-xs text-muted">{openCount}</span>
+          )}
+        </button>
+        <div className="flex items-center gap-2">
+          {expanded && (
+            <button
+              type="button"
+              onClick={() => setShowArchived((value) => !value)}
+              className={`flex h-8 items-center gap-1.5 rounded px-2.5 text-xs ${
+                showArchived ? 'bg-surface-hover text-muted' : 'text-subtle hover:bg-surface-hover hover:text-muted'
+              }`}
+              title={showArchived ? 'Hide archived todos' : 'Show archived todos'}
+            >
+              <Archive size={13} /> {showArchived ? 'Hide archived' : 'Show archived'}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={openCreateModal}
+            className="flex h-8 items-center gap-1.5 rounded bg-input px-2.5 text-sm text-muted hover:bg-surface-hover hover:text-foreground"
+            title="Add todo"
+          >
+            <Plus size={14} /> Add
+          </button>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="mt-2 space-y-2">
+          {error && <div className="rounded bg-red-500/15 px-3 py-2 text-xs text-danger">{error}</div>}
+
+          {loading ? (
+            <div className="px-2 py-3 text-sm text-subtle">Loading...</div>
+          ) : todos.length === 0 ? (
+            !error && <div className="px-2 py-3 text-sm text-subtle">No to-dos.</div>
+          ) : (
+            <div className="space-y-1.5">
+              {todos.map((todo) => {
+                const isEditing = editingId === todo.id;
+                const isBusy = updatingIds.has(todo.id);
+
+                if (todo.status === 'archived') {
+                  return (
+                    <div
+                      key={todo.id}
+                      className="flex items-center gap-2 rounded border border-border bg-surface-raised/30 px-2.5 py-1.5"
+                    >
+                      <span className="min-w-0 flex-1 truncate text-xs text-subtle line-through">{todo.title}</span>
+                      <span className="shrink-0 rounded bg-surface-hover px-1.5 py-0.5 text-[10px] text-subtle">
+                        archived
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => restoreTodo(todo)}
+                        disabled={isBusy}
+                        className="h-7 w-7 rounded text-subtle hover:bg-surface-hover hover:text-info disabled:opacity-60"
+                        title="Restore todo"
+                      >
+                        <RotateCcw size={14} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => deleteTodo(todo)}
+                        disabled={isBusy}
+                        className="h-7 w-7 rounded text-subtle hover:bg-surface-hover hover:text-danger disabled:opacity-60"
+                        title="Delete permanently"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </div>
+                  );
+                }
+
+                return (
+                  <div key={todo.id} className="rounded border border-border bg-surface-raised/40 px-2.5 py-2">
+                    {isEditing ? (
+                      <div className="space-y-2">
+                        <input
+                          value={editDraft.title}
+                          onChange={(e) => setEditDraft((prev) => ({ ...prev, title: e.target.value }))}
+                          className="w-full rounded border border-input-border bg-input px-2 py-1.5 text-sm text-foreground outline-none focus:border-focus"
+                          placeholder="Title"
+                        />
+                        <textarea
+                          value={editDraft.prompt}
+                          onChange={(e) => setEditDraft((prev) => ({ ...prev, prompt: e.target.value }))}
+                          className="min-h-24 w-full resize-y rounded border border-input-border bg-input px-2 py-1.5 text-sm text-foreground outline-none focus:border-focus"
+                          placeholder="Prompt"
+                        />
+                        <div className="flex justify-end gap-2">
+                          <button
+                            type="button"
+                            onClick={() => setEditingId(null)}
+                            className="flex h-8 items-center gap-1.5 rounded px-2.5 text-sm text-muted hover:bg-surface-hover"
+                          >
+                            <X size={14} /> Cancel
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => saveEdit(todo.id)}
+                            disabled={isBusy}
+                            className="flex h-8 items-center gap-1.5 rounded bg-accent px-2.5 text-sm text-accent-foreground hover:bg-accent-hover disabled:opacity-60"
+                          >
+                            <Save size={14} /> Save
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex items-start gap-2">
+                        <button
+                          type="button"
+                          onClick={() => toggleDone(todo)}
+                          disabled={isBusy}
+                          className="mt-0.5 h-7 w-7 shrink-0 rounded text-subtle hover:bg-surface-hover hover:text-success disabled:opacity-60"
+                          title={todo.status === 'done' ? 'Mark open' : 'Mark done'}
+                        >
+                          {todo.status === 'done' ? <CheckCircle2 size={17} /> : <Circle size={17} />}
+                        </button>
+                        <div className="min-w-0 flex-1">
+                          <div className={`truncate text-sm font-medium ${todo.status === 'done' ? 'text-subtle line-through' : 'text-foreground'}`}>
+                            {todo.title}
+                          </div>
+                          <div className="mt-0.5 line-clamp-2 whitespace-pre-wrap text-xs text-subtle">{todo.prompt}</div>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-1">
+                          <button
+                            type="button"
+                            onClick={() => openTaskModal(todo)}
+                            className="h-8 w-8 rounded text-subtle hover:bg-surface-hover hover:text-success"
+                            title={todo.created_task_id ? 'Run again (already spawned a task)' : 'Create task'}
+                          >
+                            <Play size={15} />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => startEdit(todo)}
+                            className="h-8 w-8 rounded text-subtle hover:bg-surface-hover hover:text-info"
+                            title="Edit todo"
+                          >
+                            <Pencil size={15} />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => archiveTodo(todo)}
+                            disabled={isBusy}
+                            className="h-8 w-8 rounded text-subtle hover:bg-surface-hover hover:text-warning disabled:opacity-60"
+                            title="Archive todo"
+                          >
+                            <Archive size={15} />
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {showCreate && (
+        <TodoModal
+          title="New todo"
+          draft={createDraft}
+          setDraft={setCreateDraft}
+          submitLabel="Create todo"
+          saving={saving}
+          error={error}
+          onClose={() => setShowCreate(false)}
+          onSubmit={createTodo}
+        />
+      )}
+
+      {taskTodo && (
+        <TodoModal
+          title="Create task"
+          draft={taskDraft}
+          setDraft={setTaskDraft}
+          submitLabel="Create task"
+          saving={running}
+          error={error}
+          onClose={() => setTaskTodo(null)}
+          onSubmit={createTask}
+        />
+      )}
+    </div>
+  );
+}
+
+function TodoModal({
+  title,
+  draft,
+  setDraft,
+  submitLabel,
+  saving,
+  error,
+  onClose,
+  onSubmit,
+}: {
+  title: string;
+  draft: TodoDraft;
+  setDraft: (draft: TodoDraft) => void;
+  submitLabel: string;
+  saving: boolean;
+  error?: string;
+  onClose: () => void;
+  onSubmit: (event: FormEvent) => void;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={onClose}
+    >
+      <form
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onSubmit={onSubmit}
+        onClick={(e) => e.stopPropagation()}
+        className="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl bg-surface shadow-2xl"
+      >
+        <div className="flex items-center justify-between border-b border-border px-5 py-4">
+          <h3 className="font-semibold text-foreground">{title}</h3>
+          <button type="button" onClick={onClose} className="text-subtle hover:text-foreground">
+            <X size={18} />
+          </button>
+        </div>
+        <div className="space-y-4 overflow-y-auto p-5">
+          <label className="block space-y-1.5">
+            <span className="text-sm text-muted">Title</span>
+            <input
+              value={draft.title}
+              onChange={(e) => setDraft({ ...draft, title: e.target.value })}
+              className="w-full rounded border border-input-border bg-input px-3 py-2 text-sm text-foreground outline-none focus:border-focus"
+              autoFocus
+              required
+            />
+          </label>
+          <label className="block space-y-1.5">
+            <span className="text-sm text-muted">Prompt</span>
+            <textarea
+              value={draft.prompt}
+              onChange={(e) => setDraft({ ...draft, prompt: e.target.value })}
+              className="min-h-44 w-full resize-y rounded border border-input-border bg-input px-3 py-2 text-sm text-foreground outline-none focus:border-focus"
+              required
+            />
+          </label>
+          {error && (
+            <div className="rounded bg-red-500/15 px-3 py-2 text-xs text-danger">{error}</div>
+          )}
+        </div>
+        <div className="flex justify-end gap-2 border-t border-border px-5 py-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded px-3 py-2 text-sm text-muted hover:bg-surface-hover"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={saving}
+            className="rounded bg-accent px-3 py-2 text-sm text-accent-foreground hover:bg-accent-hover disabled:opacity-60"
+          >
+            {saving ? 'Saving...' : submitLabel}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/Tasks/TaskForm.tsx
+++ b/frontend/src/components/Tasks/TaskForm.tsx
@@ -314,8 +314,8 @@ export function TaskForm({ onCreated }: TaskFormProps) {
   };
 
   return (
-    <form ref={formRef} onSubmit={handleSubmit} className="bg-gray-800 rounded-lg p-4 space-y-3 overflow-visible">
-      <h3 className="text-sm font-semibold text-gray-300">New Task</h3>
+    <form ref={formRef} onSubmit={handleSubmit} className="bg-surface rounded-lg p-4 space-y-3 overflow-visible">
+      <h3 className="text-sm font-semibold text-muted">New Task</h3>
       {dropError && (
         <div className="bg-yellow-900/50 border border-yellow-700 text-yellow-300 text-xs rounded px-3 py-2 flex items-center justify-between">
           <span>{dropError}</span>
@@ -334,7 +334,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
       )}
       <div className="flex gap-2">
         <textarea
-          className="flex-1 bg-gray-700 text-foreground rounded px-3 py-2 text-sm h-24 resize-none focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          className="flex-1 bg-input text-foreground rounded px-3 py-2 text-sm h-24 resize-none focus:outline-none focus:ring-2 focus:ring-focus"
           placeholder={mode === 'loop' ? 'Background / context (optional)' : `Prompt / Description (this will be sent to ${provider === 'codex' ? 'Codex' : 'Claude Code'})`}
           value={description}
           onChange={(e) => setDescription(e.target.value)}
@@ -353,13 +353,13 @@ export function TaskForm({ onCreated }: TaskFormProps) {
         />
         <SecretPicker selectedIds={selectedSecretIds} onChange={setSelectedSecretIds} />
         {fileUpload.uploads.map((upload) => (
-          <div key={upload.id} className="relative rounded overflow-hidden border border-gray-600">
+          <div key={upload.id} className="relative rounded overflow-hidden border border-input-border">
             {upload.preview ? (
               <div className="w-12 h-12">
                 <img src={upload.preview} alt="" className="w-full h-full object-cover" />
               </div>
             ) : (
-              <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-gray-800 text-xs text-gray-300 max-w-[120px]">
+              <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-input text-xs text-muted max-w-[120px]">
                 <Paperclip size={12} className="shrink-0" />
                 <span className="truncate">{upload.file.name}</span>
               </div>
@@ -377,7 +377,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
             <button
               type="button"
               onClick={() => fileUpload.removeFile(upload.id)}
-              className="absolute top-0 right-0 bg-gray-900/80 rounded-bl p-0.5 text-gray-300 hover:text-white"
+              className="absolute top-0 right-0 bg-surface-raised/80 rounded-bl p-0.5 text-muted hover:text-foreground"
             >
               <X size={10} />
             </button>
@@ -398,14 +398,14 @@ export function TaskForm({ onCreated }: TaskFormProps) {
         {isNewProject && (
           <div className="flex flex-col sm:flex-row gap-2">
             <input
-              className="flex-1 bg-gray-700 text-foreground rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="flex-1 bg-input text-foreground rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-focus"
               placeholder="Project name (required)"
               value={newProjectName}
               onChange={(e) => setNewProjectName(e.target.value)}
               required
             />
             <input
-              className="flex-1 min-w-0 bg-gray-700 text-foreground rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="flex-1 min-w-0 bg-input text-foreground rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-focus"
               placeholder="Remote repo URL (optional)"
               value={newProjectUrl}
               onChange={(e) => setNewProjectUrl(e.target.value)}
@@ -415,9 +415,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
       </div>
       {contextTasks.length > 0 && (
         <div className="flex items-center gap-2 min-w-0">
-          <label className="text-sm text-gray-400 whitespace-nowrap shrink-0">Copy context from:</label>
+          <label className="text-sm text-subtle whitespace-nowrap shrink-0">Copy context from:</label>
           <select
-            className="flex-1 min-w-0 bg-gray-700 text-foreground rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="flex-1 min-w-0 bg-input text-foreground rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-focus"
             value={cloneFromTaskId}
             onChange={(e) => setCloneFromTaskId(e.target.value ? Number(e.target.value) : '')}
           >
@@ -435,17 +435,17 @@ export function TaskForm({ onCreated }: TaskFormProps) {
       {mode === 'loop' && (
         <div className="flex items-center gap-2 flex-wrap">
           <input
-            className="flex-1 min-w-0 bg-gray-700 text-foreground rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="flex-1 min-w-0 bg-input text-foreground rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-focus"
             placeholder="Todo file path (e.g. TODO.md)"
             value={todoFilePath}
             onChange={(e) => setTodoFilePath(e.target.value)}
             required
           />
-          <label className="text-xs text-gray-400 whitespace-nowrap">Max iter:</label>
+          <label className="text-xs text-subtle whitespace-nowrap">Max iter:</label>
           <input
             type="text"
             inputMode="numeric"
-            className="w-16 bg-gray-700 text-foreground rounded px-2 py-1.5 text-sm"
+            className="w-16 bg-input text-foreground rounded px-2 py-1.5 text-sm"
             value={maxIterations}
             onChange={(e) => setMaxIterations(e.target.value.replace(/[^0-9]/g, ''))}
             onBlur={() => {
@@ -453,12 +453,12 @@ export function TaskForm({ onCreated }: TaskFormProps) {
               setMaxIterations(String((!n || n < 1) ? 1 : n));
             }}
           />
-          <label className="flex items-center gap-1 text-xs text-gray-400 whitespace-nowrap cursor-pointer">
+          <label className="flex items-center gap-1 text-xs text-subtle whitespace-nowrap cursor-pointer">
             <input
               type="checkbox"
               checked={mustComplete}
               onChange={(e) => setMustComplete(e.target.checked)}
-              className="accent-indigo-500"
+              className="accent-accent"
             />
             Must complete
           </label>
@@ -467,17 +467,17 @@ export function TaskForm({ onCreated }: TaskFormProps) {
       {mode === 'goal' && (
         <div className="flex items-center gap-2 flex-wrap">
           <input
-            className="flex-1 min-w-0 bg-gray-700 text-foreground rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="flex-1 min-w-0 bg-input text-foreground rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-focus"
             placeholder="Goal condition (e.g. all tests pass and lint is clean)"
             value={goalCondition}
             onChange={(e) => setGoalCondition(e.target.value)}
             required
           />
-          <label className="text-xs text-gray-400 whitespace-nowrap">Max turns:</label>
+          <label className="text-xs text-subtle whitespace-nowrap">Max turns:</label>
           <input
             type="text"
             inputMode="numeric"
-            className="w-16 bg-gray-700 text-foreground rounded px-2 py-1.5 text-sm"
+            className="w-16 bg-input text-foreground rounded px-2 py-1.5 text-sm"
             value={goalMaxTurns}
             onChange={(e) => setGoalMaxTurns(e.target.value.replace(/[^0-9]/g, ''))}
             onBlur={() => {
@@ -494,7 +494,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
           type="button"
           onClick={() => fileInputRef.current?.click()}
           disabled={fileUpload.uploads.length >= 10}
-          className="flex items-center gap-1 text-xs px-2 py-1.5 rounded border transition-colors bg-gray-700 text-gray-400 border-gray-600 hover:bg-gray-600 hover:text-gray-300 disabled:opacity-40"
+          className="flex items-center gap-1 text-xs px-2 py-1.5 rounded border transition-colors bg-input text-subtle border-input-border hover:bg-surface-hover hover:text-muted disabled:opacity-40"
         >
           <Paperclip size={13} />
           <span className="hidden sm:inline">{fileUpload.uploads.length > 0 ? `${fileUpload.uploads.length}/10 files` : 'Attach files'}</span>
@@ -508,18 +508,18 @@ export function TaskForm({ onCreated }: TaskFormProps) {
             className={`flex items-center gap-1 text-xs px-2 py-1.5 rounded border transition-colors ${
               hasNonDefaultConfig
                 ? 'bg-amber-600/30 text-amber-300 border-amber-500/50 hover:bg-amber-600/40'
-                : 'bg-gray-700 text-gray-400 border-gray-600 hover:bg-gray-600 hover:text-gray-300'
+                : 'bg-input text-subtle border-input-border hover:bg-surface-hover hover:text-muted'
             }`}
           >
             <Settings size={13} />
             <span className="hidden sm:inline">Config</span>
           </button>
           {showConfigPanel && (
-            <div className="absolute top-full mt-1 left-0 bg-gray-800 border border-gray-600 rounded shadow-lg z-20 p-3 min-w-[280px]">
+            <div className="absolute top-full mt-1 left-0 bg-surface border border-input-border rounded shadow-lg z-20 p-3 min-w-[280px]">
               <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-2 items-center text-xs">
-                <span className="text-gray-400">Priority</span>
+                <span className="text-subtle">Priority</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={priority}
                   onChange={(e) => setPriority(Number(e.target.value))}
                 >
@@ -528,9 +528,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                   ))}
                 </select>
 
-                <span className="text-gray-400">Mode</span>
+                <span className="text-subtle">Mode</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={mode}
                   onChange={(e) => setMode(e.target.value)}
                 >
@@ -540,9 +540,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                   <option value="goal">Goal</option>
                 </select>
 
-                <span className="text-gray-400">Run on</span>
+                <span className="text-subtle">Run on</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={workerId}
                   onChange={(e) => setWorkerId(e.target.value)}
                 >
@@ -554,9 +554,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                   ))}
                 </select>
 
-                <span className="text-gray-400">CLI</span>
+                <span className="text-subtle">CLI</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={provider}
                   onChange={(e) => {
                     setProvider(e.target.value);
@@ -569,9 +569,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                   ))}
                 </select>
 
-                <span className="text-gray-400">Model</span>
+                <span className="text-subtle">Model</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={model}
                   onChange={(e) => setModel(e.target.value)}
                 >
@@ -581,9 +581,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                   ))}
                 </select>
 
-                <span className="text-gray-400">Effort</span>
+                <span className="text-subtle">Effort</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={effort}
                   onChange={(e) => setEffort(e.target.value)}
                 >
@@ -593,9 +593,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                   ))}
                 </select>
 
-                <span className="text-gray-400">Thinking</span>
+                <span className="text-subtle">Thinking</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={thinkingBudget}
                   onChange={(e) => setThinkingBudget(e.target.value)}
                 >
@@ -608,9 +608,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                   <option value="131072">128k</option>
                 </select>
 
-                <span className="text-gray-400">Timeout</span>
+                <span className="text-subtle">Timeout</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={timeoutHours}
                   onChange={(e) => setTimeoutHours(e.target.value)}
                 >
@@ -625,9 +625,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                   <option value="0">No limit</option>
                 </select>
 
-                <span className="text-gray-400">System Prompt</span>
+                <span className="text-subtle">System Prompt</span>
                 <select
-                  className="bg-gray-700 text-foreground rounded px-2 py-1 text-xs"
+                  className="bg-input text-foreground rounded px-2 py-1 text-xs"
                   value={systemPromptMode}
                   onChange={(e) => setSystemPromptMode(e.target.value)}
                 >
@@ -664,7 +664,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
           className={`flex items-center gap-1 text-xs px-2 py-1.5 rounded border transition-colors ${
             starOnCreate
               ? 'bg-yellow-600/30 text-yellow-300 border-yellow-500/50 hover:bg-yellow-600/40'
-              : 'bg-gray-700 text-gray-400 border-gray-600 hover:bg-gray-600 hover:text-gray-300'
+              : 'bg-input text-subtle border-input-border hover:bg-surface-hover hover:text-muted'
           }`}
         >
           <Star size={13} fill={starOnCreate ? 'currentColor' : 'none'} />
@@ -677,7 +677,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
               className={`flex items-center gap-1 text-xs px-2 py-1.5 rounded border transition-colors ${
                 enabledUserSkillCount > 0
                   ? 'bg-green-600/30 text-green-300 border-green-500/50 hover:bg-green-600/40'
-                  : 'bg-gray-700 text-gray-400 border-gray-600 hover:bg-gray-600 hover:text-gray-300'
+                  : 'bg-input text-subtle border-input-border hover:bg-surface-hover hover:text-muted'
               }`}
             >
               <span className="text-xs">📝</span>
@@ -685,13 +685,13 @@ export function TaskForm({ onCreated }: TaskFormProps) {
               {enabledUserSkillCount > 0 && <span className="sm:hidden">{enabledUserSkillCount}</span>}
             </button>
             {showSkillsDropdown && (
-              <div className="absolute top-full mt-1 left-0 bg-gray-800 border border-gray-600 rounded shadow-lg z-20 min-w-[180px]">
+              <div className="absolute top-full mt-1 left-0 bg-surface border border-input-border rounded shadow-lg z-20 min-w-[180px]">
                 {userSkills.length === 0 ? (
-                  <div className="px-3 py-2 text-xs text-gray-500">暂无 Skill，去 Skills 页面创建</div>
+                  <div className="px-3 py-2 text-xs text-subtle">暂无 Skill，去 Skills 页面创建</div>
                 ) : userSkills.map((skill) => (
                   <label
                     key={skill.id}
-                    className="flex items-center gap-2 px-3 py-2 text-xs text-gray-300 hover:bg-gray-700 cursor-pointer"
+                    className="flex items-center gap-2 px-3 py-2 text-xs text-muted hover:bg-surface-hover cursor-pointer"
                     title={skill.description}
                   >
                     <input
@@ -714,8 +714,8 @@ export function TaskForm({ onCreated }: TaskFormProps) {
               onClick={() => setShowPluginsDropdown(!showPluginsDropdown)}
               className={`flex items-center gap-1 text-xs px-2 py-1.5 rounded border transition-colors ${
                 enabledPluginCount > 0
-                  ? 'bg-indigo-600/30 text-indigo-300 border-indigo-500/50 hover:bg-indigo-600/40'
-                  : 'bg-gray-700 text-gray-400 border-gray-600 hover:bg-gray-600 hover:text-gray-300'
+                  ? 'bg-accent-muted text-accent-muted-foreground border-focus hover:bg-accent hover:text-accent-foreground'
+                  : 'bg-input text-subtle border-input-border hover:bg-surface-hover hover:text-muted'
               }`}
             >
               <Wrench size={13} />
@@ -723,13 +723,13 @@ export function TaskForm({ onCreated }: TaskFormProps) {
               {enabledPluginCount > 0 && <span className="sm:hidden">{enabledPluginCount}</span>}
             </button>
             {showPluginsDropdown && (
-              <div className="absolute top-full mt-1 left-0 bg-gray-800 border border-gray-600 rounded shadow-lg z-20 min-w-[180px]">
+              <div className="absolute top-full mt-1 left-0 bg-surface border border-input-border rounded shadow-lg z-20 min-w-[180px]">
                 {AVAILABLE_PLUGINS.map((tool) => {
                   const locked = false;
                   return (
                     <label
                       key={tool.key}
-                      className={`flex items-center gap-2 px-3 py-2 text-xs transition-colors ${locked ? 'text-gray-500 cursor-default' : 'text-gray-300 hover:bg-gray-700 cursor-pointer'}`}
+                      className={`flex items-center gap-2 px-3 py-2 text-xs transition-colors ${locked ? 'text-subtle cursor-default' : 'text-muted hover:bg-surface-hover cursor-pointer'}`}
                       title={tool.description}
                     >
                       <input
@@ -737,7 +737,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
                         checked={!!enabledPlugins[tool.key]}
                         onChange={(e) => !locked && setEnabledPlugins((prev) => ({ ...prev, [tool.key]: e.target.checked }))}
                         disabled={locked}
-                        className="accent-indigo-500"
+                        className="accent-accent"
                       />
                       {tool.label}
                     </label>
@@ -751,7 +751,7 @@ export function TaskForm({ onCreated }: TaskFormProps) {
         <button
           type="submit"
           disabled={loading || !canSubmit}
-          className="flex items-center gap-1 bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-1.5 rounded text-xs font-medium disabled:opacity-50 ml-auto"
+          className="flex items-center gap-1 bg-accent hover:bg-accent-hover text-accent-foreground px-4 py-1.5 rounded text-xs font-medium disabled:opacity-50 ml-auto"
         >
           <Plus size={14} />
           <span className="hidden sm:inline">{loading ? 'Creating...' : 'Create'}</span>

--- a/frontend/src/components/Tasks/TaskList.tsx
+++ b/frontend/src/components/Tasks/TaskList.tsx
@@ -110,7 +110,7 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
   const { draggingId, overIndex, targetProps, pointerHandleProps, ghost } = useTaskReorder(tasks, onRefresh, autoSortOnAccess);
 
   if (tasks.length === 0) {
-    return <p className="text-gray-500 text-sm text-center py-8">No tasks yet</p>;
+    return <p className="text-subtle text-sm text-center py-8">No tasks yet</p>;
   }
 
   return (
@@ -123,15 +123,15 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
           {...targetProps(t, idx)}
           className={`relative rounded-lg p-3 transition-opacity ${
             draggingId === t.id ? 'opacity-40' : ''
-          } ${overIndex === idx && draggingId !== null && draggingId !== t.id ? 'ring-2 ring-indigo-400' : ''} ${
-            activeTaskId === t.id ? 'bg-indigo-900/60 ring-1 ring-indigo-400/60' : t.has_unread ? 'bg-indigo-900/50 ring-1 ring-indigo-500/50' : 'bg-gray-800'
+          } ${overIndex === idx && draggingId !== null && draggingId !== t.id ? 'ring-2 ring-focus' : ''} ${
+            activeTaskId === t.id ? 'bg-accent-muted ring-1 ring-focus' : t.has_unread ? 'bg-accent-muted ring-1 ring-focus' : 'bg-surface'
           }`}
         >
           {/* 拖拽手柄（右下角，空间更宽裕）：卡片正文是可选中文字，整卡
               draggable 会被文本选择手势抢走，必须用显式手柄拖动 */}
           <span
             {...pointerHandleProps(t, idx)}
-            className="absolute bottom-1.5 right-1.5 p-1 cursor-grab active:cursor-grabbing text-gray-600 hover:text-gray-400 select-none"
+            className="absolute bottom-1.5 right-1.5 p-1 cursor-grab active:cursor-grabbing text-subtle hover:text-muted select-none"
             title="按住拖动排序"
           >
             <GripVertical size={16} />
@@ -140,7 +140,7 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
           <div className="flex items-center gap-2">
             <span className={`w-2.5 h-2.5 rounded-full shrink-0 self-start mt-[9px] ${statusColors[t.status] || 'bg-gray-500'}`} />
             <div className="flex items-center gap-2 flex-wrap flex-1 min-w-0 min-h-[28px]">
-              <span className="text-xs text-gray-500">#{t.id}</span>
+              <span className="text-xs text-subtle">#{t.id}</span>
               {t.shared_from_id && (
                 <span className="text-xs bg-orange-600/30 text-orange-300 px-1.5 rounded font-medium">Shared</span>
               )}
@@ -152,9 +152,9 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
                 return <span className={`text-xs ${bg} ${text} px-1.5 rounded font-medium whitespace-nowrap`}>{proj.name}</span>;
               })()}
               {t.priority > 0 && (
-                <span className="text-xs bg-indigo-600/30 text-indigo-300 px-1.5 rounded">P{t.priority}</span>
+                <span className="text-xs bg-accent-muted text-accent-muted-foreground px-1.5 rounded">P{t.priority}</span>
               )}
-              <span className="hidden sm:inline text-xs text-gray-500 capitalize">{t.status.replace('_', ' ')}</span>
+              <span className="hidden sm:inline text-xs text-subtle capitalize">{t.status.replace('_', ' ')}</span>
               <span className={`hidden sm:inline text-xs px-1.5 rounded font-medium ${t.provider === 'codex' ? 'bg-green-600/30 text-green-300' : 'bg-blue-600/30 text-blue-300'}`}>
                 {t.provider === 'codex' ? 'Codex' : 'Claude'}
               </span>
@@ -166,14 +166,14 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
             <div className="flex gap-1 shrink-0 items-center">
               <button
                 onClick={() => handleStar(t.id)}
-                className={`p-1.5 transition-colors ${t.starred ? 'text-yellow-400 hover:text-yellow-300' : 'text-gray-600 hover:text-yellow-400'}`}
+                className={`p-1.5 transition-colors ${t.starred ? 'text-warning hover:text-yellow-300' : 'text-subtle hover:text-warning'}`}
                 title={t.starred ? "Unstar" : "Star"}
               >
                 <Star size={16} fill={t.starred ? 'currentColor' : 'none'} />
               </button>
               <button
                 onClick={() => handleToggleUnread(t.id, t.has_unread)}
-                className={`p-1.5 transition-colors ${t.has_unread ? 'text-indigo-400 hover:text-indigo-300' : 'text-gray-600 hover:text-indigo-400'}`}
+                className={`p-1.5 transition-colors ${t.has_unread ? 'text-accent-muted-foreground hover:text-foreground' : 'text-subtle hover:text-accent-muted-foreground'}`}
                 title={t.has_unread ? "Mark as read" : "Mark as unread"}
               >
                 {t.has_unread ? <MailOpen size={16} /> : <Mail size={16} />}
@@ -181,7 +181,7 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
               {t.session_id && (
                 <button
                   onClick={() => onOpenChat(t)}
-                  className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium bg-indigo-600/20 text-indigo-400 hover:bg-indigo-600/30"
+                  className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium bg-accent-muted text-accent-muted-foreground hover:bg-accent hover:text-accent-foreground"
                   title="Chat"
                 >
                   <MessageCircle size={14} /><span className="hidden sm:inline"> Chat</span>
@@ -189,10 +189,10 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
               )}
               <button
                 onClick={() => handleCopy(t)}
-                className="p-1.5 text-gray-600 hover:text-gray-300 transition-colors"
+                className="p-1.5 text-subtle hover:text-muted transition-colors"
                 title="Copy prompt"
               >
-                {copiedId === t.id ? <Check size={16} className="text-green-400" /> : <Copy size={16} />}
+                {copiedId === t.id ? <Check size={16} className="text-success" /> : <Copy size={16} />}
               </button>
               {/* Overflow menu */}
               <div className="relative">
@@ -200,16 +200,16 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
                   onClick={() => {
                     setMenuOpenId(menuOpenId === t.id ? null : t.id);
                   }}
-                  className="p-1.5 text-gray-600 hover:text-gray-300 transition-colors"
+                  className="p-1.5 text-subtle hover:text-muted transition-colors"
                   title="More actions"
                 >
                   <MoreVertical size={16} />
                 </button>
                 {menuOpenId === t.id && (
-                  <div ref={menuRef} className="absolute top-full mt-1 right-0 bg-gray-900 border border-gray-700 rounded-lg shadow-xl z-20 py-1 min-w-[140px]">
+                  <div ref={menuRef} className="absolute top-full mt-1 right-0 bg-surface-raised border border-border rounded-lg shadow-xl z-20 py-1 min-w-[140px]">
                     <button
                       onClick={() => { setTitleDraft(t.title || ''); setEditingTitleId(t.id); setMenuOpenId(null); }}
-                      className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-gray-300 hover:bg-gray-800 text-left"
+                      className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-muted hover:bg-surface-hover text-left"
                     >
                       <Pencil size={14} /> Edit title
                     </button>
@@ -219,14 +219,14 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
                         setMenuOpenId(null);
                         window.dispatchEvent(new CustomEvent('ccm-share-task', { detail: { task: t } }));
                       }}
-                      className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-gray-300 hover:bg-gray-800 text-left"
+                      className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-muted hover:bg-surface-hover text-left"
                     >
                       <Share2 size={14} /> Share
                     </button>
                     {['in_progress', 'executing'].includes(t.status) && (
                       <button
                         onClick={() => { handleCancel(t.id); setMenuOpenId(null); }}
-                        className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-yellow-400 hover:bg-gray-800 text-left"
+                        className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-warning hover:bg-surface-hover text-left"
                       >
                         <XCircle size={14} /> Cancel
                       </button>
@@ -234,14 +234,14 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
                     {t.status === 'failed' && (
                       <button
                         onClick={() => { handleRetry(t.id); setMenuOpenId(null); }}
-                        className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-blue-400 hover:bg-gray-800 text-left"
+                        className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-info hover:bg-surface-hover text-left"
                       >
                         <RotateCcw size={14} /> Retry
                       </button>
                     )}
                     <button
                       onClick={() => { handleArchive(t.id); setMenuOpenId(null); }}
-                      className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-amber-400 hover:bg-gray-800 text-left"
+                      className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-warning hover:bg-surface-hover text-left"
                     >
                       {t.archived ? <ArchiveRestore size={14} /> : <Archive size={14} />}
                       {t.archived ? 'Unarchive' : 'Archive'}
@@ -249,7 +249,7 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
                     {['pending', 'failed', 'cancelled', 'completed'].includes(t.status) && (
                       <button
                         onClick={() => { handleDelete(t.id); setMenuOpenId(null); }}
-                        className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-red-400 hover:bg-gray-800 text-left"
+                        className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-danger hover:bg-surface-hover text-left"
                       >
                         <Trash2 size={14} /> Delete
                       </button>
@@ -272,7 +272,7 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
                   if (e.key === 'Enter') handleTitleSave(t);
                   if (e.key === 'Escape') setEditingTitleId(null);
                 }}
-                className="w-full bg-gray-700 text-foreground text-sm rounded px-2 py-0.5 mt-0.5 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                className="w-full bg-input text-foreground text-sm rounded px-2 py-0.5 mt-0.5 focus:outline-none focus:ring-1 focus:ring-focus"
                 placeholder="Enter title..."
               />
             ) : (
@@ -282,37 +282,37 @@ export function TaskList({ tasks, projects, onRefresh, onOpenChat, activeTaskId,
             )}
             {/* Description (expandable) */}
             {t.mode === 'loop' && !t.description ? (
-              <p className="text-sm mt-0.5 text-gray-500 italic">{t.todo_file_path}</p>
+              <p className="text-sm mt-0.5 text-subtle italic">{t.todo_file_path}</p>
             ) : t.description ? (
               <ExpandableText
                 text={t.description}
                 collapsedLines={2}
-                className={`text-sm mt-0.5 ${t.title ? 'text-gray-400' : 'text-foreground'}`}
+                className={`text-sm mt-0.5 ${t.title ? 'text-muted' : 'text-foreground'}`}
               />
             ) : null}
             {t.mode === 'goal' && t.goal_condition && (
-              <p className="text-emerald-500/70 text-xs mt-0.5 line-clamp-1">Goal: {t.goal_condition}</p>
+              <p className="text-success text-xs mt-0.5 line-clamp-1">Goal: {t.goal_condition}</p>
             )}
             {t.mode === 'loop' && t.loop_progress && (
-              <p className="text-indigo-400 text-xs mt-0.5">⟳ {t.loop_progress}</p>
+              <p className="text-accent-muted-foreground text-xs mt-0.5">⟳ {t.loop_progress}</p>
             )}
             {t.mode === 'goal' && t.goal_turns_used > 0 && (
-              <p className="text-emerald-400 text-xs mt-0.5">
+              <p className="text-success text-xs mt-0.5">
                 ◎ Turn {t.goal_turns_used}/{t.goal_max_turns}
-                {t.goal_last_reason && <span className="text-gray-500 ml-1">— {t.goal_last_reason}</span>}
+                {t.goal_last_reason && <span className="text-subtle ml-1">— {t.goal_last_reason}</span>}
               </p>
             )}
             {t.target_repo && (
-              <p className="text-gray-600 text-xs mt-0.5 truncate">{t.target_repo}</p>
+              <p className="text-subtle text-xs mt-0.5 truncate">{t.target_repo}</p>
             )}
             {t.created_at && (
-              <p className="text-gray-600 text-xs mt-0.5 flex items-center gap-1">
+              <p className="text-subtle text-xs mt-0.5 flex items-center gap-1">
                 <Clock size={10} className="shrink-0" />
                 {formatDateTime(t.created_at)}
               </p>
             )}
             {t.error_message && (
-              <p className="text-red-400 text-xs mt-1">{t.error_message}</p>
+              <p className="text-danger text-xs mt-1">{t.error_message}</p>
             )}
           </div>
         </div>

--- a/frontend/src/config/theme.ts
+++ b/frontend/src/config/theme.ts
@@ -1,15 +1,308 @@
 const STORAGE_KEY = 'cc_theme';
 
-export const THEME_OPTIONS = [
-  { value: 'dark', label: '深色' },
-  { value: 'ocean', label: '海蓝' },
-  { value: 'forest', label: '森林' },
-  { value: 'rose', label: '莓红' },
-] as const;
+// Follow-up (semantic-theme migration, from PR #29 review):
+//  - Task status dots in TaskList (`statusColors[t.status] || 'bg-gray-500'`) and
+//    provider/shared badges (green=Codex, blue=Claude, orange=Shared) still use raw
+//    Tailwind accent classes. They currently follow the theme only via the
+//    --color-gray-*/accent compat overrides in index.css. Fold them into the
+//    semantic token set (success/danger/warning/info) once those roles cover the
+//    status palette, then the per-theme compat blocks can start shrinking.
 
-export type Theme = typeof THEME_OPTIONS[number]['value'];
+type ThemeToken =
+  | 'appBackground'
+  | 'foreground'
+  | 'muted'
+  | 'subtle'
+  | 'chromeBackground'
+  | 'chromeBorder'
+  | 'surfaceBackground'
+  | 'surfaceRaised'
+  | 'surfaceHover'
+  | 'border'
+  | 'inputBackground'
+  | 'inputBorder'
+  | 'accentBackground'
+  | 'accentHover'
+  | 'accentForeground'
+  | 'accentMutedBackground'
+  | 'accentMutedForeground'
+  | 'focusRing'
+  | 'successForeground'
+  | 'warningForeground'
+  | 'dangerForeground'
+  | 'infoForeground';
 
-const THEME_VALUES = new Set<Theme>(THEME_OPTIONS.map((t) => t.value));
+type ThemeDefinition = {
+  label: string;
+  colorScheme: 'dark' | 'light';
+  tokens: Record<ThemeToken, string>;
+};
+
+const TOKEN_VARIABLES: Record<ThemeToken, `--ccm-${string}`> = {
+  appBackground: '--ccm-app-background',
+  foreground: '--ccm-foreground',
+  muted: '--ccm-muted',
+  subtle: '--ccm-subtle',
+  chromeBackground: '--ccm-chrome-background',
+  chromeBorder: '--ccm-chrome-border',
+  surfaceBackground: '--ccm-surface-background',
+  surfaceRaised: '--ccm-surface-raised',
+  surfaceHover: '--ccm-surface-hover',
+  border: '--ccm-border',
+  inputBackground: '--ccm-input-background',
+  inputBorder: '--ccm-input-border',
+  accentBackground: '--ccm-accent-background',
+  accentHover: '--ccm-accent-hover',
+  accentForeground: '--ccm-accent-foreground',
+  accentMutedBackground: '--ccm-accent-muted-background',
+  accentMutedForeground: '--ccm-accent-muted-foreground',
+  focusRing: '--ccm-focus-ring',
+  successForeground: '--ccm-success-foreground',
+  warningForeground: '--ccm-warning-foreground',
+  dangerForeground: '--ccm-danger-foreground',
+  infoForeground: '--ccm-info-foreground',
+};
+
+// Cached at module load — TOKEN_VARIABLES is const, so this never changes.
+const TOKEN_ENTRIES = Object.entries(TOKEN_VARIABLES) as Array<[ThemeToken, `--ccm-${string}`]>;
+
+export const THEMES = {
+  // NOTE: The dark theme's token values are duplicated in index.css `:root`, which
+  // acts as the pre-JS fallback. Keep the two in sync when editing dark values.
+  dark: {
+    label: '深色',
+    colorScheme: 'dark',
+    tokens: {
+      appBackground: '#030712',
+      foreground: '#f9fafb',
+      muted: '#d1d5db',
+      subtle: '#9ca3af',
+      chromeBackground: '#111827',
+      chromeBorder: '#374151',
+      surfaceBackground: '#1f2937',
+      surfaceRaised: '#111827',
+      surfaceHover: '#374151',
+      border: '#374151',
+      inputBackground: '#374151',
+      inputBorder: '#4b5563',
+      accentBackground: '#4f46e5',
+      accentHover: '#6366f1',
+      accentForeground: '#ffffff',
+      accentMutedBackground: '#312e81',
+      accentMutedForeground: '#c7d2fe',
+      focusRing: '#6366f1',
+      successForeground: '#4ade80',
+      warningForeground: '#facc15',
+      dangerForeground: '#f87171',
+      infoForeground: '#60a5fa',
+    },
+  },
+  ocean: {
+    label: '海蓝',
+    colorScheme: 'dark',
+    tokens: {
+      appBackground: '#06131f',
+      foreground: '#e8f6ff',
+      muted: '#bed0d9',
+      subtle: '#91aebd',
+      chromeBackground: '#0b1f30',
+      chromeBorder: '#1c4562',
+      surfaceBackground: '#123047',
+      surfaceRaised: '#0b1f30',
+      surfaceHover: '#1c4562',
+      border: '#1c4562',
+      inputBackground: '#123047',
+      inputBorder: '#2f5f7c',
+      accentBackground: '#0891b2',
+      accentHover: '#06b6d4',
+      accentForeground: '#ecfeff',
+      accentMutedBackground: '#164e63',
+      accentMutedForeground: '#a5f3fc',
+      focusRing: '#22d3ee',
+      successForeground: '#86efac',
+      warningForeground: '#fcd34d',
+      dangerForeground: '#fda4af',
+      infoForeground: '#7dd3fc',
+    },
+  },
+  forest: {
+    label: '森林',
+    colorScheme: 'dark',
+    tokens: {
+      appBackground: '#07130d',
+      foreground: '#f0f8ef',
+      muted: '#c2cdbc',
+      subtle: '#9aab98',
+      chromeBackground: '#102015',
+      chromeBorder: '#29472f',
+      surfaceBackground: '#1a3221',
+      surfaceRaised: '#102015',
+      surfaceHover: '#29472f',
+      border: '#29472f',
+      inputBackground: '#1a3221',
+      inputBorder: '#3f6046',
+      accentBackground: '#15803d',
+      accentHover: '#16a34a',
+      accentForeground: '#f0fdf4',
+      accentMutedBackground: '#14532d',
+      accentMutedForeground: '#bbf7d0',
+      focusRing: '#4ade80',
+      successForeground: '#86efac',
+      warningForeground: '#fde047',
+      dangerForeground: '#fca5a5',
+      infoForeground: '#93c5fd',
+    },
+  },
+  rose: {
+    label: '莓红',
+    colorScheme: 'dark',
+    tokens: {
+      appBackground: '#1a0b12',
+      foreground: '#fff1f5',
+      muted: '#dcc0c9',
+      subtle: '#bd95a4',
+      chromeBackground: '#2a121d',
+      chromeBorder: '#55283c',
+      surfaceBackground: '#3d1c2b',
+      surfaceRaised: '#2a121d',
+      surfaceHover: '#55283c',
+      border: '#55283c',
+      inputBackground: '#3d1c2b',
+      inputBorder: '#71384f',
+      accentBackground: '#db2777',
+      accentHover: '#ec4899',
+      accentForeground: '#fff1f5',
+      accentMutedBackground: '#831843',
+      accentMutedForeground: '#fbcfe8',
+      focusRing: '#f472b6',
+      successForeground: '#6ee7b7',
+      warningForeground: '#fcd34d',
+      dangerForeground: '#fda4af',
+      infoForeground: '#c4b5fd',
+    },
+  },
+  onedark: {
+    label: 'One Dark',
+    colorScheme: 'dark',
+    tokens: {
+      appBackground: '#21252b',
+      foreground: '#d7dae0',
+      muted: '#abb2bf',
+      subtle: '#7f848e',
+      chromeBackground: '#21252b',
+      chromeBorder: '#181a1f',
+      surfaceBackground: '#282c34',
+      surfaceRaised: '#21252b',
+      surfaceHover: '#2c313c',
+      border: '#3e4451',
+      inputBackground: '#1d2026',
+      inputBorder: '#3e4451',
+      accentBackground: '#4577e6',
+      accentHover: '#528bff',
+      accentForeground: '#ffffff',
+      accentMutedBackground: '#2b3a54',
+      accentMutedForeground: '#9cc0f5',
+      focusRing: '#61afef',
+      successForeground: '#98c379',
+      warningForeground: '#e5c07b',
+      dangerForeground: '#e06c75',
+      infoForeground: '#61afef',
+    },
+  },
+  dracula: {
+    label: 'Dracula',
+    colorScheme: 'dark',
+    tokens: {
+      appBackground: '#21222c',
+      foreground: '#f8f8f2',
+      muted: '#d4d6e4',
+      subtle: '#6272a4',
+      chromeBackground: '#282a36',
+      chromeBorder: '#191a21',
+      surfaceBackground: '#343645',
+      surfaceRaised: '#282a36',
+      surfaceHover: '#44475a',
+      border: '#44475a',
+      inputBackground: '#21222c',
+      inputBorder: '#44475a',
+      accentBackground: '#7c5cc7',
+      accentHover: '#9070d8',
+      accentForeground: '#ffffff',
+      accentMutedBackground: '#3b2f5e',
+      accentMutedForeground: '#d6bcfd',
+      focusRing: '#bd93f9',
+      successForeground: '#50fa7b',
+      warningForeground: '#f1fa8c',
+      dangerForeground: '#ff5555',
+      infoForeground: '#8be9fd',
+    },
+  },
+  nord: {
+    label: 'Nord',
+    colorScheme: 'dark',
+    tokens: {
+      appBackground: '#242933',
+      foreground: '#eceff4',
+      muted: '#d8dee9',
+      subtle: '#7b88a1',
+      chromeBackground: '#2e3440',
+      chromeBorder: '#3b4252',
+      surfaceBackground: '#3b4252',
+      surfaceRaised: '#2e3440',
+      surfaceHover: '#434c5e',
+      border: '#434c5e',
+      inputBackground: '#2e3440',
+      inputBorder: '#4c566a',
+      accentBackground: '#5e81ac',
+      accentHover: '#81a1c1',
+      accentForeground: '#eceff4',
+      accentMutedBackground: '#3b4a5e',
+      accentMutedForeground: '#a3c1e0',
+      focusRing: '#88c0d0',
+      successForeground: '#a3be8c',
+      warningForeground: '#ebcb8b',
+      dangerForeground: '#bf616a',
+      infoForeground: '#88c0d0',
+    },
+  },
+  tokyonight: {
+    label: 'Tokyo Night',
+    colorScheme: 'dark',
+    tokens: {
+      appBackground: '#16161e',
+      foreground: '#c0caf5',
+      muted: '#a9b1d6',
+      subtle: '#565f89',
+      chromeBackground: '#1a1b26',
+      chromeBorder: '#292e42',
+      surfaceBackground: '#1f2335',
+      surfaceRaised: '#1a1b26',
+      surfaceHover: '#292e42',
+      border: '#292e42',
+      inputBackground: '#1a1b26',
+      inputBorder: '#3b4261',
+      accentBackground: '#4d62a6',
+      accentHover: '#7aa2f7',
+      accentForeground: '#ffffff',
+      accentMutedBackground: '#2a3158',
+      accentMutedForeground: '#a9c0ff',
+      focusRing: '#7aa2f7',
+      successForeground: '#9ece6a',
+      warningForeground: '#e0af68',
+      dangerForeground: '#f7768e',
+      infoForeground: '#7dcfff',
+    },
+  },
+} as const satisfies Record<string, ThemeDefinition>;
+
+export type Theme = keyof typeof THEMES;
+
+export const THEME_OPTIONS = Object.entries(THEMES).map(([value, theme]) => ({
+  value: value as Theme,
+  label: theme.label,
+}));
+
+const THEME_VALUES = new Set<Theme>(Object.keys(THEMES) as Theme[]);
 
 export function getTheme(): Theme {
   const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
@@ -23,6 +316,14 @@ export function setTheme(theme: Theme) {
 
 export function applyTheme(theme?: Theme) {
   const t = theme || getTheme();
-  document.documentElement.classList.remove('light');
-  document.documentElement.dataset.theme = t;
+  const definition = THEMES[t];
+  const root = document.documentElement;
+
+  root.classList.remove('light');
+  root.dataset.theme = t;
+  root.style.colorScheme = definition.colorScheme;
+
+  for (const [token, variable] of TOKEN_ENTRIES) {
+    root.style.setProperty(variable, definition.tokens[token]);
+  }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,19 +1,77 @@
 @import "tailwindcss";
 
 @theme {
-  --color-foreground: #ffffff;
+  --color-app: var(--ccm-app-background);
+  --color-foreground: var(--ccm-foreground);
+  --color-muted: var(--ccm-muted);
+  --color-subtle: var(--ccm-subtle);
+  --color-chrome: var(--ccm-chrome-background);
+  --color-chrome-border: var(--ccm-chrome-border);
+  --color-surface: var(--ccm-surface-background);
+  --color-surface-raised: var(--ccm-surface-raised);
+  --color-surface-hover: var(--ccm-surface-hover);
+  --color-border: var(--ccm-border);
+  --color-input: var(--ccm-input-background);
+  --color-input-border: var(--ccm-input-border);
+  --color-accent: var(--ccm-accent-background);
+  --color-accent-hover: var(--ccm-accent-hover);
+  --color-accent-foreground: var(--ccm-accent-foreground);
+  --color-accent-muted: var(--ccm-accent-muted-background);
+  --color-accent-muted-foreground: var(--ccm-accent-muted-foreground);
+  --color-focus: var(--ccm-focus-ring);
+  --color-success: var(--ccm-success-foreground);
+  --color-warning: var(--ccm-warning-foreground);
+  --color-danger: var(--ccm-danger-foreground);
+  --color-info: var(--ccm-info-foreground);
+}
+
+:root {
+  color-scheme: dark;
+  --ccm-app-background: #030712;
+  --ccm-foreground: #f9fafb;
+  --ccm-muted: #d1d5db;
+  --ccm-subtle: #9ca3af;
+  --ccm-chrome-background: #111827;
+  --ccm-chrome-border: #374151;
+  --ccm-surface-background: #1f2937;
+  --ccm-surface-raised: #111827;
+  --ccm-surface-hover: #374151;
+  --ccm-border: #374151;
+  --ccm-input-background: #374151;
+  --ccm-input-border: #4b5563;
+  --ccm-accent-background: #4f46e5;
+  --ccm-accent-hover: #6366f1;
+  --ccm-accent-foreground: #ffffff;
+  --ccm-accent-muted-background: #312e81;
+  --ccm-accent-muted-foreground: #c7d2fe;
+  --ccm-focus-ring: #6366f1;
+  --ccm-success-foreground: #4ade80;
+  --ccm-warning-foreground: #facc15;
+  --ccm-danger-foreground: #f87171;
+  --ccm-info-foreground: #60a5fa;
 }
 
 html {
-  background-color: #030712;
+  background-color: var(--ccm-app-background);
   touch-action: manipulation;
   overflow-x: clip;
 }
 
-
+/*
+ * Compat layer for components not yet migrated to semantic tokens.
+ * Migrated components consume semantic aliases (bg-surface, text-muted, …) which
+ * resolve from the JS-applied --ccm- vars. Everything else still uses raw
+ * bg-gray and text-gray classes; these per-theme blocks re-map Tailwind's
+ * --color-gray- scale (+ a few accents) so those components keep following the theme.
+ * Remove a theme's block only once every component reads semantic tokens.
+ *
+ * NOTE: only dark-family themes are shipped. A light theme is intentionally NOT
+ * included: inverting the gray scale leaves the many `text-white`/`bg-white`
+ * literals across the app (ProjectSelect, Files tabs, Chat, badges, …) as
+ * white-on-light and unreadable. Re-add light only after those components move
+ * off raw white/gray classes onto semantic tokens.
+ */
 html[data-theme='ocean'] {
-  background-color: #06131f;
-
   --color-foreground: #e8f6ff;
 
   --color-gray-950: #06131f;
@@ -51,8 +109,6 @@ html[data-theme='ocean'] {
 }
 
 html[data-theme='forest'] {
-  background-color: #07130d;
-
   --color-foreground: #f0f8ef;
 
   --color-gray-950: #07130d;
@@ -90,8 +146,6 @@ html[data-theme='forest'] {
 }
 
 html[data-theme='rose'] {
-  background-color: #1a0b12;
-
   --color-foreground: #fff1f5;
 
   --color-gray-950: #1a0b12;
@@ -126,6 +180,154 @@ html[data-theme='rose'] {
   --color-red-300: #fda4af;
 
   --color-emerald-300: #6ee7b7;
+}
+
+html[data-theme='onedark'] {
+  --color-foreground: #d7dae0;
+
+  --color-gray-950: #21252b;
+  --color-gray-900: #282c34;
+  --color-gray-800: #2c313c;
+  --color-gray-700: #3e4451;
+  --color-gray-600: #4b5263;
+  --color-gray-500: #5c6370;
+  --color-gray-400: #7f848e;
+  --color-gray-300: #abb2bf;
+  --color-gray-200: #c5cad3;
+  --color-gray-100: #d7dae0;
+  --color-gray-50: #e8eaed;
+
+  --color-blue-600: #4577e6;
+  --color-blue-400: #61afef;
+  --color-blue-300: #83c0f2;
+
+  --color-indigo-600: #4577e6;
+  --color-indigo-500: #528bff;
+  --color-indigo-400: #6ea3ff;
+  --color-indigo-300: #9cc0f5;
+
+  --color-green-500: #98c379;
+  --color-green-400: #a9d08a;
+  --color-green-300: #b8d99c;
+
+  --color-yellow-400: #e5c07b;
+  --color-yellow-300: #edcf98;
+
+  --color-red-400: #e06c75;
+  --color-red-300: #e88b92;
+
+  --color-emerald-300: #56b6c2;
+}
+
+html[data-theme='dracula'] {
+  --color-foreground: #f8f8f2;
+
+  --color-gray-950: #21222c;
+  --color-gray-900: #282a36;
+  --color-gray-800: #343645;
+  --color-gray-700: #44475a;
+  --color-gray-600: #565972;
+  --color-gray-500: #6272a4;
+  --color-gray-400: #7d88b8;
+  --color-gray-300: #c9cbe0;
+  --color-gray-200: #e2e3ef;
+  --color-gray-100: #f0f0f6;
+  --color-gray-50: #f8f8f2;
+
+  --color-blue-600: #6272a4;
+  --color-blue-400: #8be9fd;
+  --color-blue-300: #a5eefb;
+
+  --color-indigo-600: #7c5cc7;
+  --color-indigo-500: #bd93f9;
+  --color-indigo-400: #caa6fb;
+  --color-indigo-300: #ddc7fc;
+
+  --color-green-500: #50fa7b;
+  --color-green-400: #6ffb92;
+  --color-green-300: #8dfcaa;
+
+  --color-yellow-400: #f1fa8c;
+  --color-yellow-300: #f5fca8;
+
+  --color-red-400: #ff5555;
+  --color-red-300: #ff7b7b;
+
+  --color-emerald-300: #8be9fd;
+}
+
+html[data-theme='nord'] {
+  --color-foreground: #eceff4;
+
+  --color-gray-950: #242933;
+  --color-gray-900: #2e3440;
+  --color-gray-800: #3b4252;
+  --color-gray-700: #434c5e;
+  --color-gray-600: #4c566a;
+  --color-gray-500: #616e88;
+  --color-gray-400: #7b88a1;
+  --color-gray-300: #d8dee9;
+  --color-gray-200: #e5e9f0;
+  --color-gray-100: #eceff4;
+  --color-gray-50: #f4f6f9;
+
+  --color-blue-600: #5e81ac;
+  --color-blue-400: #81a1c1;
+  --color-blue-300: #88c0d0;
+
+  --color-indigo-600: #5e81ac;
+  --color-indigo-500: #81a1c1;
+  --color-indigo-400: #88c0d0;
+  --color-indigo-300: #a3c1e0;
+
+  --color-green-500: #a3be8c;
+  --color-green-400: #b5cca0;
+  --color-green-300: #c6d7b5;
+
+  --color-yellow-400: #ebcb8b;
+  --color-yellow-300: #f0d8a5;
+
+  --color-red-400: #bf616a;
+  --color-red-300: #d08088;
+
+  --color-emerald-300: #8fbcbb;
+}
+
+html[data-theme='tokyonight'] {
+  --color-foreground: #c0caf5;
+
+  --color-gray-950: #16161e;
+  --color-gray-900: #1a1b26;
+  --color-gray-800: #1f2335;
+  --color-gray-700: #292e42;
+  --color-gray-600: #3b4261;
+  --color-gray-500: #565f89;
+  --color-gray-400: #737aa2;
+  --color-gray-300: #a9b1d6;
+  --color-gray-200: #c0caf5;
+  --color-gray-100: #d5d9f0;
+  --color-gray-50: #ebedf9;
+
+  --color-blue-600: #4d62a6;
+  --color-blue-400: #7aa2f7;
+  --color-blue-300: #9db3f9;
+
+  --color-indigo-600: #5e46a8;
+  --color-indigo-500: #bb9af7;
+  --color-indigo-400: #cbb0f9;
+  --color-indigo-300: #d5bffb;
+
+  --color-green-500: #9ece6a;
+  --color-green-400: #b0d97f;
+  --color-green-300: #c1e195;
+
+  --color-yellow-400: #e0af68;
+  --color-yellow-300: #ebc488;
+
+  --color-red-400: #f7768e;
+  --color-red-300: #f994a6;
+
+  --color-emerald-300: #7dcfff;
 }
 
 /* Markdown body styles */
@@ -187,14 +389,14 @@ html[data-theme='rose'] {
 .markdown-body blockquote {
   margin: 0.5em 0;
   padding: 0.25em 0.75em;
-  border-left: 3px solid #4b5563;
-  color: #9ca3af;
+  border-left: 3px solid var(--ccm-input-border);
+  color: var(--ccm-subtle);
 }
 
 .markdown-body hr {
   margin: 0.75em 0;
   border: none;
-  border-top: 1px solid #374151;
+  border-top: 1px solid var(--ccm-border);
 }
 
 .markdown-body img {

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -6,6 +6,7 @@ import { ShareModal } from '../components/ShareModal';
 import { resolveTagColor, TAG_COLOR_OPTIONS } from '../components/TagColors';
 import { TagManager } from '../components/TagManager';
 import { EnvFilesEditor } from '../components/EnvFilesEditor';
+import { ProjectTodoList } from '../components/Projects/ProjectTodoList';
 
 // ── Shared: identity warning ──────────────────────────────────────────────────
 
@@ -1038,6 +1039,8 @@ export function ProjectsPage() {
                       tagColorMap={tagColorMap}
                     />
                   </div>
+
+                  <ProjectTodoList projectId={p.id} />
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary

Per-project **Todo list**: manage prompt templates, one-click **▶ Run** to create a Task and jump to Chat. Rebased onto latest `main` and with @youchengsong's review addressed.

- Data: new `project_todos` table (`title`, `prompt`, `status` open/done/archived, `sort_order`, `created_task_id`).
- API: `GET/POST/PATCH/DELETE /api/projects/{id}/todos`.
- UI: collapsible list inside each Project card (`ProjectTodoList`), add/edit/run/archive + a modal.

> ⚠️ **Stacked on #29** (semantic themes) so the todo UI can use the semantic token classes the review asked for. **Merge after #29.** The extra files in the diff are #29's; once #29 merges this shrinks to the 15 todo files.

## Review responses (thanks @youchengsong)

- **#1** DELETE now **permanently deletes**; archive/restore is a soft `PATCH status='archived'`/`'open'` — no more DELETE-means-archive.
- **#2** timezone-aware timestamps (`datetime.now(timezone.utc)`).
- **#4** running a todo marks it **done** + records the spawned task, then navigates (closes the loop, prevents double-Run).
- **#5** `ProjectTodoList` + `TodoModal` use **semantic token classes** (`bg-surface`, `text-muted`, `border-border`, `bg-accent`, …), not hardcoded `gray-*`.
- **#6** project delete keeps the explicit todo cascade (SQLite doesn't enforce FKs) **with a comment** explaining why.
- **#7** modal closes on **Esc** and **backdrop click**.
- **#8** `sort_order` updatable via PATCH.
- **#10** **fixed the alembic head** — `down_revision` pointed at `e7f8a9b0c1d2`, which after the `user_skills` migrations landed created a **second head** and broke `upgrade head`; now chains off the real head `a2628601782f`.
- **#3 (target_repo)** verified a non-issue: `target_repo` is optional and the dispatcher resolves it from `project_id` (no 400).

## Design additions

- `created_task_id` on the todo (soft link, no FK) records todo→task provenance — replaces fragile title-matching and grounds a future "task completed → mark todo done" sync. (Chosen over a `source_todo_id` FK on the hot `tasks` table.)
- **Archived-todo recovery UI**: "Show archived" toggle + Restore + Delete-permanently (archived was previously an unrecoverable dead end).
- Explicit status transitions; finalized design at `docs/plans/project-todo-design.md`.

Also **drops an unrelated provider-defaulting change** that the original commit had bundled in (it altered global `create_task` behavior and conflicted with an existing dispatcher test).

## Validation

- Backend: todo API + migration + task tests green (`test_api_project_todos`, `test_alembic_migrations`). `alembic heads` = single head.
- Frontend: `tsc` + **4 vitest** tests + `npm run build` green.
- Adversarial self-review caught & fixed one bug: the "Show archived" toggle was unreachable (archived view was dead code); now always available when expanded, with a regression test.
- Pre-existing flaky dispatcher/worker tests (failing on `origin/main` too) are untouched.