### PR TITLE
fix: update_migrate.sh self-escape trampoline — 让修复能到达仍跑旧后端的存量部署

### DIFF
--- a/backend/tests/test_service_update.py
+++ b/backend/tests/test_service_update.py
@@ -169,6 +169,7 @@ async def test_rollback_non_systemd_delegates_to_script_kill_mode(tmp_path):
 
 def test_is_managed_true_only_when_self_in_service_cgroup(tmp_path):
     svc = _make_service(tmp_path)
+    svc._service_name = "ccm.service"  # pin: settings.service_name varies per .env
     with patch.object(svc, "_cgroup_text",
                       return_value="0::/user.slice/user-1000.slice/user@1000.service/app.slice/ccm.service\n"):
         assert svc._is_managed_by_systemd() is True
@@ -305,3 +306,84 @@ def test_migrate_script_trap_starts_service_even_if_killed(tmp_path):
     calls = call_log.read_text()
     assert "stop ccm.service" in calls
     assert "start ccm.service" in calls, "EXIT trap must restart the service"
+
+
+# ---- self-escape trampoline: the script itself must survive old backends ----
+# The 2026-07-16 production outage: a pre-systemd-run backend spawned the
+# (freshly pulled, already "fixed") script as a plain uvicorn child — inside
+# the service cgroup — and its own `systemctl stop` killed it mid-stop.
+# Fixing the Python spawn can't reach old deployments (they run their old
+# Python), but the script is pulled fresh each update, so it must save itself.
+
+
+def _self_cgroup_leaf() -> str | None:
+    """Leaf name of the current process's cgroup (cgroup v2), e.g.
+    'session-42.scope' — lets tests trigger the trampoline's match for real."""
+    try:
+        text = Path("/proc/self/cgroup").read_text()
+    except OSError:
+        return None
+    path = text.strip().splitlines()[0].split("::", 1)[-1]
+    leaf = path.rstrip("/").rsplit("/", 1)[-1]
+    return leaf or None
+
+
+def _stub_systemd_run(tmp_path: Path) -> Path:
+    """Replace systemd-run with a logger so the escape is observable."""
+    run_log = tmp_path / "systemd-run.log"
+    stub = tmp_path / "bin" / "systemd-run"
+    stub.write_text(f'#!/bin/bash\necho "$@" >> {run_log}\nexit 0\n')
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+    return run_log
+
+
+def test_migrate_script_escapes_own_service_cgroup(tmp_path):
+    """Launched inside the service's own cgroup, the script must re-exec via
+    systemd-run and NOT run `systemctl stop` from its doomed position."""
+    env, call_log = _script_env(tmp_path)
+    leaf = _self_cgroup_leaf()
+    if not leaf:
+        pytest.skip("cgroup v2 unavailable")
+    run_log = _stub_systemd_run(tmp_path)
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    # SERVICE_NAME = our own cgroup leaf → the in-service detection matches
+    result = subprocess.run(
+        ["bash", str(SCRIPT), str(project), "deadbeef",
+         str(tmp_path / "backup.db"), "8999",
+         str(tmp_path / "claude_manager.db"), leaf, "migrate"],
+        env=env, timeout=30, capture_output=True, text=True,
+    )
+
+    assert result.returncode == 0
+    calls = run_log.read_text()
+    assert "--setenv=CCM_ESCAPED=1" in calls
+    assert str(SCRIPT) in calls, "must re-exec itself by absolute path"
+    assert f"--working-directory={project}" in calls, \
+        "transient units don't inherit cwd — must be pinned"
+    stop_calls = call_log.read_text() if call_log.exists() else ""
+    assert "stop" not in stop_calls, "must never stop the service from inside its cgroup"
+
+
+def test_migrate_script_trampoline_runs_once(tmp_path):
+    """CCM_ESCAPED=1 (the re-exec'd copy) must skip the trampoline and proceed
+    into the normal flow — no infinite escape loop."""
+    env, call_log = _script_env(tmp_path)
+    leaf = _self_cgroup_leaf()
+    if not leaf:
+        pytest.skip("cgroup v2 unavailable")
+    run_log = _stub_systemd_run(tmp_path)
+    env["CCM_ESCAPED"] = "1"
+
+    # project dir intentionally missing: proceeding past the trampoline means
+    # dying at the `cd` guard with exit 1 — proof the escape was skipped
+    result = subprocess.run(
+        ["bash", str(SCRIPT), str(tmp_path / "missing"), "deadbeef",
+         str(tmp_path / "backup.db"), "8999",
+         str(tmp_path / "claude_manager.db"), leaf, "migrate"],
+        env=env, timeout=30, capture_output=True, text=True,
+    )
+
+    assert result.returncode == 1
+    assert not run_log.exists(), "escaped copy must not systemd-run again"

--- a/scripts/update_migrate.sh
+++ b/scripts/update_migrate.sh
@@ -18,6 +18,35 @@ PYTHON_BIN="${9:-python3}"
 STATUS_FILE="/tmp/ccm-update-status-${PORT}.json"
 LOG_FILE="/tmp/ccm-update-migrate-${PORT}.log"
 
