### PR TITLE
fix: support system service scope in self-update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,11 @@ sudo systemctl stop ccm-backend      # 停止后端
 sudo journalctl -u ccm-backend -f    # 查看后端日志
 sudo journalctl -u ccm-tunnel -f     # 查看 tunnel 日志
 # 开机自启已通过 systemctl enable 配置
+
+# 自动更新的 systemd 服务配置（.env）:
+#   SERVICE_NAME=ccm-backend   # 服务单元名（不含 .service 后缀），默认 ccm
+#   SERVICE_SCOPE=auto         # auto | user | system，auto 从 cgroup 自动检测
+# 非默认服务名的部署必须显式配置，否则更新机制无法正确 restart
 ```
 
 ## 数据库

--- a/backend/api/system.py
+++ b/backend/api/system.py
@@ -21,7 +21,7 @@ _GIT_COMMIT: str = git_head_commit()
 
 @router.get("/health")
 async def health():
-    return {"status": "ok", "commit": _GIT_COMMIT, "test": "system-scope-update"}
+    return {"status": "ok", "commit": _GIT_COMMIT}
 
 
 @router.get("/stats")

--- a/backend/api/system.py
+++ b/backend/api/system.py
@@ -21,7 +21,7 @@ _GIT_COMMIT: str = git_head_commit()
 
 @router.get("/health")
 async def health():
-    return {"status": "ok", "commit": _GIT_COMMIT}
+    return {"status": "ok", "commit": _GIT_COMMIT, "scope_test": True}
 
 
 @router.get("/stats")

--- a/backend/api/system.py
+++ b/backend/api/system.py
@@ -21,7 +21,7 @@ _GIT_COMMIT: str = git_head_commit()
 
 @router.get("/health")
 async def health():
-    return {"status": "ok", "commit": _GIT_COMMIT}
+    return {"status": "ok", "commit": _GIT_COMMIT, "test": "system-scope-update"}
 
 
 @router.get("/stats")

--- a/backend/api/system.py
+++ b/backend/api/system.py
@@ -21,7 +21,7 @@ _GIT_COMMIT: str = git_head_commit()
 
 @router.get("/health")
 async def health():
-    return {"status": "ok", "commit": _GIT_COMMIT, "scope_test": True}
+    return {"status": "ok", "commit": _GIT_COMMIT}
 
 
 @router.get("/stats")

--- a/backend/config.py
+++ b/backend/config.py
@@ -115,7 +115,8 @@ class Settings(BaseSettings):
     backup_oss_secret_key: str = ""
 
     # --- One-click update & restart ---
-    service_name: str = "ccm.service"  # systemd user service to restart (e.g. ccm-dev.service)
+    service_name: str = "ccm.service"  # systemd service to restart (e.g. ccm-dev.service)
+    service_scope: str = "auto"        # auto | user | system
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -118,7 +118,7 @@ class Settings(BaseSettings):
     service_name: str = "ccm.service"  # systemd service to restart (e.g. ccm-dev.service)
     service_scope: str = "auto"        # auto | user | system
 
-    model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+    model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 
 
 settings = Settings()

--- a/backend/services/update_service.py
+++ b/backend/services/update_service.py
@@ -153,6 +153,7 @@ class UpdateService:
         self._status_file = Path(f"/tmp/ccm-update-status-{port}.json")
         from backend.config import settings
         self._service_name = settings.service_name
+        self._service_scope = settings.service_scope
         self._tools = {
             "git": _find_tool("git"),
             "uv": _find_tool("uv"),
@@ -160,6 +161,7 @@ class UpdateService:
             "bash": _find_tool("bash"),
             "systemctl": _find_tool("systemctl"),
             "systemd-run": _find_tool("systemd-run"),
+            "sudo": _find_tool("sudo"),
         }
         logger.info("Resolved tool paths: %s", self._tools)
 
@@ -234,9 +236,11 @@ class UpdateService:
     async def _needs_restart(self) -> bool:
         """Check if the running service is older than the code on disk."""
         try:
-            systemctl = self._tools["systemctl"]
+            scope = self._systemd_scope()
+            if not scope:
+                return False
             result = await self._run_cmd(
-                [systemctl, "--user", "show", self._service_name,
+                self._systemctl_cmd(scope) + ["show", self._service_name,
                  "-p", "ActiveEnterTimestamp", "--value"],
             )
             ts_str = result["stdout"].strip()
@@ -603,7 +607,8 @@ class UpdateService:
             if tool_dir not in env.get("PATH", ""):
                 env["PATH"] = tool_dir + ":" + env.get("PATH", "")
 
-        managed = self._is_managed_by_systemd()
+        scope = self._systemd_scope()
+        managed = scope is not None
         script_argv = [
             self._tools["bash"], str(script),
             self.project_dir,
@@ -617,6 +622,7 @@ class UpdateService:
             mode,
             str(os.getpid()),
             sys.executable,
+            scope or "auto",
         ]
 
         if managed:
@@ -625,8 +631,8 @@ class UpdateService:
             # leaving the service stopped with nobody left to start it again.
             # systemd-run puts the script in its own transient unit (own cgroup).
             subprocess.Popen(
-                [
-                    self._tools["systemd-run"], "--user", "--collect",
+                self._systemd_run_cmd(scope) + [
+                    "--collect",
                     f"--unit=ccm-update-{self.port}",
                     # transient units do NOT inherit our cwd — without this the
                     # script's git/uv/alembic would run from systemd's default dir
@@ -675,8 +681,14 @@ class UpdateService:
     def _cgroup_text(self) -> str:
         return Path("/proc/self/cgroup").read_text()
 
-    def _is_managed_by_systemd(self) -> bool:
-        """True only if THIS process runs inside the service's own cgroup.
+    def _normalized_service_name(self) -> str:
+        name = self._service_name
+        if not name.endswith(".service"):
+            name += ".service"
+        return name
+
+    def _systemd_scope(self) -> str | None:
+        """Return user/system only if THIS process is in its service cgroup.
 
         `systemctl is-active` is not enough: a manually launched uvicorn can
         coexist with an active (but port-less) systemd unit — it would then
@@ -684,20 +696,41 @@ class UpdateService:
         (2026-07-16 test-env orphan incident). /proc/self/cgroup answers for
         this very process; on non-Linux it raises → False → fallback path.
         """
-        name = self._service_name
-        if not name.endswith(".service"):
-            name += ".service"
         try:
-            return f"/{name}" in self._cgroup_text()
+            text = self._cgroup_text()
         except Exception:
-            return False
+            return None
+        if f"/{self._normalized_service_name()}" not in text:
+            return None
+        configured = (self._service_scope or "auto").strip().lower()
+        if configured in {"user", "system"}:
+            return configured
+        if "/system.slice/" in text:
+            return "system"
+        if "/user.slice/" in text:
+            return "user"
+        return "user"
+
+    def _is_managed_by_systemd(self) -> bool:
+        return self._systemd_scope() is not None
+
+    def _systemctl_cmd(self, scope: str) -> list[str]:
+        if scope == "system":
+            return [self._tools["sudo"], "-n", self._tools["systemctl"]]
+        return [self._tools["systemctl"], "--user"]
+
+    def _systemd_run_cmd(self, scope: str | None) -> list[str]:
+        if scope == "system":
+            return [self._tools["sudo"], "-n", self._tools["systemd-run"]]
+        return [self._tools["systemd-run"], "--user"]
 
     def _restart_service(self):
         """Restart via systemd if managed, otherwise re-exec the process."""
-        if self._is_managed_by_systemd():
+        scope = self._systemd_scope()
+        if scope:
+            cmd = self._systemctl_cmd(scope) + ["restart", self._service_name]
             subprocess.Popen(
-                [self._tools["bash"], "-c",
-                 f"sleep 2 && {self._tools['systemctl']} --user restart {self._service_name}"],
+                [self._tools["bash"], "-c", "sleep 2 && exec \"$@\"", "ccm-restart", *cmd],
                 stdout=open(f"/tmp/ccm-restart-{self.port}.log", "w"),
                 stderr=subprocess.STDOUT,
                 start_new_session=True,

--- a/backend/tests/test_service_update.py
+++ b/backend/tests/test_service_update.py
@@ -51,7 +51,7 @@ async def test_migration_path_uses_systemd_run_when_managed(tmp_path):
     svc = _make_service(tmp_path)
     state = _make_state()
 
-    with patch.object(svc, "_is_managed_by_systemd", return_value=True), \
+    with patch.object(svc, "_systemd_scope", return_value="user"), \
          patch("backend.services.update_service.subprocess.Popen") as popen, \
          patch("backend.services.update_service.asyncio.sleep", new=AsyncMock()):
         await svc._migration_path(state)
@@ -68,11 +68,27 @@ async def test_migration_path_uses_systemd_run_when_managed(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_migration_path_uses_system_systemd_run_for_system_service(tmp_path):
+    svc = _make_service(tmp_path)
+    state = _make_state()
+
+    with patch.object(svc, "_systemd_scope", return_value="system"), \
+         patch("backend.services.update_service.subprocess.Popen") as popen, \
+         patch("backend.services.update_service.asyncio.sleep", new=AsyncMock()):
+        await svc._migration_path(state)
+
+    argv = popen.call_args[0][0]
+    assert argv[:4] == [svc._tools["sudo"], "-n", svc._tools["systemd-run"], "--collect"]
+    assert "--user" not in argv
+    assert argv[-1] == "system"
+
+
+@pytest.mark.asyncio
 async def test_migration_path_plain_popen_when_not_managed(tmp_path):
     svc = _make_service(tmp_path)
     state = _make_state()
 
-    with patch.object(svc, "_is_managed_by_systemd", return_value=False), \
+    with patch.object(svc, "_systemd_scope", return_value=None), \
          patch("backend.services.update_service.subprocess.Popen") as popen, \
          patch("backend.services.update_service.asyncio.sleep", new=AsyncMock()):
         await svc._migration_path(state)
@@ -133,7 +149,7 @@ async def test_rollback_delegates_to_script_when_managed(tmp_path):
     backup.write_text("db")
     svc._current.backup_file = str(backup)
 
-    with patch.object(svc, "_is_managed_by_systemd", return_value=True), \
+    with patch.object(svc, "_systemd_scope", return_value="user"), \
          patch("backend.services.update_service.subprocess.Popen") as popen, \
          patch("backend.services.update_service.asyncio.sleep", new=AsyncMock()):
         result = await svc.rollback()
@@ -152,7 +168,7 @@ async def test_rollback_non_systemd_delegates_to_script_kill_mode(tmp_path):
     backup.write_text("db")
     svc._current.backup_file = str(backup)
 
-    with patch.object(svc, "_is_managed_by_systemd", return_value=False), \
+    with patch.object(svc, "_systemd_scope", return_value=None), \
          patch("backend.services.update_service.subprocess.Popen") as popen, \
          patch("backend.services.update_service.asyncio.sleep", new=AsyncMock()):
         result = await svc.rollback()
@@ -173,6 +189,11 @@ def test_is_managed_true_only_when_self_in_service_cgroup(tmp_path):
     with patch.object(svc, "_cgroup_text",
                       return_value="0::/user.slice/user-1000.slice/user@1000.service/app.slice/ccm.service\n"):
         assert svc._is_managed_by_systemd() is True
+        assert svc._systemd_scope() == "user"
+    with patch.object(svc, "_cgroup_text",
+                      return_value="0::/system.slice/ccm.service\n"):
+        assert svc._is_managed_by_systemd() is True
+        assert svc._systemd_scope() == "system"
     # orphan uvicorn in a login session — unit may be active, but WE are not it
     with patch.object(svc, "_cgroup_text",
                       return_value="0::/user.slice/user-1000.slice/session-19215.scope\n"):
@@ -220,17 +241,25 @@ def test_migrate_script_rollback_mode(tmp_path):
 
 
 def _script_env(tmp_path: Path) -> tuple[dict, Path]:
-    """Stub systemctl/uv into PATH; systemctl logs its calls."""
+    """Stub service-management tools into PATH; systemctl logs its calls.
+
+    The test runner itself may live under /system.slice. update_migrate.sh can
+    then choose system scope and call `sudo -n systemctl ...`, so sudo must be
+    stubbed too; otherwise this test can escape the fake PATH and touch real
+    systemd units.
+    """
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     call_log = tmp_path / "systemctl.log"
 
     systemctl = bin_dir / "systemctl"
     systemctl.write_text(f'#!/bin/bash\necho "$@" >> {call_log}\nexit 0\n')
+    sudo = bin_dir / "sudo"
+    sudo.write_text('#!/bin/bash\nif [ "${1:-}" = "-n" ]; then shift; fi\nexec "$@"\n')
     # stub uv: alembic hangs so the test can kill the script mid-migration
     uv = bin_dir / "uv"
     uv.write_text('#!/bin/bash\nif [[ "$*" == *alembic* ]]; then sleep 30; fi\nexit 0\n')
-    for f in (systemctl, uv):
+    for f in (systemctl, sudo, uv):
         f.chmod(f.stat().st_mode | stat.S_IEXEC)
 
     env = os.environ.copy()

--- a/frontend/src/components/System/UpdateButton.tsx
+++ b/frontend/src/components/System/UpdateButton.tsx
@@ -146,6 +146,7 @@ export function UpdateButton() {
   const startReconnectPolling = () => {
     if (reconnectTimer.current) clearInterval(reconnectTimer.current);
     let attempts = 0;
+    let sawDown = false;
     setReconnectSlow(false);
 
     const poll = async () => {
@@ -153,6 +154,12 @@ export function UpdateButton() {
       setReconnectCount(attempts);
       try {
         await api.health();
+        if (!sawDown) {
+          // Server hasn't gone down yet — the restart command fires with
+          // a 2s delay so early polls can hit the OLD still-alive server.
+          // Wait until it actually dies before accepting a success.
+          return;
+        }
         if (reconnectTimer.current) clearInterval(reconnectTimer.current);
         reconnectTimer.current = null;
         setReconnectSlow(false);
@@ -166,11 +173,14 @@ export function UpdateButton() {
             setPhase('failed');
           } else {
             setPhase('completed');
+            setTimeout(() => window.location.reload(), 1500);
           }
         } catch {
           setPhase('completed');
+          setTimeout(() => window.location.reload(), 1500);
         }
       } catch {
+        sawDown = true;
         // After 120s (60 fast polls), switch to slow polling instead of giving up
         if (attempts === 60) {
           setReconnectSlow(true);

--- a/scripts/update_migrate.sh
+++ b/scripts/update_migrate.sh
@@ -15,8 +15,40 @@ SERVICE_NAME="${6:-ccm.service}"
 MODE="${7:-migrate}"     # migrate | rollback
 SERVER_PID="${8:-}"      # only used when SERVICE_NAME="-"
 PYTHON_BIN="${9:-python3}"
+SYSTEMD_SCOPE="${10:-auto}"  # auto | user | system
 STATUS_FILE="/tmp/ccm-update-status-${PORT}.json"
 LOG_FILE="/tmp/ccm-update-migrate-${PORT}.log"
+
+cgroup_text() {
+    cat /proc/self/cgroup 2>/dev/null || true
+}
+
+resolve_scope() {
+    if [ "$SYSTEMD_SCOPE" = "user" ] || [ "$SYSTEMD_SCOPE" = "system" ]; then
+        echo "$SYSTEMD_SCOPE"
+        return
+    fi
+    case "$(cgroup_text)" in
+        *"/system.slice/"*) echo "system" ;;
+        *) echo "user" ;;
+    esac
+}
+
+systemctl_cmd() {
+    if [ "$(resolve_scope)" = "system" ]; then
+        sudo -n systemctl "$@"
+    else
+        systemctl --user "$@"
+    fi
+}
+
+systemd_run_cmd() {
+    if [ "$(resolve_scope)" = "system" ]; then
+        sudo -n systemd-run "$@"
+    else
+        systemd-run --user "$@"
+    fi
+}
 
 # ---- self-escape trampoline -------------------------------------------------
 # Old (pre-systemd-run) backends spawn this script as a plain uvicorn child, so
@@ -29,14 +61,15 @@ LOG_FILE="/tmp/ccm-update-migrate-${PORT}.log"
 SELF="$(readlink -f "$0")"
 if [ -z "${CCM_ESCAPED:-}" ] && [ "$SERVICE_NAME" != "-" ] \
     && command -v systemd-run >/dev/null 2>&1; then
-    case "$(cat /proc/self/cgroup 2>/dev/null)" in
+    case "$(cgroup_text)" in
         *"/${SERVICE_NAME}"*)
             # transient units inherit neither cwd nor env — pin both, and pass
             # $SELF (absolute) because a relative $0 breaks after the re-exec
-            if systemd-run --user --collect --unit="ccm-update-escape-${PORT}-$$" \
+            if systemd_run_cmd --collect --unit="ccm-update-escape-${PORT}-$$" \
                 --working-directory="$PROJECT_DIR" \
                 --setenv=CCM_ESCAPED=1 \
                 --setenv=PATH="$PATH" \
+                --setenv=SYSTEMD_SCOPE="$(resolve_scope)" \
                 --property=StandardOutput="append:${LOG_FILE}" \
                 --property=StandardError=inherit \
                 /bin/bash "$SELF" "$@"; then
@@ -68,7 +101,7 @@ EOJSON
 
 svc_stop() {
     if [ "$SERVICE_NAME" != "-" ]; then
-        systemctl --user stop "$SERVICE_NAME"
+        systemctl_cmd stop "$SERVICE_NAME"
     else
         [ -n "$SERVER_PID" ] || return 1
         kill "$SERVER_PID" 2>/dev/null || true
@@ -87,7 +120,7 @@ svc_start() {
     [ "$STARTED" = 1 ] && return 0
     STARTED=1
     if [ "$SERVICE_NAME" != "-" ]; then
-        systemctl --user start "$SERVICE_NAME"
+        systemctl_cmd start "$SERVICE_NAME"
     else
         cd "$PROJECT_DIR" && nohup "$PYTHON_BIN" -m uvicorn backend.main:app \
             --host 0.0.0.0 --port "$PORT" >> "/tmp/ccm-restart-${PORT}.log" 2>&1 &
@@ -95,7 +128,7 @@ svc_start() {
 }
 
 echo "=== update_migrate.sh started at $(date -Iseconds) (mode=$MODE) ===" > "$LOG_FILE"
-echo "cgroup: $(cat /proc/self/cgroup 2>/dev/null) (escaped=${CCM_ESCAPED:-0})" >> "$LOG_FILE"
+echo "cgroup: $(cgroup_text) (escaped=${CCM_ESCAPED:-0}, scope=$(resolve_scope))" >> "$LOG_FILE"
 
 # 1. Stop service
 write_status "stopping" "正在停止服务..." "stop_service"


### PR DESCRIPTION
## Summary
- detect whether the running CCM service is managed by system or user systemd scope from its cgroup
- use the matching systemctl/systemd-run invocation for one-click update restart and migration scripts
- keep bare uvicorn fallback behavior unchanged
- harden update_migrate.sh tests by stubbing sudo so system-scope tests cannot escape the fake systemctl/systemd-run PATH

## Why
The cyf deployment runs as a system service under /system.slice, but the updater assumed user services and called systemctl --user. That allowed code/build updates to land while the live backend kept running the old commit, which hid newly added Codex GPT-5.6 models until a manual restart.

During validation, the full update_service test file initially interrupted the execution session because script integration tests could choose system scope in this CCM-hosted runner and call sudo -n systemctl outside the test stub. The PR now fixes that test isolation issue by stubbing sudo in the script test environment.

## Validation
- python -m py_compile backend/config.py backend/services/update_service.py backend/tests/test_service_update.py
- bash -n scripts/update_migrate.sh
- uv run pytest backend/tests/test_service_update.py -q