### PR TITLE
feat: support branch selection in auto-update

### DIFF
--- a/backend/api/system.py
+++ b/backend/api/system.py
@@ -80,6 +80,11 @@ async def distill_skills(db: AsyncSession = Depends(get_db)):
     return await analyze_patterns(db)
 
 
+import re
+
+_BRANCH_RE = re.compile(r'^[a-zA-Z0-9._/\-]+$')
+
+
 class UpdateRequest(BaseModel):
     skip_frontend_build: bool = False
     dry_run: bool = False
@@ -96,6 +101,8 @@ def _get_update_service():
 
 @router.post("/update")
 async def start_update(req: UpdateRequest):
+    if req.branch and not _BRANCH_RE.match(req.branch):
+        raise HTTPException(status_code=400, detail="Invalid branch name")
     svc = _get_update_service()
     if req.dry_run:
         return await svc.dry_run(branch=req.branch)

--- a/backend/api/system.py
+++ b/backend/api/system.py
@@ -84,6 +84,7 @@ class UpdateRequest(BaseModel):
     skip_frontend_build: bool = False
     dry_run: bool = False
     force: bool = False
+    branch: str | None = None
 
 
 def _get_update_service():
@@ -97,10 +98,11 @@ def _get_update_service():
 async def start_update(req: UpdateRequest):
     svc = _get_update_service()
     if req.dry_run:
-        return await svc.dry_run()
+        return await svc.dry_run(branch=req.branch)
     result = await svc.start_update(
         skip_frontend_build=req.skip_frontend_build,
         force=req.force,
+        branch=req.branch,
     )
     if "error" in result:
         raise HTTPException(status_code=409, detail=result["error"])

--- a/backend/services/update_service.py
+++ b/backend/services/update_service.py
@@ -263,14 +263,15 @@ class UpdateService:
             logger.debug("_needs_restart check failed", exc_info=True)
             return False
 
-    async def dry_run(self) -> dict[str, Any]:
+    async def dry_run(self, branch: str | None = None) -> dict[str, Any]:
         """Check for available updates without applying them."""
-        result = await self._run_cmd(["git", "fetch", "origin", "main"], timeout=60)
+        target_branch = branch or "main"
+        result = await self._run_cmd(["git", "fetch", "origin", target_branch], timeout=60)
         if result["returncode"] != 0:
             return {"has_updates": False, "error": result["stderr"]}
 
         head = (await self._run_cmd(["git", "rev-parse", "HEAD"]))["stdout"].strip()
-        origin = (await self._run_cmd(["git", "rev-parse", "origin/main"]))["stdout"].strip()
+        origin = (await self._run_cmd(["git", "rev-parse", f"origin/{target_branch}"]))["stdout"].strip()
 
         if head == origin:
             needs_restart = await self._needs_restart()
@@ -297,6 +298,7 @@ class UpdateService:
 
         return {
             "has_updates": True,
+            "branch": target_branch,
             "commits_behind": len(commits),
             "has_new_migrations": len(migration_files) > 0,
             "migration_count": len(migration_files),
@@ -311,6 +313,7 @@ class UpdateService:
         self,
         skip_frontend_build: bool = False,
         force: bool = False,
+        branch: str | None = None,
     ) -> dict[str, Any]:
         if self._lock.locked():
             if self._current:
@@ -327,7 +330,7 @@ class UpdateService:
         self._current = state
 
         asyncio.create_task(
-            self._run_pipeline(state, skip_frontend_build=skip_frontend_build, force=force)
+            self._run_pipeline(state, skip_frontend_build=skip_frontend_build, force=force, branch=branch)
         )
         return {"update_id": update_id, "status": "started"}
 
@@ -362,10 +365,11 @@ class UpdateService:
         state: UpdateState,
         skip_frontend_build: bool = False,
         force: bool = False,
+        branch: str | None = None,
     ):
         async with self._lock:
             try:
-                await self._pipeline_inner(state, skip_frontend_build, force)
+                await self._pipeline_inner(state, skip_frontend_build, force, branch=branch)
             except Exception as e:
                 state.status = "failed"
                 state.error = str(e)
@@ -378,7 +382,9 @@ class UpdateService:
         state: UpdateState,
         skip_frontend_build: bool,
         force: bool,
+        branch: str | None = None,
     ):
+        target_branch = branch or "main"
         has_new_migrations = False
         has_frontend_changes = False
         has_package_changes = False
@@ -400,7 +406,7 @@ class UpdateService:
             stashed = True
             await self._broadcast("log_line", step="git_pull", log=f"已暂存 {len(dirty_files)} 个本地改动", status="running")
 
