### PR TITLE
fix: prevent chat scroll from bleeding to parent task list

### DIFF
--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -1227,7 +1227,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, inline }: Chat
       )}
 
       {/* Messages */}
-      <div ref={messagesContainerRef} className="flex-1 overflow-y-auto p-4 space-y-3 min-h-0">
+      <div ref={messagesContainerRef} className="flex-1 overflow-y-auto overscroll-contain p-4 space-y-3 min-h-0">
         {messages.length === 0 && historyLoading && (
           <div className="flex items-center justify-center gap-2 text-gray-500 mt-20">
             <Loader2 size={16} className="animate-spin" />


### PR DESCRIPTION
## Summary
- Chat 页面滚到底部后继续滑动，滚动事件会穿透到外层任务列表，导致列表跟着滚动
- 在消息容器上添加 `overscroll-contain`（CSS `overscroll-behavior: contain`），阻止 scroll chaining

## Test plan
- [ ] 打开 split 模式（桌面宽屏），进入某个 task 的 chat
- [ ] 滚动聊天消息到最底部，继续往下滑，确认左侧任务列表不再跟着滚动
- [ ] 移动端同样测试：chat 全屏时滚到底，确认底部不会穿透

🤖 Generated with [Claude Code](https://claude.com/claude-code)