### PR TITLE
fix: compact_retry skipped when session_id is None

### DIFF
--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -2820,8 +2820,13 @@ class GlobalDispatcher:
         original_skills: dict = {}
         async with self.db_factory() as db:
             task = await db.get(Task, task_id)
-            if not task or not task.session_id:
-                logger.warning(f"Task {task_id} not found or no session, skipping queued message")
+            if not task:
+                logger.warning(f"Task {task_id} not found, skipping queued message")
+                return
+            # compact_retry starts a fresh session with the compacted summary,
+            # so it doesn't need an existing session_id to resume.
+            if not task.session_id and msg.source != "compact_retry":
+                logger.warning(f"Task {task_id} no session, skipping queued message")
                 return
 
             # Recover before resuming when the session can't be resumed:


### PR DESCRIPTION
## Summary
- Fix bug where `compact_retry` messages were silently dropped in `_process_queued_message`
- When "Prompt is too long" triggers, `instance_manager` clears `session_id` and enqueues a `compact_retry` message. But `dispatcher` skipped it because `session_id` was `None`
- Now allows `compact_retry` messages to proceed without an existing `session_id`, since they start a fresh session with the compacted summary

## Symptom
Task gets stuck with locked input after "Prompt is too long" error — the compact retry never fires.

## Test plan
- [ ] Trigger "Prompt too long" by filling context window (e.g. haiku model + long messages)
- [ ] Verify task auto-recovers with compacted summary in a new session instead of getting stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)