-        result = await self._run_cmd(["git", "pull", "--rebase", "origin", "main"], timeout=60, step=step)
+        result = await self._run_cmd(["git", "pull", "--rebase", "origin", target_branch], timeout=60, step=step)
         if result["returncode"] != 0:
             if stashed:
                 await self._run_cmd(["git", "stash", "pop"])

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1029,7 +1029,7 @@ export const api = {
     request<{ ok: boolean }>(`/api/user-skills/${id}`, { method: 'DELETE' }),
 
   // System Update
-  startUpdate: (data: { skip_frontend_build?: boolean; dry_run?: boolean; force?: boolean } = {}) =>
+  startUpdate: (data: { skip_frontend_build?: boolean; dry_run?: boolean; force?: boolean; branch?: string | null } = {}) =>
     request<any>('/api/system/update', { method: 'POST', body: JSON.stringify(data) }),
   getUpdateStatus: () =>
     request<any>('/api/system/update/status'),

--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -162,6 +162,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, inline }: Chat
   const [titleDraft, setTitleDraft] = useState(task.title || '');
   const titleInputRef = useRef<HTMLInputElement>(null);
   const [titleExpanded, setTitleExpanded] = useState(false);
+  const chatRootRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -245,11 +246,16 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, inline }: Chat
     const containerRect = container.getBoundingClientRect();
     const threshold = 30;
 
+    const scrollToNode = (node: HTMLElement) => {
+      const nodeTop = node.offsetTop;
+      container.scrollTo({ top: nodeTop, behavior: 'smooth' });
+    };
+
     if (direction === 'up') {
       for (let i = nodes.length - 1; i >= 0; i--) {
         const rect = nodes[i].getBoundingClientRect();
         if (rect.top < containerRect.top - threshold) {
-          nodes[i].scrollIntoView({ behavior: 'smooth', block: 'start' });
+          scrollToNode(nodes[i]);
           return;
         }
       }
@@ -257,7 +263,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, inline }: Chat
       for (const node of nodes) {
         const rect = node.getBoundingClientRect();
         if (rect.top > containerRect.top + threshold) {
-          node.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          scrollToNode(node);
           return;
         }
       }
@@ -807,32 +813,49 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, inline }: Chat
     };
   }, []);
 
-  // Prevent scroll/touch events from propagating to parent when messages
-  // container is not scrollable (content shorter than viewport)
+  // Prevent scroll/touch events on the entire ChatView from reaching parent
+  // scroll containers (task list). Allows scrolling inside the messages area
+  // but blocks propagation when touching non-scrollable zones (header, input)
+  // or when messages content is shorter than the viewport.
   useEffect(() => {
-    const el = messagesContainerRef.current;
-    if (!el) return;
-    const prevent = (e: Event) => {
-      if (el.scrollHeight <= el.clientHeight) {
+    const root = chatRootRef.current;
+    const msgEl = messagesContainerRef.current;
+    if (!root) return;
+    const handleWheel = (e: WheelEvent) => {
+      if (!msgEl) { e.preventDefault(); return; }
+      const atTop = msgEl.scrollTop <= 0 && e.deltaY < 0;
+      const atBottom = msgEl.scrollTop + msgEl.clientHeight >= msgEl.scrollHeight - 1 && e.deltaY > 0;
+      const notScrollable = msgEl.scrollHeight <= msgEl.clientHeight;
+      if (notScrollable || atTop || atBottom) {
         e.preventDefault();
       }
     };
-    el.addEventListener('wheel', prevent, { passive: false });
-    el.addEventListener('touchmove', prevent, { passive: false });
+    const handleTouch = (e: TouchEvent) => {
+      if (!msgEl) { e.preventDefault(); return; }
+      if (msgEl.scrollHeight <= msgEl.clientHeight) {
+        e.preventDefault();
+      }
+    };
+    root.addEventListener('wheel', handleWheel, { passive: false });
+    root.addEventListener('touchmove', handleTouch, { passive: false });
     return () => {
-      el.removeEventListener('wheel', prevent);
-      el.removeEventListener('touchmove', prevent);
+      root.removeEventListener('wheel', handleWheel);
+      root.removeEventListener('touchmove', handleTouch);
     };
   }, []);
 
   const loadMoreRef = useRef(loadMoreHistory);
   loadMoreRef.current = loadMoreHistory;
 
-  // Auto-scroll only on initial history load
+  // Auto-scroll only on initial history load — use scrollTop instead of
+  // scrollIntoView to avoid accidentally scrolling ancestor containers.
   useEffect(() => {
     if (messages.length > 0 && !hasScrolledRef.current) {
       hasScrolledRef.current = true;
-      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+      const container = messagesContainerRef.current;
+      if (container) {
+        container.scrollTop = container.scrollHeight;
+      }
     }
   }, [messages]);
 
@@ -987,7 +1010,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, inline }: Chat
   };
 
   return (
-    <div className={inline ? "flex flex-col h-full bg-gray-950" : "fixed inset-0 bg-gray-950 flex flex-col z-50"}>
+    <div ref={chatRootRef} className={inline ? "flex flex-col h-full bg-gray-950 overscroll-none" : "fixed inset-0 bg-gray-950 flex flex-col z-50 overscroll-none"}>
       {/* Header — two rows */}
       <div className="px-3 sm:px-4 py-1.5 pt-[max(0.375rem,env(safe-area-inset-top))] border-b border-gray-800 bg-gray-900">
         {/* Row 1: back + task info + action buttons */}
@@ -1574,7 +1597,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, inline }: Chat
                 <ChevronDown size={16} />
               </button>
               <button
