### PR TITLE
feat: 侧栏与任务列表宽度可拖拽调整

### DIFF
--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import {
   Bot, Menu, X, LayoutDashboard, ListTodo, FolderGit2, KeyRound,
@@ -36,9 +36,52 @@ interface NavItem {
  * 高度 = h-12 (3rem) + 底边框。 */
 export function AppShell({ currentPage, onNavigate, wide, children }: AppShellProps) {
   const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const [navWidth, setNavWidth] = useState(() => {
+    const saved = localStorage.getItem('ccm-nav-width');
+    return saved ? Math.max(180, Math.min(400, Number(saved))) : 240;
+  });
+  const navDragging = useRef(false);
+  const navDragStartX = useRef(0);
+  const navDragStartW = useRef(240);
+
+  const handleNavDragStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    navDragging.current = true;
+    navDragStartX.current = e.clientX;
+    navDragStartW.current = navWidth;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    const onMove = (ev: MouseEvent) => {
+      if (!navDragging.current) return;
+      const w = Math.max(180, Math.min(400, navDragStartW.current + ev.clientX - navDragStartX.current));
+      setNavWidth(w);
+    };
+    const onUp = () => {
+      navDragging.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      setNavWidth(w => { localStorage.setItem('ccm-nav-width', String(w)); return w; });
+    };
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  }, [navWidth]);
+
   // 主题图标集：feishu → IconPark two-tone / apple → Ionicons；其余 Lucide
   const theme = useTheme();
   const iconSet = getThemeOption(theme).iconSet;
+  const navResizable = theme !== 'feishu' && theme !== 'apple';
+
+  const [isLg, setIsLg] = useState(() => window.innerWidth >= 1024);
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 1024px)');
+    const h = (e: MediaQueryListEvent) => setIsLg(e.matches);
+    mq.addEventListener('change', h);
+    return () => mq.removeEventListener('change', h);
+  }, []);
 
   const ccUser = JSON.parse(localStorage.getItem('cc_user') || '{}');
   const isAdmin = ccUser.role === 'admin' || ccUser.role === 'super_admin' || !ccUser.id;
