### PR TITLE
fix: PTY 模式 chat turn 结束后 task status 卡在 executing

### DIFF
--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -3133,10 +3133,27 @@ class GlobalDispatcher:
                     logger.exception(f"Failed to restore enabled_skills for task {task_id}")
 
             # PTY mode: the persistent session stays alive after a turn, so
-            # _consume_output's process_exit broadcast never fires. The frontend
-            # relies on this event to clear the "thinking" spinner and re-enable
-            # the input box.
+            # _consume_output's process_exit broadcast never fires. Two things
+            # the frontend needs that _consume_output normally handles:
+            #  1. task.status back to "completed" in DB (poll-based fallback)
+            #  2. process_exit WS event (clears spinner immediately)
+            # Without (1) the 5s poll keeps seeing "executing" even after the
+            # spinner is cleared, re-pinning the UI into "running" state.
             if self.instance_manager.pty_mode_enabled:
+                try:
+                    async with self.db_factory() as db:
+                        result = await db.execute(
+                            update(Task)
+                            .where(Task.id == task_id, Task.status == "executing")
+                            .values(status="completed", completed_at=datetime.utcnow(), error_message=None)
+                        )
+                        await db.commit()
+                        if result.rowcount:
+                            from backend.services.task_events import broadcast_status_change
+                            await broadcast_status_change(task_id, "completed", inst_id)
+                except Exception:
+                    logger.exception("Failed to restore task %d status after PTY turn", task_id)
+
                 process = self.instance_manager.processes.get(inst_id)
                 exit_code = getattr(process, "returncode", 0) if process else 0
                 await self.broadcaster.broadcast(f"task:{task_id}", {


### PR DESCRIPTION
## Summary
- PTY 模式下 chat turn 结束后，task.status 在 DB 里停留在 `executing`，没有回到 `completed`
- 原因：`_consume_output` 不走 PTY（进程不退出），dispatcher finally 块只发了 `process_exit` WS 事件，遗漏了 DB status 回写
- 前端 5s 轮询拿到 `executing` → UI 一直显示"运行中"（Interrupt 按钮常驻、发送按钮停在排队模式）
- 修复：PTY `process_exit` 广播前，把 task status 写回 `completed` 并广播 `status_change`

## Test plan
- [ ] PTY 模式下发消息，turn 结束后 task status 回到 completed
- [ ] 发送按钮恢复正常模式（靛蓝色），Interrupt 按钮消失
- [ ] WS 断连重连后状态仍然正确
- [ ] 非 PTY 模式不受影响（989 tests passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)