### PR TITLE
fix: sliding JWT token refresh to prevent session expiry

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -377,6 +377,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["X-Refreshed-Token"],
 )
 
 app.include_router(tasks_router)

--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -1,8 +1,12 @@
+from datetime import datetime, timezone
+
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from backend.config import settings
+
+JWT_REFRESH_THRESHOLD_DAYS = 7
 
 
 class TokenAuthMiddleware(BaseHTTPMiddleware):
@@ -73,6 +77,12 @@ class TokenAuthMiddleware(BaseHTTPMiddleware):
                 request.state.user_id = payload.get("user_id")
                 request.state.user_role = payload.get("role", "member")
                 request.state.auth_type = "jwt"
+                # Sliding refresh: if token expires within threshold, flag for refresh
+                exp = payload.get("exp")
+                if exp:
+                    remaining = datetime.fromtimestamp(exp, tz=timezone.utc) - datetime.now(timezone.utc)
+                    if remaining.total_seconds() < JWT_REFRESH_THRESHOLD_DAYS * 86400:
+                        request.state._refresh_jwt = True
             else:
                 return JSONResponse(status_code=401, content={"detail": "Unauthorized"})
 
@@ -84,7 +94,21 @@ class TokenAuthMiddleware(BaseHTTPMiddleware):
                     if path.startswith(prefix):
                         return JSONResponse(status_code=403, content={"detail": "Admin only"})
 
-        return await call_next(request)
+        response = await call_next(request)
+
+        if getattr(request.state, "_refresh_jwt", False):
+            try:
+                from backend.api.auth import create_jwt
+                from backend.database import async_session
+                from backend.models.user import User
+                async with async_session() as db:
+                    user = await db.get(User, request.state.user_id)
+                    if user:
+                        response.headers["X-Refreshed-Token"] = create_jwt(user)
+            except Exception:
+                pass
+
+        return response
 
     @classmethod
     async def _resolve_admin_id(cls):

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -35,6 +35,10 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
     const err = await res.json().catch(() => ({ detail: res.statusText }));
     throw new Error(err.detail || res.statusText);
   }
+  const refreshedToken = res.headers.get('X-Refreshed-Token');
+  if (refreshedToken) {
+    setToken(refreshedToken);
+  }
   return res.json();
 }
 


### PR DESCRIPTION
## Summary
- JWT tokens (30-day expiry) had no refresh mechanism — expired tokens caused silent logout mid-session
- Added sliding refresh in auth middleware: when a JWT has < 7 days remaining, a fresh token is returned via `X-Refreshed-Token` response header
- Frontend `request()` auto-picks up the refreshed token, so active users never get kicked to login
- Added `expose_headers` to CORS config so the browser can read the custom header

## Changes
- `backend/middleware/auth.py`: Check token expiry after decode, generate new token if within threshold
- `backend/main.py`: Expose `X-Refreshed-Token` in CORS headers
- `frontend/src/api/client.ts`: Read `X-Refreshed-Token` from response and update localStorage

## Test plan
- [ ] Login with JWT, verify normal requests work unchanged
- [ ] Manually set JWT_EXPIRE_DAYS to a small value (e.g. 1 minute), verify X-Refreshed-Token header appears
- [ ] Verify frontend auto-stores the new token without user interaction
- [ ] Verify legacy token login is unaffected
- [ ] Backend tests: 754 passed (1 pre-existing failure unrelated)
- [ ] Frontend type check: passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)