+# ---- self-escape trampoline -------------------------------------------------
+# Old (pre-systemd-run) backends spawn this script as a plain uvicorn child, so
+# it starts INSIDE the service's cgroup and `systemctl stop` below would kill it
+# mid-stop (KillMode=control-group ignores setsid/nohup), leaving the service
+# permanently down with the status file frozen at "stopping". The script itself
+# is freshly pulled during the update, so fixing it HERE reaches those old
+# deployments: detect the situation and re-exec into a transient unit first.
+# Backends that already launch us via systemd-run don't match and skip this.
+SELF="$(readlink -f "$0")"
+if [ -z "${CCM_ESCAPED:-}" ] && [ "$SERVICE_NAME" != "-" ] \
+    && command -v systemd-run >/dev/null 2>&1; then
+    case "$(cat /proc/self/cgroup 2>/dev/null)" in
+        *"/${SERVICE_NAME}"*)
+            # transient units inherit neither cwd nor env — pin both, and pass
+            # $SELF (absolute) because a relative $0 breaks after the re-exec
+            if systemd-run --user --collect --unit="ccm-update-escape-${PORT}-$$" \
+                --working-directory="$PROJECT_DIR" \
+                --setenv=CCM_ESCAPED=1 \
+                --setenv=PATH="$PATH" \
+                --property=StandardOutput="append:${LOG_FILE}" \
+                --property=StandardError=inherit \
+                /bin/bash "$SELF" "$@"; then
+                exit 0  # escaped copy owns the update from here
+            fi
+            echo "cgroup escape failed at $(date -Iseconds) — continuing in-place (may die at svc_stop)" >> "$LOG_FILE"
+            ;;
+    esac
+fi
+
 # Everything below (git/uv/alembic/relative DB paths) assumes the project dir;
 # abort outright if it is gone rather than running them somewhere random.
 cd "$PROJECT_DIR" || exit 1
@@ -66,6 +95,7 @@ svc_start() {
 }
 
 echo "=== update_migrate.sh started at $(date -Iseconds) (mode=$MODE) ===" > "$LOG_FILE"
+echo "cgroup: $(cat /proc/self/cgroup 2>/dev/null) (escaped=${CCM_ESCAPED:-0})" >> "$LOG_FILE"
 
 # 1. Stop service
 write_status "stopping" "正在停止服务..." "stop_service"


### PR DESCRIPTION
## 问题

2026-07-16 生产事故：systemd 托管的部署点「一键更新」，且更新内容包含 alembic 迁移时，服务停止后**永远不会被重新拉起**，状态文件永久冻结在 `"status": "stopping"`，migrate 日志只有启动一行。需要 SSH 手动 `systemctl --user start` 才能救回。

## 根因

旧后端（#38 之前）用裸 `subprocess.Popen(..., start_new_session=True)` 拉起 `update_migrate.sh`。`start_new_session` 只逃离进程组，**逃不出 systemd 的 cgroup**——脚本仍活在服务自己的 cgroup 里。脚本第一步 `systemctl --user stop` 触发 `KillMode=control-group` 整锅端，**把正在发号施令的脚本自己也杀了**，此后无人执行 start。服务是干净 stop（非 failure），`Restart=on-failure` 不生效 → 永久躺平。

自 2026-06-25（`e939344` 一键更新上线）起就存在，三周内 main 进了 16 个迁移文件、分布在 8 个发布日，每一个都是触发点。

## 为什么 #38 修不到存量用户

#38 把 Python 侧的 spawn 改成了 `systemd-run`（独立 cgroup），修复正确。但**跑更新的是用户机器上的旧 Python**——修复要生效得先活着更新一次，鸡生蛋。今天的生产事故正是「装 #38 的那次更新」自己被这个 bug 杀死的：13:58:50 pull 到新代码，13:59:28 旧 Python 把新脚本 spawn 进服务 cgroup，卒。

关键观察：**`update_migrate.sh` 是更新时新拉下来再执行的**（时间线可证）。所以修在脚本里，能穿透旧后端到达所有存量部署。

## 修复

脚本顶部加自逃逸跳板：读 `/proc/self/cgroup`，发现自己在 `SERVICE_NAME` 的 cgroup 里时，用 `systemd-run --user --collect` 把自己重新拉进独立 transient unit 再干活。

失败模式刻意收敛为「最坏 = 维持现状」：
- 新后端（#38）拉起的脚本已在 `ccm-update-*` cgroup → 检测不匹配，跳板不触发，零影响
- 裸 uvicorn（`SERVICE_NAME="-"`）显式跳过（该形态本就免疫：`svc_stop` 是 kill 单进程，不炸 cgroup）
- `systemd-run` 不存在/失败 → 记日志后原地继续（= 现状，不更糟）
- `CCM_ESCAPED` 哨兵防无限逃逸；`readlink -f` + `--working-directory` 双保险（transient unit 不继承 cwd，裸 `$0` 相对路径会摔死——实测踩过）

另附一行 cgroup 诊断日志（下次出事时 migrate 日志能直接看到脚本跑在哪个 cgroup、是否逃逸过）。

## 验证

- 单测 14/14 全绿，新增 2 个回归测试：逃逸时必须带 `CCM_ESCAPED=1`/绝对路径/pin cwd 且绝不从 cgroup 内执行 stop；已逃逸副本必须跳过跳板直接干活
- 顺手修了 `test_is_managed_true_only_when_self_in_service_cgroup` 对 `.env` 里 `SERVICE_NAME` 的隐式依赖（此前只在恰好叫 `ccm.service` 的机器上能过）
- 真机 A/B（ccm-test.service，把脚本进程真实写进服务 cgroup 复现）：无跳板 → 服务停在 inactive、状态冻结 `STOPPING`，与生产事故逐项吻合；有跳板 → journal 可见脚本先进入自己的 transient unit，随后 stop → migrate → start，服务回到 active / HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)