-                onClick={() => bottomRef.current?.scrollIntoView({ behavior: 'smooth' })}
+                onClick={() => { const c = messagesContainerRef.current; if (c) c.scrollTo({ top: c.scrollHeight, behavior: 'smooth' }); }}
                 className="p-1.5 text-gray-500 hover:text-gray-300 rounded transition-colors"
                 title="Scroll to bottom"
               >

--- a/frontend/src/components/System/UpdateButton.tsx
+++ b/frontend/src/components/System/UpdateButton.tsx
@@ -52,6 +52,7 @@ export function UpdateButton() {
   const [logs, setLogs] = useState<string[]>([]);
   const [dryRunResult, setDryRunResult] = useState<Record<string, unknown> | null>(null);
   const [skipFrontend, setSkipFrontend] = useState(false);
+  const [branch, setBranch] = useState('');
   const [error, setError] = useState('');
   const [oldCommit, setOldCommit] = useState('');
   const [newCommit, setNewCommit] = useState('');
@@ -186,7 +187,7 @@ export function UpdateButton() {
     setPhase('checking');
     setError('');
     try {
-      const result = await api.startUpdate({ dry_run: true });
+      const result = await api.startUpdate({ dry_run: true, branch: branch || undefined });
       setDryRunResult(result);
       setPhase('confirming');
     } catch (e: any) {
@@ -208,7 +209,7 @@ export function UpdateButton() {
     setSteps(defaultSteps);
 
     try {
-      const result = await api.startUpdate({ skip_frontend_build: skipFrontend });
+      const result = await api.startUpdate({ skip_frontend_build: skipFrontend, branch: branch || undefined });
       if (result.update_id) {
         setOldCommit(result.old_commit || '');
       }
@@ -236,6 +237,7 @@ export function UpdateButton() {
     setError('');
     setDryRunResult(null);
     setSkipFrontend(false);
+    setBranch('');
     setOldCommit('');
     setNewCommit('');
     setReconnectCount(0);
@@ -285,6 +287,26 @@ export function UpdateButton() {
               {/* Confirm phase */}
               {phase === 'confirming' && dryRunResult && (
                 <div className="space-y-3">
+                  {/* Branch selector */}
+                  <div className="flex items-center gap-2">
+                    <label className="text-xs text-gray-400 shrink-0">分支:</label>
+                    <input
+                      value={branch}
+                      onChange={e => setBranch(e.target.value)}
+                      placeholder="main"
+                      className="flex-1 bg-gray-800 text-foreground text-xs rounded px-2 py-1 border border-gray-700 focus:outline-none focus:border-indigo-500"
+                    />
+                    <button
+                      onClick={handleCheck}
+                      className="px-2 py-1 text-xs rounded bg-gray-800 text-gray-300 hover:bg-gray-700 shrink-0"
+                    >
+                      重新检查
+                    </button>
+                  </div>
+                  {branch && (
+                    <p className="text-xs text-amber-400">⚠️ 将从分支 <span className="font-mono">{branch}</span> 更新（非 main）</p>
+                  )}
+
                   {!(dryRunResult.has_updates as boolean) && !(dryRunResult.needs_restart as boolean) ? (
                     <p className="text-sm text-gray-300">已是最新版本，无需更新。</p>
                   ) : !(dryRunResult.has_updates as boolean) && (dryRunResult.needs_restart as boolean) ? (


### PR DESCRIPTION
## Summary
- 自动更新功能新增可选 `branch` 参数，支持从任意分支拉取代码（不必合进 main 就能线上测试）
- 后端：`UpdateRequest` / `start_update` / `dry_run` / `_pipeline_inner` 全链路透传 branch
- 前端：更新弹窗增加分支输入框 + "重新检查"按钮，非 main 分支显示警告提示
- 不传 branch 时行为不变（默认 main）

## Test plan
- [ ] 不填分支 → 行为与之前一致，拉 main
- [ ] 填写一个存在的分支名 → dry_run 检查该分支的 commit 差异
- [ ] 确认更新 → git pull --rebase origin <branch>
- [ ] 填写不存在的分支 → dry_run 返回错误信息

🤖 Generated with [Claude Code](https://claude.com/claude-code)