@@ -134,13 +177,30 @@ export function AppShell({ currentPage, onNavigate, wide, children }: AppShellPr
   return (
     <div className="min-h-screen bg-gray-900 text-foreground overflow-x-clip">
       {/* 桌面侧栏 */}
-      <aside data-shell-sidebar className="hidden lg:flex fixed inset-y-0 left-0 z-40 w-60 flex-col bg-gray-950 border-r border-gray-800">
-        <div data-shell-brand-row className="h-14 shrink-0 flex items-center px-4 border-b border-gray-800/70">
-          {brand}
-        </div>
-        {navList}
-        {userFooter}
-      </aside>
+      {navResizable ? (
+        <>
+          <aside data-shell-sidebar className="hidden lg:flex fixed inset-y-0 left-0 z-40 flex-col bg-gray-950 border-r border-gray-800" style={{ width: navWidth }}>
+            <div data-shell-brand-row className="h-14 shrink-0 flex items-center px-4 border-b border-gray-800/70">
+              {brand}
+            </div>
+            {navList}
+            {userFooter}
+          </aside>
+          <div
+            onMouseDown={handleNavDragStart}
+            className="hidden lg:block fixed inset-y-0 z-40 w-1 cursor-col-resize bg-transparent hover:bg-indigo-500/40 active:bg-indigo-500/60 transition-colors"
+            style={{ left: navWidth }}
+          />
+        </>
+      ) : (
+        <aside data-shell-sidebar className="hidden lg:flex fixed inset-y-0 left-0 z-40 w-60 flex-col bg-gray-950 border-r border-gray-800">
+          <div data-shell-brand-row className="h-14 shrink-0 flex items-center px-4 border-b border-gray-800/70">
+            {brand}
+          </div>
+          {navList}
+          {userFooter}
+        </aside>
+      )}
 
       {/* 移动端抽屉 */}
       {drawerOpen && (
@@ -163,7 +223,7 @@ export function AppShell({ currentPage, onNavigate, wide, children }: AppShellPr
       )}
 
       {/* 右侧主列：sticky 顶栏 + 页面内容 */}
-      <div data-shell-main className="lg:pl-60 flex flex-col min-h-screen">
+      <div data-shell-main className={`flex flex-col min-h-screen ${navResizable ? '' : 'lg:pl-60'}`} style={navResizable && isLg ? { paddingLeft: navWidth } : undefined}>
         <header className="sticky top-0 z-30 bg-gray-900 border-b border-gray-800 pt-[env(safe-area-inset-top)]">
           <div className="h-12 flex items-center gap-2 px-3 sm:px-4">
             <button

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -517,6 +517,38 @@ export function TasksPage({ chatTaskId, onChatTaskChange }: TasksPageProps) {
   );
 
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarWidth, setSidebarWidth] = useState(() => {
+    const saved = localStorage.getItem('ccm-sidebar-width');
+    return saved ? Math.max(200, Math.min(600, Number(saved))) : 260;
+  });
+  const isDragging = useRef(false);
+  const dragStartX = useRef(0);
+  const dragStartWidth = useRef(260);
+
+  const handleDragStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    isDragging.current = true;
+    dragStartX.current = e.clientX;
+    dragStartWidth.current = sidebarWidth;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    const onMove = (ev: MouseEvent) => {
+      if (!isDragging.current) return;
+      const newWidth = Math.max(200, Math.min(600, dragStartWidth.current + ev.clientX - dragStartX.current));
+      setSidebarWidth(newWidth);
+    };
+    const onUp = () => {
+      isDragging.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      setSidebarWidth(w => { localStorage.setItem('ccm-sidebar-width', String(w)); return w; });
+    };
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  }, [sidebarWidth]);
 
   if (splitMode) {
     const sidebarStatusColors: Record<string, string> = {
@@ -531,7 +563,7 @@ export function TasksPage({ chatTaskId, onChatTaskChange }: TasksPageProps) {
     return (
       <div className="flex h-[calc(100vh-49px)] -m-4">
         {sidebarOpen && (
-          <div className="w-[260px] shrink-0 flex flex-col border-r border-gray-800 bg-gray-900/50">
+          <div className="shrink-0 flex flex-col border-r border-gray-800 bg-gray-900/50" style={{ width: sidebarWidth }}>
             <div className="px-3 py-2 border-b border-gray-800 flex items-center justify-between shrink-0">
               <span className="text-xs font-medium text-gray-400">Tasks</span>
               <button
@@ -628,6 +660,12 @@ export function TasksPage({ chatTaskId, onChatTaskChange }: TasksPageProps) {
               </div>
             )}
           </div>
+        )}
+        {sidebarOpen && (
+          <div
+            onMouseDown={handleDragStart}
+            className="w-1 shrink-0 cursor-col-resize bg-transparent hover:bg-indigo-500/40 active:bg-indigo-500/60 transition-colors"
+          />
         )}
         {!sidebarOpen && (
           <div className="shrink-0 border-r border-gray-800 bg-gray-900/50 flex flex-col items-center pt-2">


### PR DESCRIPTION
## Summary
- AppShell 左侧导航栏支持拖拽调整宽度（180–400px），默认 240px，拖拽手柄 hover 显示靛蓝色指示条
- TasksPage 分屏模式任务列表支持拖拽调整宽度（200–600px），默认 260px
- 宽度持久化到 localStorage，刷新后保留
- 飞书/苹果主题因结构复刻限制禁用导航栏拖拽

## Test plan
- [ ] 桌面端侧栏右边缘出现拖拽光标（col-resize），拖拽可调整宽度
- [ ] Tasks 分屏模式任务列表右边缘可拖拽调整宽度
- [ ] 刷新页面后宽度从 localStorage 恢复
- [ ] 飞书/苹果主题下导航栏拖拽手柄不显示
- [ ] 移动端抽屉导航不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)