### PR TITLE
feat: add claude-fable-5[1m] model option

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
     default_provider: str = "claude"
     provider_options: str = "claude,codex"
     default_model: str = "claude-opus-4-6"
-    model_options: str = "default,claude-sonnet-5,claude-sonnet-5[1m],claude-fable-5,claude-opus-4-6,claude-opus-4-6[1m],claude-opus-4-7,claude-opus-4-7[1m],claude-opus-4-8,claude-opus-4-8[1m],claude-sonnet-4-6,claude-sonnet-4-6[1m],claude-haiku-4-5"  # comma-separated
+    model_options: str = "default,claude-sonnet-5,claude-sonnet-5[1m],claude-fable-5,claude-fable-5[1m],claude-opus-4-6,claude-opus-4-6[1m],claude-opus-4-7,claude-opus-4-7[1m],claude-opus-4-8,claude-opus-4-8[1m],claude-sonnet-4-6,claude-sonnet-4-6[1m],claude-haiku-4-5"  # comma-separated
     default_codex_model: str = "gpt-5.5"
     codex_model_options: str = "default,gpt-5.6,gpt-5.5,gpt-5.4,gpt-5.4-mini,gpt-5.3-codex-spark"  # comma-separated
     codex_effort_options: str = "low,medium,high,xhigh"  # codex supports reasoning levels, no 'max'


### PR DESCRIPTION
## Summary
- Add `claude-fable-5[1m]` to model_options in `backend/config.py`, enabling 1M context window selection for Fable 5

## Test plan
- [x] Verified Claude CLI natively supports `[1m]` suffix (returns `contextWindow: 1000000`)
- [x] Backend passes model name to CLI unchanged — no stripping needed
- [x] Context window estimation in `instance_manager` and `dispatcher` already handles `[1m]` and `fable` keywords
- [x] Frontend `ChatView.tsx` context bar already handles fable/1m models

🤖 Generated with [Claude Code](https://claude.com/claude-code)