### PR TITLE
fix: project filter ignored when chat panel is open

### DIFF
--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -171,6 +171,7 @@ export function TasksPage({ chatTaskId, onChatTaskChange }: TasksPageProps) {
     const prev = prevFilter.current;
     if (prev.statusFilterParam !== statusFilterParam || prev.showArchived !== showArchived || prev.projectFilter !== projectFilter || prev.starredFilter !== starredFilter || prev.unreadFilter !== unreadFilter) {
       setPage(1);
+      skipFreezeOnce.current = true;
       prevFilter.current = { statusFilterParam, showArchived, projectFilter, starredFilter, unreadFilter };
     }
   }, [statusFilterParam, showArchived, projectFilter, starredFilter, unreadFilter]);


### PR DESCRIPTION
## Summary
- Chat 打开时 sidebar 的 freeze 逻辑会保留所有旧 task，导致切换 project 过滤器无效
- 过滤器变化时设置 `skipFreezeOnce` 让 freeze 放行一次，用服务端过滤结果替换列表

## Test plan
- [ ] 打开任意 task 的 chat 面板
- [ ] 切换 project 过滤器，确认任务列表正确过滤
- [ ] 切换 status/starred/unread 等其他过滤器，同样正确生效
- [ ] 不切换过滤器时，sidebar 顺序仍然保持 freeze（不因轮询闪烁）

🤖 Generated with [Claude Code](https://claude.com/claude-code)