### PR TITLE
feat: update button fallback for non-systemd uvicorn

### DIFF
--- a/backend/services/update_service.py
+++ b/backend/services/update_service.py
@@ -7,7 +7,9 @@ import json
 import logging
 import os
 import shutil
+import signal
 import subprocess
+import sys
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -333,13 +335,7 @@ class UpdateService:
             await self._broadcast("restarting", message="服务即将重启...")
             await asyncio.sleep(1)
 
-            systemctl = self._tools["systemctl"]
-            subprocess.Popen(
-                [self._tools["bash"], "-c", f"sleep 2 && {systemctl} --user restart {self._service_name}"],
-                stdout=open(f"/tmp/ccm-restart-{self.port}.log", "w"),
-                stderr=subprocess.STDOUT,
-                start_new_session=True,
-            )
+            self._restart_service()
             return {"status": "rolling_back", "old_commit": old_commit}
 
     # ---- Pipeline implementation ----
@@ -596,15 +592,44 @@ class UpdateService:
         await self._broadcast("restarting", message="服务即将重启，请等待自动重连...")
         await asyncio.sleep(1)
 
-        systemctl = self._tools["systemctl"]
-        subprocess.Popen(
-            [self._tools["bash"], "-c", f"sleep 2 && {systemctl} --user restart {self._service_name}"],
-            stdout=open(f"/tmp/ccm-restart-{self.port}.log", "w"),
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
-        )
+        self._restart_service()
 
     # ---- Helpers ----
+
+    def _is_managed_by_systemd(self) -> bool:
+        """Check if this process was started by systemd."""
+        try:
+            result = subprocess.run(
+                [self._tools["systemctl"], "--user", "is-active", self._service_name],
+                capture_output=True, text=True, timeout=5,
+            )
+            return result.stdout.strip() == "active"
+        except Exception:
+            return False
+
+    def _restart_service(self):
+        """Restart via systemd if managed, otherwise re-exec the process."""
+        if self._is_managed_by_systemd():
+            subprocess.Popen(
+                [self._tools["bash"], "-c",
+                 f"sleep 2 && {self._tools['systemctl']} --user restart {self._service_name}"],
+                stdout=open(f"/tmp/ccm-restart-{self.port}.log", "w"),
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+        else:
+            uvicorn_cmd = (
+                f"sleep 2 && kill {os.getpid()} && sleep 1 && "
+                f"cd {self.project_dir} && "
+                f"{sys.executable} -m uvicorn backend.main:app "
+                f"--host 0.0.0.0 --port {self.port}"
+            )
+            subprocess.Popen(
+                [self._tools["bash"], "-c", uvicorn_cmd],
+                stdout=open(f"/tmp/ccm-restart-{self.port}.log", "w"),
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
 
     async def _backup_database(self) -> str:
         import sqlite3 as _sqlite3


### PR DESCRIPTION
## Summary
- Update button now works for users who start CCM with `uvicorn` directly (without systemd)
- Detects whether the process is managed by systemd: if yes, uses `systemctl --user restart`; if not, falls back to kill + re-exec `uvicorn`
- Both restart paths (normal update + rollback) are covered

## Context
Many users run CCM via bare `uvicorn` without configuring a systemd service, causing the frontend update button to fail on the restart step.

## Test plan
- [x] systemd-managed service: restart via `systemctl --user restart` (unchanged behavior)
- [ ] bare `uvicorn` start: restart via kill + re-exec fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)