### PR TITLE
fix: block scroll propagation when chat content is short

### DIFF
--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -771,6 +771,23 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, inline }: Chat
     };
   }, []);
 
+  // Prevent scroll/touch events from propagating to parent when messages
+  // container is not scrollable (content shorter than viewport)
+  useEffect(() => {
+    const el = messagesContainerRef.current;
+    if (!el) return;
+    const prevent = (e: Event) => {
+      if (el.scrollHeight <= el.clientHeight) {
+        e.preventDefault();
+      }
+    };
+    el.addEventListener('wheel', prevent, { passive: false });
+    el.addEventListener('touchmove', prevent, { passive: false });
+    return () => {
+      el.removeEventListener('wheel', prevent);
+      el.removeEventListener('touchmove', prevent);
+    };
+  }, []);
 
   const loadMoreRef = useRef(loadMoreHistory);
   loadMoreRef.current = loadMoreHistory;


### PR DESCRIPTION
## Summary
- 上一个 PR (#46) 修了内容够长时滚到底的穿透问题（`overscroll-contain`）
- 本 PR 修复内容不够长（无法滚动）时，wheel/touchmove 事件仍然穿透到底层任务列表的问题
- 当 `scrollHeight <= clientHeight`（无可滚动内容）时，`preventDefault` 阻止事件传播

## Test plan
- [ ] 打开一个对话内容很少（不足以滚动）的 task chat
- [ ] 在 chat 区域往下滑/滚，确认底层任务列表不会跟着滚动
- [ ] 对话内容变长后，正常滚动不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)