### PR TITLE
feat: support Onet and Gazeta mailbox auto-login

### DIFF
--- a/backend/api/codex_pool.py
+++ b/backend/api/codex_pool.py
@@ -116,7 +116,7 @@ async def codex_relogin(request: Request, account_id: str):
         running = [k for k, v in _relogin_state.items() if v.get("status") == "running"]
         raise HTTPException(status_code=409, detail=f"另一个账号正在登录中（{', '.join(running)}）")
 
-    # Look up the saved OTP receiver credential (171mail or webmail token/password).
+    # Look up the saved OTP receiver API token (171mail or MailCatcher).
     tokens_path = Path.home() / ".codex-pool" / "email_tokens.json"
     receiver_credential = ""
     openai_password = ""
@@ -179,7 +179,7 @@ async def codex_relogin_status(account_id: str):
 
 class AddCodexAccountRequest(BaseModel):
     email: str
-    token: str  # 171mail token, or Onet/Gazeta webmail token/password
+    token: str  # 171mail token, or a MailCatcher-issued Onet/Gazeta query token
     password: str = ""
     login_method: str = ""
 

--- a/backend/api/codex_pool.py
+++ b/backend/api/codex_pool.py
@@ -116,18 +116,27 @@ async def codex_relogin(request: Request, account_id: str):
         running = [k for k, v in _relogin_state.items() if v.get("status") == "running"]
         raise HTTPException(status_code=409, detail=f"另一个账号正在登录中（{', '.join(running)}）")
 
-    # Look up 171mail token
+    # Look up the saved OTP receiver credential (171mail or webmail token/password).
     tokens_path = Path.home() / ".codex-pool" / "email_tokens.json"
-    token_171 = ""
+    receiver_credential = ""
+    openai_password = ""
+    mail_provider = ""
     if tokens_path.exists():
         try:
             tokens = json.loads(tokens_path.read_text())
-            token_171 = tokens.get(acc.email, "")
+            saved = tokens.get(acc.email, "")
+            if isinstance(saved, dict):
+                receiver_credential = saved.get("token", "")
+                openai_password = saved.get("password", "")
+                mail_provider = saved.get("provider", "")
+            else:
+                receiver_credential = saved
+                mail_provider = ""
         except Exception:
             pass
 
-    if not token_171:
-        raise HTTPException(status_code=400, detail=f"No 171mail token for {acc.email}. Add via /api/codex-pool/add first.")
+    if not receiver_credential:
+        raise HTTPException(status_code=400, detail=f"No mailbox verification credential for {acc.email}. Add the account again first.")
 
     root = Path(__file__).resolve().parents[2]
     login_py = root / ".venv" / "bin" / "python3"
@@ -139,11 +148,18 @@ async def codex_relogin(request: Request, account_id: str):
 
     await _login_lock.acquire()
     script = root / "scripts" / "codex_login.py"
-    proc = await asyncio.create_subprocess_exec(
+    cmd = [
         str(login_py), str(script),
         "--email", acc.email,
-        "--token", token_171,
+        "--token", receiver_credential,
         "--codex-home", acc.codex_home,
+    ]
+    if openai_password:
+        cmd.extend(["--password", openai_password])
+    if mail_provider in ("171mail", "onet", "gazeta"):
+        cmd.extend(["--mail-provider", mail_provider])
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
         stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
         env={**os.environ, "DISPLAY": ":99", "PYTHONUNBUFFERED": "1"},
     )
@@ -163,8 +179,9 @@ async def codex_relogin_status(account_id: str):
 
 class AddCodexAccountRequest(BaseModel):
     email: str
-    token: str  # 171mail token
+    token: str  # 171mail token, or Onet/Gazeta webmail token/password
     password: str = ""
+    login_method: str = ""
 
 
 _xvfb_proc = None
@@ -242,6 +259,8 @@ async def codex_add_account(request: Request, body: AddCodexAccountRequest):
     ]
     if body.password:
         cmd.extend(["--password", body.password])
+    if body.login_method in ("171mail", "onet", "gazeta"):
+        cmd.extend(["--mail-provider", body.login_method])
 
     proc = await asyncio.create_subprocess_exec(
         *cmd,

--- a/backend/api/pool.py
+++ b/backend/api/pool.py
@@ -200,7 +200,7 @@ async def set_preferred(request: Request, body: dict):
 class AddAccountRequest(BaseModel):
     email: str
     token: str
-    login_method: str = ""  # "171mail" | "mailcom" | "" (auto-detect by suffix)
+    login_method: str = ""  # 171mail | mailcom | onet | gazeta | "" (auto-detect)
 
 
 # 全局 Xvfb：所有 auto_login 共享一个 display
@@ -289,7 +289,7 @@ async def add_account(request: Request, body: AddAccountRequest):
         "--add-to-pool", account_id,
         "--save-token",
     ]
-    if body.login_method in ("171mail", "mailcom"):
+    if body.login_method in ("171mail", "mailcom", "onet", "gazeta"):
         cmd.extend(["--login-method", body.login_method])
     proc = await asyncio.create_subprocess_exec(
         *cmd,

--- a/backend/api/workers.py
+++ b/backend/api/workers.py
@@ -320,7 +320,7 @@ async def add_worker_account(worker_id: int, request: Request, body: dict, db: A
     remote_dir = settings.worker_remote_dir
 
     # 后台跑 auto_login（xvfb-run 包装）
-    login_method_arg = f" --login-method {login_method}" if login_method in ("171mail", "mailcom") else ""
+    login_method_arg = f" --login-method {login_method}" if login_method in ("171mail", "mailcom", "onet", "gazeta") else ""
     cmd = (
         f"cd {remote_dir} && export PATH=\"$HOME/.local/bin:$PATH\" && "
         f"xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' "

--- a/backend/api/workers.py
+++ b/backend/api/workers.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import shlex
 import socket
 import time
 
@@ -27,6 +28,51 @@ router = APIRouter(prefix="/api/workers", tags=["workers"])
 # 后台任务强引用：event loop 只持弱引用，长耗时 bootstrap 任务可能被 GC
 # 掐死在半路（asyncio 文档明确的坑）
 _background_tasks: set[asyncio.Task] = set()
+
+_LOGIN_METHODS = frozenset({"", "171mail", "mailcom", "onet", "gazeta"})
+
+
+def _normalize_login_method(value: str | None) -> str:
+    if value is not None and not isinstance(value, str):
+        raise HTTPException(400, "login_method 必须是字符串")
+    method = (value or "").strip().lower()
+    if method not in _LOGIN_METHODS:
+        raise HTTPException(400, f"不支持的登录方式: {method}")
+    return method
+
+
+def _build_add_account_command(
+    remote_dir: str,
+    *,
+    email: str,
+    token: str,
+    slot: str,
+    login_method: str,
+) -> str:
+    """Build the remote login command with every dynamic argv shell-quoted."""
+    argv = [
+        "xvfb-run",
+        "--auto-servernum",
+        "--server-args=-screen 0 1920x1080x24",
+        "uv",
+        "run",
+        "python",
+        "scripts/auto_login.py",
+        "--email",
+        email,
+        "--token",
+        token,
+        "--add-to-pool",
+        slot,
+        "--save-token",
+    ]
+    if login_method:
+        argv.extend(["--login-method", login_method])
+    return (
+        f"cd {shlex.quote(remote_dir)} && "
+        'export PATH="$HOME/.local/bin:$PATH" && '
+        f"{shlex.join(argv)}"
+    )
 
 
 def _spawn(coro) -> asyncio.Task:
@@ -63,18 +109,30 @@ async def create_worker(body: WorkerCreate, request: Request, db: AsyncSession =
     prov = _provisioner()
     if not body.name or not body.name.strip():
         raise HTTPException(400, "请填写 Worker 名称")
+    accounts = []
+    for account in body.accounts:
+        email = account.email.strip()
+        token = (account.token or "").strip()
+        if not email:
+            raise HTTPException(400, "账号 email 必填")
+        if not token.strip():
+            raise HTTPException(400, f"账号 {email} 的 token 必填")
+        accounts.append({
+            "email": email,
+            "token": token,
+            "login_method": _normalize_login_method(account.login_method),
+        })
     worker = Worker(
         name=body.name.strip(),
         status="creating",
         ssh_user=settings.worker_ssh_user,
         ssh_key_path=settings.worker_ssh_key_path,
-        accounts=[{"email": a.email, "token": a.token or "", "status": "pending"} for a in body.accounts],
+        accounts=[{**account, "status": "pending"} for account in accounts],
     )
     db.add(worker)
     await db.commit()
     await db.refresh(worker)
 
-    accounts = [a.model_dump() for a in body.accounts]
     _spawn(
         prov.create_worker(worker.id, accounts=accounts)
     )
@@ -218,12 +276,31 @@ async def retry_bootstrap(worker_id: int, request: Request, db: AsyncSession = D
         await require_worker_access(request, worker)
     prov = _provisioner()
     worker = await _require_worker(db, worker_id, ("error",))
+    # 从 DB 读已有账号信息（创建时存的 email/token），retry 时重新登录
+    saved_accounts = worker.accounts or []
+    accounts = []
+    for account in saved_accounts:
+        email = str(account.get("email", "")).strip()
+        if not email:
+            raise HTTPException(409, "Worker 保存的账号缺少 email，无法重试")
+        token = account.get("token") or ""
+        if not isinstance(token, str) or not token.strip():
+            raise HTTPException(
+                409,
+                f"账号 {email} 缺少 token，无法重试；请删除后重新创建 Worker",
+            )
+        try:
+            login_method = _normalize_login_method(account.get("login_method"))
+        except HTTPException as exc:
+            raise HTTPException(409, f"账号 {email} 的登录方式无效，无法重试") from exc
+        accounts.append({
+            "email": email,
+            "token": token,
+            "login_method": login_method,
+        })
     worker.status = "creating"
     await db.commit()
     await db.refresh(worker)
-    # 从 DB 读已有账号信息（创建时存的 email/token），retry 时重新登录
-    saved_accounts = worker.accounts or []
-    accounts = [{"email": a.get("email", ""), "token": a.get("token", "")} for a in saved_accounts if a.get("email")]
     _spawn(
         prov.create_worker(worker.id, accounts=accounts)
     )
@@ -286,7 +363,7 @@ async def get_worker_pool(worker_id: int, request: Request, db: AsyncSession = D
 
 @router.post("/{worker_id}/pool/add")
 async def add_worker_account(worker_id: int, request: Request, body: dict, db: AsyncSession = Depends(get_db)):
-    """在 worker 上添加账号（跑 auto_login.py）。body: {email, token}"""
+    """在 worker 上添加账号（跑 auto_login.py）。body: {email, token, login_method}"""
     worker = await db.get(Worker, worker_id)
     if not worker:
         raise HTTPException(404, "Worker not found")
@@ -295,9 +372,13 @@ async def add_worker_account(worker_id: int, request: Request, body: dict, db: A
     if worker.status != "ready" or not worker.private_ip:
         raise HTTPException(409, f"Worker 未就绪（{worker.status}）")
 
-    email = body.get("email", "").strip()
-    token = body.get("token", "").strip()
-    login_method = body.get("login_method", "").strip()
+    raw_email = body.get("email", "")
+    raw_token = body.get("token", "")
+    if not isinstance(raw_email, str) or not isinstance(raw_token, str):
+        raise HTTPException(400, "email 和 token 必须是字符串")
+    email = raw_email.strip()
+    token = raw_token.strip()
+    login_method = _normalize_login_method(body.get("login_method"))
     if not email or not token:
         raise HTTPException(400, "email 和 token 必填")
 
@@ -320,19 +401,19 @@ async def add_worker_account(worker_id: int, request: Request, body: dict, db: A
     remote_dir = settings.worker_remote_dir
 
     # 后台跑 auto_login（xvfb-run 包装）
-    login_method_arg = f" --login-method {login_method}" if login_method in ("171mail", "mailcom", "onet", "gazeta") else ""
-    cmd = (
-        f"cd {remote_dir} && export PATH=\"$HOME/.local/bin:$PATH\" && "
-        f"xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' "
-        f"python3 scripts/auto_login.py --email {email} --token {token} "
-        f"--add-to-pool {slot} --save-token{login_method_arg}"
+    cmd = _build_add_account_command(
+        remote_dir,
+        email=email,
+        token=token,
+        slot=slot,
+        login_method=login_method,
     )
 
     # 这个任务可能跑 1-2 分钟，用 fire-and-forget
     _worker_login_state[f"{worker_id}:{email}"] = {"status": "running", "started_at": time.time()}
 
     async def _run():
-        code, out = await ssh.run(cmd, timeout=600)
+        code, out = await ssh.run(cmd, timeout=600, sensitive=True)
         _worker_login_state[f"{worker_id}:{email}"] = {
             "status": "success" if code == 0 else "failed",
             "detail": out[-1000:],

--- a/backend/models/worker.py
+++ b/backend/models/worker.py
@@ -36,8 +36,8 @@ class Worker(Base):
     auth_token: Mapped[str | None] = mapped_column(String(128), nullable=True)
     ccm_commit: Mapped[str | None] = mapped_column(String(64), nullable=True)  # 版本锁定校验
 
-    # 账号信息（在 Worker 本机登录；密码经 secrets 机制加密后只存引用）
-    accounts: Mapped[list | None] = mapped_column(JSON, default=list)  # [{"email", "status": pending/logged_in/failed}]
+    # 账号信息（在 Worker 本机登录；接码 token 留存供 bootstrap retry，API 响应脱敏）
+    accounts: Mapped[list | None] = mapped_column(JSON, default=list)  # email/token/login_method/status
 
     # Project ID 映射（manager_project_id → worker_project_id）
     project_mapping: Mapped[dict | None] = mapped_column(JSON, default=dict)

--- a/backend/schemas/worker.py
+++ b/backend/schemas/worker.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ConfigDict, field_serializer
 class WorkerAccountIn(BaseModel):
     email: str
     token: str | None = None
-    login_method: str = ""  # "171mail" | "mailcom" | "" (auto-detect by suffix)
+    login_method: str = ""  # 171mail | mailcom | onet | gazeta | "" (auto-detect)
 
 
 class WorkerCreate(BaseModel):

--- a/backend/services/ssh_executor.py
+++ b/backend/services/ssh_executor.py
@@ -41,9 +41,14 @@ class SSHExecutor:
         finally:
             client.close()
 
-    async def run(self, command: str, timeout: int = 300) -> tuple[int, str]:
+    async def run(
+        self, command: str, timeout: int = 300, *, sensitive: bool = False,
+    ) -> tuple[int, str]:
         """执行远程命令，返回 (exit_code, output)。"""
-        logger.debug("ssh %s: %s", self.host, command[:200])
+        logger.debug(
+            "ssh %s: %s", self.host,
+            "[sensitive command redacted]" if sensitive else command[:200],
+        )
         return await asyncio.to_thread(self._run_sync, command, timeout)
 
     async def check_alive(self, timeout: int = 10) -> bool:

--- a/backend/services/worker_provisioner.py
+++ b/backend/services/worker_provisioner.py
@@ -11,9 +11,11 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import logging
 import os
 import secrets as pysecrets
+import shlex
 from datetime import datetime
 
 import httpx
@@ -34,6 +36,59 @@ logger = logging.getLogger(__name__)
 DEPLOY_EXCLUDES = [
     ".git", ".env", ".env.*", "uploads/", ".claude-manager/", "archive-do-not-use/",
 ]
+
+LOGIN_METHODS = frozenset({"", "171mail", "mailcom", "onet", "gazeta"})
+
+
+def _build_account_login_script(
+    remote_dir: str,
+    *,
+    email: str,
+    token: str,
+    slot: str,
+    login_method: str,
+) -> str:
+    """Build the login script without interpolating unquoted account data."""
+    config_name = ".claude" if slot == "default" else f".claude-{slot}"
+    argv = [
+        "uv",
+        "run",
+        "python",
+        "scripts/auto_login.py",
+        "--email",
+        email,
+        "--token",
+        token,
+        "--add-to-pool",
+        slot,
+        "--save-token",
+    ]
+    if login_method:
+        argv.extend(["--login-method", login_method])
+    return "\n".join([
+        "#!/bin/bash",
+        "set +e",
+        'export PATH="$HOME/.local/bin:$PATH"',
+        f"cd {shlex.quote(remote_dir)}",
+        "pkill -f 'Xvfb :99' 2>/dev/null",
+        "sleep 0.5",
+        "Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp -ac > /dev/null 2>&1 &",
+        "sleep 1",
+        "export DISPLAY=:99",
+        f'CONFIG_DIR="$HOME/"{shlex.quote(config_name)}',
+        f'{shlex.join(argv)} --config-dir "$CONFIG_DIR"',
+        "",
+    ])
+
+
+def _build_script_upload_command(script: str, remote_path: str) -> str:
+    """Transfer a script as base64 so its contents cannot terminate a heredoc."""
+    encoded = base64.b64encode(script.encode()).decode("ascii")
+    quoted_path = shlex.quote(remote_path)
+    return (
+        f"umask 077 && printf %s {shlex.quote(encoded)} | "
+        f"base64 -d > {quoted_path} && chmod 700 {quoted_path}"
+    )
 
 
 class BootstrapError(Exception):
@@ -332,32 +387,52 @@ echo deploy-ok
             await self._log(worker_id, "no accounts given, skipping login (worker 已有凭证或稍后手动登录)")
             return
         remote_dir = settings.worker_remote_dir
+        normalized_accounts = []
+        for account in accounts:
+            email = str(account.get("email", "")).strip()
+            raw_token = account.get("token") or ""
+            login_method = str(account.get("login_method") or "").strip().lower()
+            if not email:
+                raise BootstrapError("account-login", "账号 email 必填")
+            if not isinstance(raw_token, str) or not raw_token.strip():
+                raise BootstrapError("account-login", f"账号 {email} 缺少 token")
+            token = raw_token.strip()
+            if login_method not in LOGIN_METHODS:
+                raise BootstrapError("account-login", f"账号 {email} 的登录方式无效: {login_method}")
+            normalized_accounts.append({
+                "email": email,
+                "token": token,
+                "login_method": login_method,
+            })
+
         results = []
-        for i, acct in enumerate(accounts):
-            email = acct.get("email", "")
-            token = acct.get("token", "")
-            login_method = acct.get("login_method", "")
+        for i, acct in enumerate(normalized_accounts):
+            email = acct["email"]
+            token = acct["token"]
+            login_method = acct["login_method"]
             name = "default" if i == 0 else f"account-{i + 1}"
             await self._log(worker_id, f"login {email} -> pool slot {name} (method: {login_method or 'auto'})")
-            login_method_arg = f" --login-method {login_method}" if login_method in ("171mail", "mailcom") else ""
-            login_script = f"""#!/bin/bash
-set +e
-export PATH="$HOME/.local/bin:$PATH"
-cd {remote_dir}
-pkill -f 'Xvfb :99' 2>/dev/null
-sleep 0.5
-Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp -ac > /dev/null 2>&1 &
-sleep 1
-export DISPLAY=:99
-CONFIG_DIR="$HOME/.claude" && [ "{name}" != "default" ] && CONFIG_DIR="$HOME/.claude-{name}"
-uv run python scripts/auto_login.py --email '{email}' --token '{token}' --config-dir "$CONFIG_DIR" --add-to-pool {name} --save-token{login_method_arg}
-"""
-            # 写脚本到 worker 再执行
-            await ssh.run(f"cat > /tmp/ccm_login.sh << 'SCRIPT'\n{login_script}SCRIPT\nchmod +x /tmp/ccm_login.sh")
-            cmd = "bash /tmp/ccm_login.sh && rm -f /tmp/ccm_login.sh"
-            code, out = await ssh.run(cmd, timeout=600)
+            login_script = _build_account_login_script(
+                remote_dir,
+                email=email,
+                token=token,
+                slot=name,
+                login_method=login_method,
+            )
+            remote_script = f"/tmp/ccm_login_{worker_id}_{i}.sh"
+            upload_cmd = _build_script_upload_command(login_script, remote_script)
+            code, out = await ssh.run(upload_cmd, sensitive=True)
+            if code == 0:
+                quoted_script = shlex.quote(remote_script)
+                cmd = (
+                    f"bash {quoted_script}; rc=$?; "
+                    f"rm -f {quoted_script}; exit $rc"
+                )
+                code, out = await ssh.run(cmd, timeout=600)
+            else:
+                await ssh.run(f"rm -f {shlex.quote(remote_script)}")
             status = "logged_in" if code == 0 else "failed"
-            results.append({"email": email, "status": status})
+            results.append({**acct, "status": status})
             await self._log(worker_id, f"login {email}: {status}")
             if code != 0:
                 await self._log(worker_id, f"login output: {out[-500:]}")

--- a/backend/tests/test_api_workers.py
+++ b/backend/tests/test_api_workers.py
@@ -1,13 +1,23 @@
 """Tests for Worker management API + provisioner state machine."""
 import asyncio
+import base64
+import logging
+import shlex
 import socket
 from unittest.mock import AsyncMock
 
 import pytest
 
 import backend.main as main_module
+from backend.api.workers import _build_add_account_command
 from backend.models.worker import Worker
-from backend.services.worker_provisioner import BootstrapError, WorkerProvisioner
+from backend.services.worker_provisioner import (
+    BootstrapError,
+    WorkerProvisioner,
+    _build_account_login_script,
+    _build_script_upload_command,
+)
+from backend.services.ssh_executor import SSHExecutor
 
 
 # === Fixtures ===
@@ -79,10 +89,19 @@ async def test_create_worker_disabled_returns_503(client, monkeypatch):
     assert resp.status_code == 503
 
 
-async def test_create_worker_auto_name_and_background_task(client, fake_provisioner):
+async def test_create_worker_auto_name_and_background_task(
+    client, fake_provisioner, session_factory,
+):
     resp = await client.post(
         "/api/workers",
-        json={"name": "test-w", "accounts": [{"email": "a@x.com", "token": "tok123"}]},
+        json={
+            "name": "test-w",
+            "accounts": [{
+                "email": "a@x.com",
+                "token": "tok123",
+                "login_method": "onet",
+            }],
+        },
     )
     assert resp.status_code == 200, resp.text
     data = resp.json()
@@ -92,8 +111,32 @@ async def test_create_worker_auto_name_and_background_task(client, fake_provisio
     await asyncio.sleep(0)  # 让 create_task 跑起来
     fake_provisioner.create_worker.assert_called_once()
     kwargs = fake_provisioner.create_worker.call_args.kwargs
-    # login_method 为可选字段（"" = 按邮箱后缀自动识别），schema 会补默认值
-    assert kwargs["accounts"] == [{"email": "a@x.com", "token": "tok123", "login_method": ""}]
+    assert kwargs["accounts"] == [{
+        "email": "a@x.com",
+        "token": "tok123",
+        "login_method": "onet",
+    }]
+    async with session_factory() as db:
+        worker = await db.get(Worker, data["id"])
+    assert worker.accounts == [{
+        "email": "a@x.com",
+        "token": "tok123",
+        "login_method": "onet",
+        "status": "pending",
+    }]
+
+
+@pytest.mark.parametrize("token", [None, "", " \n "])
+async def test_create_worker_rejects_empty_account_token(
+    client, fake_provisioner, token,
+):
+    resp = await client.post(
+        "/api/workers",
+        json={"name": "test-w", "accounts": [{"email": "a@x.com", "token": token}]},
+    )
+    assert resp.status_code == 400
+    assert "token" in resp.json()["detail"]
+    fake_provisioner.create_worker.assert_not_called()
 
 
 async def test_stop_requires_ready(client, session_factory, fake_provisioner):
@@ -138,6 +181,50 @@ async def test_retry_only_from_error(client, session_factory, fake_provisioner):
     assert (await client.post(f"/api/workers/{wid}/retry")).status_code == 200
 
 
+async def test_retry_preserves_account_token_and_login_method(
+    client, session_factory, fake_provisioner,
+):
+    wid = await _insert_worker(
+        session_factory,
+        status="error",
+        accounts=[{
+            "email": "onet@example.com",
+            "token": "mailcatcher-token",
+            "login_method": "onet",
+            "status": "failed",
+        }],
+    )
+    resp = await client.post(f"/api/workers/{wid}/retry")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["accounts"] == [{"email": "onet@example.com", "status": "failed"}]
+    await asyncio.sleep(0)
+    fake_provisioner.create_worker.assert_awaited_once_with(
+        wid,
+        accounts=[{
+            "email": "onet@example.com",
+            "token": "mailcatcher-token",
+            "login_method": "onet",
+        }],
+    )
+
+
+async def test_retry_missing_historical_token_fails_without_status_change(
+    client, session_factory, fake_provisioner,
+):
+    wid = await _insert_worker(
+        session_factory,
+        status="error",
+        accounts=[{"email": "legacy@example.com", "status": "failed"}],
+    )
+    resp = await client.post(f"/api/workers/{wid}/retry")
+    assert resp.status_code == 409
+    assert "缺少 token" in resp.json()["detail"]
+    async with session_factory() as db:
+        worker = await db.get(Worker, wid)
+    assert worker.status == "error"
+    fake_provisioner.create_worker.assert_not_called()
+
+
 async def test_get_worker_and_logs(client, session_factory, fake_provisioner):
     wid = await _insert_worker(session_factory, bootstrap_log="[00:00:00] hi\n")
     resp = await client.get(f"/api/workers/{wid}")
@@ -155,6 +242,111 @@ async def test_terminated_workers_hidden_from_list(client, session_factory):
 
 
 # === Provisioner state machine tests（cloud/bootstrap 全替身，不碰网络） ===
+
+
+def _flag_value(argv: list[str], flag: str) -> str:
+    return argv[argv.index(flag) + 1]
+
+
+def test_worker_login_commands_quote_untrusted_values():
+    email = "mail+'; touch /tmp/pwn; #@example.com"
+    token = "line-one\n$(touch /tmp/pwn) ' \" end"
+    remote_dir = "/srv/ccm dir; touch /tmp/pwn"
+    script = _build_account_login_script(
+        remote_dir,
+        email=email,
+        token=token,
+        slot="account-2",
+        login_method="gazeta",
+    )
+    assert shlex.split(script.splitlines()[3]) == ["cd", remote_dir]
+    login_argv = shlex.split(script[script.index("uv run "):])
+    assert _flag_value(login_argv, "--email") == email
+    assert _flag_value(login_argv, "--token") == token
+    assert _flag_value(login_argv, "--add-to-pool") == "account-2"
+    assert _flag_value(login_argv, "--login-method") == "gazeta"
+    assert _flag_value(login_argv, "--config-dir") == "$CONFIG_DIR"
+
+    upload = _build_script_upload_command(script, "/tmp/a script.sh")
+    upload_argv = shlex.split(upload)
+    encoded = upload_argv[upload_argv.index("%s") + 1]
+    assert base64.b64decode(encoded).decode() == script
+    assert email not in upload
+    assert token not in upload
+    assert "<<" not in upload
+
+    add_command = _build_add_account_command(
+        remote_dir,
+        email=email,
+        token=token,
+        slot="default",
+        login_method="onet",
+    )
+    pieces = add_command.split(" && ")
+    assert shlex.split(pieces[0]) == ["cd", remote_dir]
+    add_argv = shlex.split(pieces[-1])
+    assert _flag_value(add_argv, "--email") == email
+    assert _flag_value(add_argv, "--token") == token
+    assert _flag_value(add_argv, "--login-method") == "onet"
+
+
+async def test_sensitive_ssh_command_is_redacted_from_debug_log(monkeypatch, caplog):
+    ssh = SSHExecutor(host="worker.internal", user="ubuntu", key_path="/tmp/test-key")
+    monkeypatch.setattr(ssh, "_run_sync", lambda _command, _timeout: (0, "ok"))
+
+    with caplog.at_level(logging.DEBUG, logger="backend.services.ssh_executor"):
+        result = await ssh.run("login --token super-secret-token", sensitive=True)
+
+    assert result == (0, "ok")
+    assert "super-secret-token" not in caplog.text
+    assert "sensitive command redacted" in caplog.text
+
+
+async def test_provisioner_login_persists_credentials_and_onet_method(
+    db_factory, session_factory,
+):
+    wid = await _insert_worker(session_factory, status="creating")
+    prov = WorkerProvisioner(db_factory=db_factory, cloud=FakeCloud(), broadcaster=None)
+    ssh = AsyncMock()
+    ssh.run.side_effect = [(0, "uploaded"), (0, "login ok")]
+    account = {
+        "email": "user+'quote@example.com",
+        "token": "secret\n'; echo injected",
+        "login_method": "onet",
+    }
+
+    await prov._step_account_login(ssh, wid, [account])
+
+    async with session_factory() as db:
+        worker = await db.get(Worker, wid)
+    assert worker.accounts == [{**account, "status": "logged_in"}]
+    upload_command = ssh.run.await_args_list[0].args[0]
+    assert ssh.run.await_args_list[0].kwargs["sensitive"] is True
+    assert account["email"] not in upload_command
+    assert account["token"] not in upload_command
+    uploaded_argv = shlex.split(upload_command)
+    uploaded_script = base64.b64decode(
+        uploaded_argv[uploaded_argv.index("%s") + 1]
+    ).decode()
+    login_argv = shlex.split(uploaded_script[uploaded_script.index("uv run "):])
+    assert _flag_value(login_argv, "--email") == account["email"]
+    assert _flag_value(login_argv, "--token") == account["token"]
+    assert _flag_value(login_argv, "--login-method") == "onet"
+
+
+async def test_provisioner_login_rejects_empty_token_before_ssh(
+    db_factory, session_factory,
+):
+    wid = await _insert_worker(session_factory, status="creating")
+    prov = WorkerProvisioner(db_factory=db_factory, cloud=FakeCloud(), broadcaster=None)
+    ssh = AsyncMock()
+    with pytest.raises(BootstrapError, match="缺少 token"):
+        await prov._step_account_login(
+            ssh,
+            wid,
+            [{"email": "legacy@example.com", "token": "", "login_method": "onet"}],
+        )
+    ssh.run.assert_not_awaited()
 
 
 async def test_provisioner_create_happy_path(db_factory, session_factory):

--- a/backend/tests/test_cdp_login_mailbox.py
+++ b/backend/tests/test_cdp_login_mailbox.py
@@ -1,0 +1,241 @@
+import datetime
+import io
+from pathlib import Path
+
+import pytest
+
+from scripts import cdp_login as login_module
+
+
+class FakeProcess:
+    def __init__(self, *, running: bool = True, pid: int = 1234):
+        self.pid = pid
+        self.returncode = None if running else 1
+        self.stdout = io.BytesIO()
+        self.kill_calls = 0
+        self.wait_calls = 0
+
+    def poll(self):
+        return self.returncode
+
+    def kill(self):
+        self.kill_calls += 1
+        self.returncode = -9
+
+    def wait(self, timeout=None):
+        self.wait_calls += 1
+        return self.returncode
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class FakeHttpClient:
+    def __init__(self, payload, **_kwargs):
+        self.payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def get(self, *_args, **_kwargs):
+        return FakeResponse(self.payload)
+
+
+async def _no_sleep(_seconds):
+    return None
+
+
+def _temporary_auth_dir(monkeypatch, tmp_path: Path) -> Path:
+    auth_dir = tmp_path / "temporary-auth"
+
+    def fake_mkdtemp(**_kwargs):
+        auth_dir.mkdir()
+        return str(auth_dir)
+
+    monkeypatch.setattr(login_module.tempfile, "mkdtemp", fake_mkdtemp)
+    return auth_dir
+
+
+def test_temporary_auth_commit_copies_all_credential_files(tmp_path):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    (source / ".credentials.json").write_text('{"token": "new"}')
+    (source / ".claude.json").write_text('{"onboarding": true}')
+
+    login_module._commit_temporary_credentials(source, target)
+
+    assert (target / ".credentials.json").read_bytes() == b'{"token": "new"}'
+    assert (target / ".claude.json").read_bytes() == b'{"onboarding": true}'
+    assert (target / ".credentials.json").stat().st_mode & 0o777 == 0o600
+    assert (target / ".claude.json").stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.asyncio
+async def test_preflight_without_oauth_url_reaps_cli_and_removes_temp_dir(
+    monkeypatch, tmp_path
+):
+    auth_dir = _temporary_auth_dir(monkeypatch, tmp_path)
+    cli = FakeProcess()
+    monkeypatch.setattr(login_module.subprocess, "Popen", lambda *_a, **_k: cli)
+
+    async def no_oauth_url(*_args):
+        return None, b"preflight failed"
+
+    monkeypatch.setattr(login_module, "_wait_cli_oauth_url", no_oauth_url)
+
+    result = await login_module.cdp_login(
+        "user@onet.pl", "query-token", str(tmp_path / "account"), mail_provider="onet"
+    )
+
+    assert result is None
+    assert cli.kill_calls == 1
+    assert cli.wait_calls == 1
+    assert not auth_dir.exists()
+
+
+@pytest.mark.asyncio
+async def test_chrome_launch_exception_cleans_preflight_and_stderr(monkeypatch, tmp_path):
+    auth_dir = _temporary_auth_dir(monkeypatch, tmp_path)
+    cli = FakeProcess()
+    chrome_stderr = io.StringIO()
+    calls = 0
+
+    def fake_popen(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return cli
+        raise RuntimeError("chrome failed to launch")
+
+    async def oauth_url(*_args):
+        return "https://claude.com/cai/oauth/authorize?state=test", b""
+
+    monkeypatch.setattr(login_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(login_module.subprocess, "run", lambda *_a, **_k: None)
+    monkeypatch.setattr(login_module.asyncio, "sleep", _no_sleep)
+    monkeypatch.setattr(login_module, "_wait_cli_oauth_url", oauth_url)
+    monkeypatch.setattr(login_module, "open", lambda *_a, **_k: chrome_stderr, raising=False)
+
+    with pytest.raises(RuntimeError, match="chrome failed"):
+        await login_module.cdp_login(
+            "user@onet.pl", "query-token", str(tmp_path / "account"), mail_provider="onet"
+        )
+
+    assert cli.kill_calls == 1
+    assert cli.wait_calls == 1
+    assert chrome_stderr.closed
+    assert not auth_dir.exists()
+
+
+@pytest.mark.asyncio
+async def test_chrome_early_exit_is_reaped_and_stderr_is_closed(monkeypatch, tmp_path):
+    chrome = FakeProcess(running=False)
+    chrome_stderr = io.StringIO()
+    monkeypatch.setattr(login_module.subprocess, "Popen", lambda *_a, **_k: chrome)
+    monkeypatch.setattr(login_module.subprocess, "run", lambda *_a, **_k: None)
+    monkeypatch.setattr(login_module.asyncio, "sleep", _no_sleep)
+    monkeypatch.setattr(login_module, "open", lambda *_a, **_k: chrome_stderr, raising=False)
+
+    result = await login_module.cdp_login(
+        "user@example.com", "query-token", str(tmp_path / "account")
+    )
+
+    assert result is None
+    assert chrome.kill_calls == 0
+    assert chrome.wait_calls == 1
+    assert chrome_stderr.closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tabs", [[], [{"type": "service_worker"}]])
+async def test_missing_page_tab_reaps_chrome_and_closes_stderr(
+    monkeypatch, tmp_path, tabs
+):
+    chrome = FakeProcess()
+    chrome_stderr = io.StringIO()
+    monkeypatch.setattr(login_module.subprocess, "Popen", lambda *_a, **_k: chrome)
+    monkeypatch.setattr(login_module.subprocess, "run", lambda *_a, **_k: None)
+    monkeypatch.setattr(login_module.asyncio, "sleep", _no_sleep)
+    monkeypatch.setattr(login_module, "open", lambda *_a, **_k: chrome_stderr, raising=False)
+    monkeypatch.setattr(
+        login_module.httpx,
+        "AsyncClient",
+        lambda **kwargs: FakeHttpClient(tabs, **kwargs),
+    )
+
+    result = await login_module.cdp_login(
+        "user@example.com", "query-token", str(tmp_path / "account")
+    )
+
+    assert result is None
+    assert chrome.kill_calls == 1
+    assert chrome.wait_calls == 1
+    assert chrome_stderr.closed
+
+
+@pytest.mark.asyncio
+async def test_websocket_exception_still_reaps_chrome(monkeypatch, tmp_path):
+    chrome = FakeProcess()
+    chrome_stderr = io.StringIO()
+    monkeypatch.setattr(login_module.subprocess, "Popen", lambda *_a, **_k: chrome)
+    monkeypatch.setattr(login_module.subprocess, "run", lambda *_a, **_k: None)
+    monkeypatch.setattr(login_module.asyncio, "sleep", _no_sleep)
+    monkeypatch.setattr(login_module, "open", lambda *_a, **_k: chrome_stderr, raising=False)
+    monkeypatch.setattr(
+        login_module.httpx,
+        "AsyncClient",
+        lambda **kwargs: FakeHttpClient(
+            [{"type": "page", "webSocketDebuggerUrl": "ws://test"}], **kwargs
+        ),
+    )
+
+    class FailingWebsocket:
+        async def __aenter__(self):
+            raise RuntimeError("websocket failed")
+
+        async def __aexit__(self, *_args):
+            return None
+
+    monkeypatch.setattr(login_module.websockets, "connect", lambda *_a, **_k: FailingWebsocket())
+
+    with pytest.raises(RuntimeError, match="websocket failed"):
+        await login_module.cdp_login(
+            "user@example.com", "query-token", str(tmp_path / "account")
+        )
+
+    assert chrome.kill_calls == 1
+    assert chrome.wait_calls == 1
+    assert chrome_stderr.closed
+
+
+@pytest.mark.asyncio
+async def test_magic_link_freshness_prefers_lowercase_payload_date(monkeypatch):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    payload = {
+        "code": 200,
+        "data": {
+            "date": now.isoformat(),
+            "subject": "Claude login | 2000-01-01 00:00:00",
+            "code": "https://claude.ai/magic-link#fresh",
+        },
+    }
+    monkeypatch.setattr(
+        login_module.httpx,
+        "AsyncClient",
+        lambda **kwargs: FakeHttpClient(payload, **kwargs),
+    )
+
+    link = await login_module.poll_mailcatcher_magic_link(
+        "query-token", now.timestamp(), timeout_s=1
+    )
+
+    assert link == "https://claude.ai/magic-link#fresh"

--- a/backend/tests/test_claude_login_mailbox.py
+++ b/backend/tests/test_claude_login_mailbox.py
@@ -1,0 +1,15 @@
+from scripts.auto_login import detect_login_method, uses_mailcatcher_api
+
+
+def test_detect_claude_mailbox_provider():
+    assert detect_login_method("user@onet.pl") == "onet"
+    assert detect_login_method("user@GAZETA.PL") == "gazeta"
+    assert detect_login_method("user@mail.com") == "mailcom"
+    assert detect_login_method("user@example.com") == "171mail"
+
+
+def test_onet_and_gazeta_use_mailcatcher_decode_api():
+    assert uses_mailcatcher_api("onet") is True
+    assert uses_mailcatcher_api("gazeta") is True
+    assert uses_mailcatcher_api("mailcom") is True
+    assert uses_mailcatcher_api("171mail") is False

--- a/backend/tests/test_claude_login_mailbox.py
+++ b/backend/tests/test_claude_login_mailbox.py
@@ -1,15 +1,171 @@
-from scripts.auto_login import detect_login_method, uses_mailcatcher_api
+from __future__ import annotations
+
+import stat
+import sys
+import types
+from pathlib import Path
+
+import scripts.auto_login as auto_login
 
 
 def test_detect_claude_mailbox_provider():
-    assert detect_login_method("user@onet.pl") == "onet"
-    assert detect_login_method("user@GAZETA.PL") == "gazeta"
-    assert detect_login_method("user@mail.com") == "mailcom"
-    assert detect_login_method("user@example.com") == "171mail"
+    assert auto_login.detect_login_method("user@onet.pl") == "onet"
+    assert auto_login.detect_login_method("user@GAZETA.PL") == "gazeta"
+    assert auto_login.detect_login_method("user@mail.com") == "mailcom"
+    assert auto_login.detect_login_method("user@example.com") == "171mail"
 
 
 def test_onet_and_gazeta_use_mailcatcher_decode_api():
-    assert uses_mailcatcher_api("onet") is True
-    assert uses_mailcatcher_api("gazeta") is True
-    assert uses_mailcatcher_api("mailcom") is True
-    assert uses_mailcatcher_api("171mail") is False
+    assert auto_login.uses_mailcatcher_api("onet") is True
+    assert auto_login.uses_mailcatcher_api("gazeta") is True
+    assert auto_login.uses_mailcatcher_api("mailcom") is True
+    assert auto_login.uses_mailcatcher_api("171mail") is False
+
+
+def _write_credential(config_dir: Path, name: str, content: bytes, mode: int) -> None:
+    path = config_dir / name
+    path.write_bytes(content)
+    path.chmod(mode)
+
+
+def _credential_state(config_dir: Path, name: str) -> tuple[bytes, int] | None:
+    path = config_dir / name
+    if not path.exists():
+        return None
+    return path.read_bytes(), stat.S_IMODE(path.stat().st_mode)
+
+
+def _install_cdp_login(monkeypatch, callback) -> None:
+    module = types.ModuleType("cdp_login")
+    module.cdp_login = callback
+    monkeypatch.setitem(sys.modules, "cdp_login", module)
+
+
+async def test_171mail_exception_restores_credentials_before_cdp(tmp_path, monkeypatch):
+    _write_credential(tmp_path, ".claude.json", b"old-claude", 0o640)
+    _write_credential(tmp_path, ".credentials.json", b"old-oauth", 0o600)
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    async def failed_trigger(*_args):
+        raise auto_login.MailServiceError("mailbox unavailable")
+
+    monkeypatch.setattr(auto_login.httpx, "AsyncClient", lambda **_kwargs: _Client())
+    monkeypatch.setattr(auto_login, "_trigger_send", failed_trigger)
+
+    ok = await auto_login.perform_login(
+        email="user@example.com",
+        token_171="171mail-token",
+        config_dir=str(tmp_path),
+        provider="171mail",
+    )
+
+    assert ok is False
+    assert _credential_state(tmp_path, ".claude.json") == (b"old-claude", 0o640)
+    assert _credential_state(tmp_path, ".credentials.json") == (b"old-oauth", 0o600)
+
+
+async def test_perform_login_false_restores_credentials_content_and_mode(tmp_path, monkeypatch):
+    _write_credential(tmp_path, ".claude.json", b"old-claude", 0o640)
+    _write_credential(tmp_path, ".credentials.json", b"old-oauth", 0o600)
+
+    async def failed_login(**kwargs):
+        config_dir = Path(kwargs["config_dir"])
+        _write_credential(config_dir, ".claude.json", b"partial-claude", 0o666)
+        _write_credential(config_dir, ".credentials.json", b"partial-oauth", 0o644)
+        return {"success": False}
+
+    _install_cdp_login(monkeypatch, failed_login)
+
+    ok = await auto_login.perform_login(
+        email="user@onet.pl",
+        token_171="platform-query-token",
+        config_dir=str(tmp_path),
+        provider="onet",
+    )
+
+    assert ok is False
+    assert _credential_state(tmp_path, ".claude.json") == (b"old-claude", 0o640)
+    assert _credential_state(tmp_path, ".credentials.json") == (b"old-oauth", 0o600)
+
+
+async def test_perform_login_false_leaves_no_partial_credentials_when_none_existed(
+    tmp_path, monkeypatch,
+):
+    async def failed_login(**kwargs):
+        config_dir = Path(kwargs["config_dir"])
+        _write_credential(config_dir, ".claude.json", b"partial-claude", 0o600)
+        _write_credential(config_dir, ".credentials.json", b"partial-oauth", 0o600)
+        return None
+
+    _install_cdp_login(monkeypatch, failed_login)
+
+    ok = await auto_login.perform_login(
+        email="user@gazeta.pl",
+        token_171="platform-query-token",
+        config_dir=str(tmp_path),
+        provider="gazeta",
+    )
+
+    assert ok is False
+    assert _credential_state(tmp_path, ".claude.json") is None
+    assert _credential_state(tmp_path, ".credentials.json") is None
+
+
+async def test_perform_login_exception_restores_exact_previous_state(tmp_path, monkeypatch):
+    _write_credential(tmp_path, ".claude.json", b"old-claude", 0o600)
+    _write_credential(tmp_path, ".credentials.json", b"old-oauth", 0o640)
+
+    async def crashing_login(**kwargs):
+        config_dir = Path(kwargs["config_dir"])
+        _write_credential(config_dir, ".claude.json", b"partial-claude", 0o666)
+        _write_credential(config_dir, ".credentials.json", b"partial-oauth", 0o666)
+        raise RuntimeError("browser crashed")
+
+    _install_cdp_login(monkeypatch, crashing_login)
+
+    ok = await auto_login.perform_login(
+        email="user@onet.pl",
+        token_171="platform-query-token",
+        config_dir=str(tmp_path),
+        provider="onet",
+    )
+
+    assert ok is False
+    assert _credential_state(tmp_path, ".claude.json") == (b"old-claude", 0o600)
+    assert _credential_state(tmp_path, ".credentials.json") == (b"old-oauth", 0o640)
+
+
+async def test_perform_login_success_keeps_new_credentials_and_platform_token(
+    tmp_path, monkeypatch,
+):
+    _write_credential(tmp_path, ".claude.json", b"old-claude", 0o600)
+    _write_credential(tmp_path, ".credentials.json", b"old-oauth", 0o600)
+    captured: dict = {}
+
+    async def successful_login(**kwargs):
+        captured.update(kwargs)
+        config_dir = Path(kwargs["config_dir"])
+        _write_credential(config_dir, ".claude.json", b"new-claude", 0o640)
+        _write_credential(config_dir, ".credentials.json", b"new-oauth", 0o600)
+        return {"success": True}
+
+    _install_cdp_login(monkeypatch, successful_login)
+
+    ok = await auto_login.perform_login(
+        email="user@onet.pl",
+        token_171="platform-query-token",
+        config_dir=str(tmp_path),
+        provider="onet",
+    )
+
+    assert ok is True
+    assert captured["token"] == "platform-query-token"
+    assert captured["mail_provider"] == "onet"
+    assert _credential_state(tmp_path, ".claude.json") == (b"new-claude", 0o640)
+    assert _credential_state(tmp_path, ".credentials.json") == (b"new-oauth", 0o600)

--- a/backend/tests/test_codex_login_mailbox.py
+++ b/backend/tests/test_codex_login_mailbox.py
@@ -1,14 +1,154 @@
-from scripts.codex_login import WEBMAIL_LOGIN_URLS, detect_mail_provider
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pytest
+
+import scripts.codex_login as codex_login
+
+
+class _Response:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _MailClient:
+    def __init__(self, responses: Iterable[dict], calls: list[dict]):
+        self._responses = iter(responses)
+        self._calls = calls
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def get(self, url: str, **kwargs):
+        self._calls.append({"url": url, **kwargs})
+        return _Response(next(self._responses))
+
+
+def _install_mail_client(monkeypatch, responses: list[dict]) -> dict:
+    state: dict = {"timeouts": [], "calls": []}
+
+    def factory(*_args, **kwargs):
+        state["timeouts"].append(kwargs.get("timeout"))
+        return _MailClient(responses, state["calls"])
+
+    monkeypatch.setattr(codex_login.httpx, "AsyncClient", factory)
+    monkeypatch.setattr(codex_login, "MAIL_POLL_INTERVAL", 0)
+    return state
+
+
+def _success(*, code: str = "654321", **timestamp_fields) -> dict:
+    return {
+        "code": 200,
+        "message": "success",
+        "data": {
+            "subject": "Your OpenAI verification code",
+            "code": code,
+            **timestamp_fields,
+        },
+    }
 
 
 def test_detect_mail_provider():
-    assert detect_mail_provider("user@onet.pl") == "onet"
-    assert detect_mail_provider("user@GAZETA.PL") == "gazeta"
-    assert detect_mail_provider("user@israelmail.com") == "171mail"
+    assert codex_login.detect_mail_provider("user@onet.pl") == "onet"
+    assert codex_login.detect_mail_provider("user@GAZETA.PL") == "gazeta"
+    assert codex_login.detect_mail_provider("user@israelmail.com") == "171mail"
 
 
-def test_webmail_login_urls_are_explicit():
-    assert WEBMAIL_LOGIN_URLS == {
-        "onet": "https://onet.pl/poczta",
-        "gazeta": "https://oauth.gazeta.pl",
-    }
+@pytest.mark.parametrize(
+    "timestamp_fields",
+    [
+        {"date": "2023-11-14T22:13:30+00:00"},
+        {"Date": "Tue, 14 Nov 2023 22:13:30 +0000"},
+        {"subject": "Your OpenAI verification code | 2023-11-14 22:13:30"},
+    ],
+    ids=["mailcatcher-lowercase-date", "legacy-uppercase-Date", "subject-fallback"],
+)
+async def test_mailcatcher_accepts_only_fresh_timestamped_code(monkeypatch, timestamp_fields):
+    state = _install_mail_client(monkeypatch, [_success(**timestamp_fields)])
+
+    code = await codex_login.poll_verification_code(
+        "platform-query-token",
+        after_ts=1_699_999_990,
+        timeout_s=1,
+        email="user@onet.pl",
+        provider="onet",
+    )
+
+    assert code == "654321"
+    assert state["timeouts"] and state["timeouts"][0] >= 90
+    assert state["calls"] == [{
+        "url": codex_login.MAIL_DECODE_API,
+        "params": {"token": "platform-query-token", "type": "gpt"},
+    }]
+
+
+async def test_mailcatcher_202_is_polled_until_200(monkeypatch):
+    state = _install_mail_client(monkeypatch, [
+        {"code": 202, "message": "processing"},
+        _success(date="2023-11-14T22:13:30+00:00"),
+    ])
+
+    code = await codex_login.poll_verification_code(
+        "platform-query-token",
+        after_ts=1_699_999_990,
+        timeout_s=1,
+        provider="gazeta",
+    )
+
+    assert code == "654321"
+    assert len(state["calls"]) == 2
+
+
+async def test_mailcatcher_invalid_query_token_fails_immediately(monkeypatch):
+    state = _install_mail_client(monkeypatch, [
+        {"code": 401, "message": "invalid token"},
+    ])
+
+    with pytest.raises(RuntimeError, match="rejected.*token|token.*rejected"):
+        await codex_login.poll_verification_code(
+            "not-a-mailbox-password",
+            after_ts=1_699_999_990,
+            timeout_s=1,
+            provider="onet",
+        )
+
+    assert len(state["calls"]) == 1
+
+
+async def test_mailcatcher_stale_code_is_not_returned(monkeypatch):
+    _install_mail_client(monkeypatch, [
+        # Even a message one second before the login attempt is stale.  A
+        # grace window here can reuse the previous attempt's still-valid OTP.
+        _success(code="111111", date="2023-11-14T22:13:19+00:00"),
+        _success(code="222222", date="2023-11-14T22:13:21+00:00"),
+    ])
+
+    code = await codex_login.poll_verification_code(
+        "platform-query-token",
+        after_ts=1_700_000_000,
+        timeout_s=1,
+        provider="onet",
+    )
+
+    assert code == "222222"
+
+
+async def test_mailcatcher_undated_code_times_out_instead_of_being_reused(monkeypatch):
+    _install_mail_client(monkeypatch, [_success(code="111111")])
+    clock = iter([0.0, 0.0, 2.0])
+    monkeypatch.setattr(codex_login.time, "time", lambda: next(clock))
+
+    with pytest.raises(RuntimeError, match="No fresh OpenAI verification code"):
+        await codex_login.poll_verification_code(
+            "platform-query-token",
+            after_ts=0.5,
+            timeout_s=1,
+            provider="gazeta",
+        )

--- a/backend/tests/test_codex_login_mailbox.py
+++ b/backend/tests/test_codex_login_mailbox.py
@@ -1,0 +1,14 @@
+from scripts.codex_login import WEBMAIL_LOGIN_URLS, detect_mail_provider
+
+
+def test_detect_mail_provider():
+    assert detect_mail_provider("user@onet.pl") == "onet"
+    assert detect_mail_provider("user@GAZETA.PL") == "gazeta"
+    assert detect_mail_provider("user@israelmail.com") == "171mail"
+
+
+def test_webmail_login_urls_are_explicit():
+    assert WEBMAIL_LOGIN_URLS == {
+        "onet": "https://onet.pl/poczta",
+        "gazeta": "https://oauth.gazeta.pl",
+    }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -973,7 +973,7 @@ export const api = {
     request<RuntimeSettings>(`/api/workers/${id}/settings/runtime`, { method: 'PUT', body: JSON.stringify(data) }),
   getWorkerPool: (id: number) =>
     request<{ enabled: boolean; total: number; available: number; accounts: { id: string; email: string | null; enabled: boolean; available: boolean; cooldown_remaining: number }[] }>(`/api/workers/${id}/pool`),
-  createWorker: (data: { accounts: { email: string; token?: string }[]; name?: string }) =>
+  createWorker: (data: { accounts: { email: string; token?: string; login_method?: string }[]; name?: string }) =>
     request<Worker>('/api/workers', { method: 'POST', body: JSON.stringify(data) }),
   getWorker: (id: number) => request<Worker>(`/api/workers/${id}`),
   getWorkerLogs: (id: number) => request<{ id: number; bootstrap_log: string | null }>(`/api/workers/${id}/logs`),

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1035,7 +1035,7 @@ export const api = {
     request<{ ok: boolean; status: string }>(`/api/codex-pool/accounts/${accountId}/relogin`, { method: 'POST' }),
   codexPoolReloginStatus: (accountId: string) =>
     request<{ status: string; detail?: string }>(`/api/codex-pool/accounts/${accountId}/relogin`),
-  codexPoolAddAccount: (data: { email: string; token: string; password?: string }) =>
+  codexPoolAddAccount: (data: { email: string; token: string; password?: string; login_method?: string }) =>
     request<{ ok: boolean; status: string; account_id?: string }>('/api/codex-pool/add', { method: 'POST', body: JSON.stringify(data) }),
   codexPoolAddStatus: (email: string) =>
     request<{ status: string; detail?: string }>(`/api/codex-pool/add/${encodeURIComponent(email)}`),

--- a/frontend/src/components/Layout/PoolDrawer.tsx
+++ b/frontend/src/components/Layout/PoolDrawer.tsx
@@ -363,6 +363,8 @@ function AddAccountModal({ onClose, onAdded }: { onClose: () => void; onAdded: (
               <option value="">自动识别（按邮箱后缀）</option>
               <option value="171mail">171mail（API 接码）</option>
               <option value="mailcom">mail.com（Chrome 接码）</option>
+              <option value="onet">Onet（Token 接码）</option>
+              <option value="gazeta">Gazeta（Token 接码）</option>
             </select>
           </div>
           {status === 'running' && <p className="text-xs text-blue-400">登录中… 请等待（可能需要 1-2 分钟）</p>}
@@ -385,10 +387,15 @@ function AddCodexAccountModal({ onClose, onAdded }: { onClose: () => void; onAdd
   const [email, setEmail] = useState('');
   const [token, setToken] = useState('');
   const [password, setPassword] = useState('');
+  const [loginMethod, setLoginMethod] = useState('');
 
   const [status, setStatus] = useState<string | null>(null);
   const [detail, setDetail] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const emailDomain = email.trim().toLowerCase().split('@').pop() || '';
+  const detectedMethod = emailDomain === 'onet.pl' ? 'onet' : emailDomain === 'gazeta.pl' ? 'gazeta' : '171mail';
+  const activeMethod = loginMethod || detectedMethod;
+  const usesWebmail = activeMethod === 'onet' || activeMethod === 'gazeta';
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -396,7 +403,10 @@ function AddCodexAccountModal({ onClose, onAdded }: { onClose: () => void; onAdd
     setSubmitting(true);
     setDetail(null);
     try {
-      await api.codexPoolAddAccount({ email: email.trim(), token: token.trim(), password: password || undefined });
+      await api.codexPoolAddAccount({
+        email: email.trim(), token: token.trim(), password: password || undefined,
+        login_method: loginMethod || undefined,
+      });
       setStatus('running');
       const poll = async () => {
         const s = await api.codexPoolAddStatus(email.trim());
@@ -427,9 +437,25 @@ function AddCodexAccountModal({ onClose, onAdded }: { onClose: () => void; onAdd
               value={email} onChange={e => setEmail(e.target.value)} placeholder="user@example.com" required />
           </div>
           <div>
-            <label className="block text-xs text-gray-400 mb-1">171mail 接码 Token</label>
+            <label className="block text-xs text-gray-400 mb-1">验证码接收方式</label>
+            <select
+              className="w-full bg-gray-700 text-foreground text-xs rounded px-2.5 py-1.5 outline-none focus:ring-1 focus:ring-emerald-500"
+              value={loginMethod} onChange={e => setLoginMethod(e.target.value)}
+            >
+              <option value="">自动识别（按邮箱后缀）</option>
+              <option value="171mail">171mail（API 接码）</option>
+              <option value="onet">Onet（Token 接码）</option>
+              <option value="gazeta">Gazeta（Token 接码）</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">
+              {usesWebmail ? '邮箱接码 Token' : '接码 Token'}
+            </label>
             <input className="w-full bg-gray-700 text-foreground text-xs rounded px-2.5 py-1.5 outline-none focus:ring-1 focus:ring-emerald-500"
-              value={token} onChange={e => setToken(e.target.value)} placeholder="171mail token" required />
+              type="text" value={token} onChange={e => setToken(e.target.value)}
+              placeholder="接码 Token" required />
+            {usesWebmail && <p className="mt-1 text-[11px] text-gray-500">Token 用于接码 API 获取 OpenAI 邮箱验证码。</p>}
           </div>
           <div>
             <label className="block text-xs text-gray-400 mb-1">密码（留空=无密码登录 OTP）</label>

--- a/frontend/src/components/Layout/PoolDrawer.tsx
+++ b/frontend/src/components/Layout/PoolDrawer.tsx
@@ -350,9 +350,10 @@ function AddAccountModal({ onClose, onAdded }: { onClose: () => void; onAdded: (
               value={email} onChange={e => setEmail(e.target.value)} placeholder="user@example.com" required />
           </div>
           <div>
-            <label className="block text-xs text-gray-400 mb-1">接码 Token / 密码</label>
+            <label className="block text-xs text-gray-400 mb-1">接码 API Token</label>
             <input className="w-full bg-gray-700 text-foreground text-xs rounded px-2.5 py-1.5 outline-none focus:ring-1 focus:ring-indigo-500"
-              value={token} onChange={e => setToken(e.target.value)} placeholder="Token 或邮箱密码" required />
+              type="password" value={token} onChange={e => setToken(e.target.value)}
+              placeholder="171mail / MailCatcher Token" required />
           </div>
           <div>
             <label className="block text-xs text-gray-400 mb-1">登录方式</label>
@@ -395,7 +396,7 @@ function AddCodexAccountModal({ onClose, onAdded }: { onClose: () => void; onAdd
   const emailDomain = email.trim().toLowerCase().split('@').pop() || '';
   const detectedMethod = emailDomain === 'onet.pl' ? 'onet' : emailDomain === 'gazeta.pl' ? 'gazeta' : '171mail';
   const activeMethod = loginMethod || detectedMethod;
-  const usesWebmail = activeMethod === 'onet' || activeMethod === 'gazeta';
+  const usesMailCatcher = activeMethod === 'onet' || activeMethod === 'gazeta';
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -450,12 +451,12 @@ function AddCodexAccountModal({ onClose, onAdded }: { onClose: () => void; onAdd
           </div>
           <div>
             <label className="block text-xs text-gray-400 mb-1">
-              {usesWebmail ? '邮箱接码 Token' : '接码 Token'}
+              {usesMailCatcher ? 'MailCatcher 查询 Token' : '接码 Token'}
             </label>
             <input className="w-full bg-gray-700 text-foreground text-xs rounded px-2.5 py-1.5 outline-none focus:ring-1 focus:ring-emerald-500"
-              type="text" value={token} onChange={e => setToken(e.target.value)}
+              type="password" value={token} onChange={e => setToken(e.target.value)}
               placeholder="接码 Token" required />
-            {usesWebmail && <p className="mt-1 text-[11px] text-gray-500">Token 用于接码 API 获取 OpenAI 邮箱验证码。</p>}
+            {usesMailCatcher && <p className="mt-1 text-[11px] text-gray-500">使用 MailCatcher 平台签发的 Token，不是邮箱密码。</p>}
           </div>
           <div>
             <label className="block text-xs text-gray-400 mb-1">密码（留空=无密码登录 OTP）</label>

--- a/frontend/src/pages/WorkersPage.tsx
+++ b/frontend/src/pages/WorkersPage.tsx
@@ -82,6 +82,8 @@ function AddWorkerModal({ onClose, onSaved }: { onClose: () => void; onSaved: ()
                   <option value="">自动识别（按邮箱后缀）</option>
                   <option value="171mail">171mail（API 接码）</option>
                   <option value="mailcom">mail.com（Chrome 接码）</option>
+                  <option value="onet">Onet（Token 接码）</option>
+                  <option value="gazeta">Gazeta（Token 接码）</option>
                 </select>
               </div>
               {accounts.length > 1 && (

--- a/frontend/src/pages/WorkersPage.tsx
+++ b/frontend/src/pages/WorkersPage.tsx
@@ -71,7 +71,7 @@ function AddWorkerModal({ onClose, onSaved }: { onClose: () => void; onSaved: ()
                 />
                 <input
                   className="w-full bg-gray-700 text-foreground text-sm rounded px-3 py-2 outline-none focus:ring-1 focus:ring-indigo-500"
-                  value={acct.token} placeholder="Token 或邮箱密码"
+                  type="password" value={acct.token} placeholder="171mail / MailCatcher Token"
                   onChange={(e) => setAccounts(accounts.map((a, j) => (j === i ? { ...a, token: e.target.value } : a)))}
                 />
                 <select

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "claude-pty @ git+https://github.com/zjw49246/Claude-Code-PTY",
     "pyjwt>=2.13.0",
     "bcrypt>=5.0.0",
+    "playwright>=1.61.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/auto_login.py
+++ b/scripts/auto_login.py
@@ -70,11 +70,26 @@ EMAIL_POLL_TIMEOUT = 300  # mail.com IMAP 拉取可能延迟几分钟
 MAILCOM_DOMAINS = {
     "mail.com",
 }
+TOKEN_MAILBOX_DOMAINS = {
+    "onet.pl": "onet",
+    "gazeta.pl": "gazeta",
+}
 
 
 def is_mailcom_domain(email: str) -> bool:
     domain = email.split("@")[-1].lower()
     return domain in MAILCOM_DOMAINS
+
+
+def detect_login_method(email: str) -> str:
+    domain = email.rsplit("@", 1)[-1].strip().lower()
+    if domain in MAILCOM_DOMAINS:
+        return "mailcom"
+    return TOKEN_MAILBOX_DOMAINS.get(domain, "171mail")
+
+
+def uses_mailcatcher_api(provider: str) -> bool:
+    return provider in {"mailcom", "onet", "gazeta"}
 PLAYWRIGHT_NAV_TIMEOUT = 30_000  # ms
 CLI_OAUTH_URL_TIMEOUT = 15
 CLI_EXIT_TIMEOUT = 30
@@ -757,10 +772,8 @@ async def perform_login(
     config_path = Path(config_dir).expanduser()
     config_path.mkdir(parents=True, exist_ok=True)
 
-    if provider:
-        _use_mailcatcher = provider == "mailcom"
-    else:
-        _use_mailcatcher = is_mailcom_domain(email)
+    provider = provider or detect_login_method(email)
+    _use_mailcatcher = uses_mailcatcher_api(provider)
 
     # Backup old credentials — only delete after successful login to avoid
     # leaving the account in a "no credentials" state if login fails.
@@ -787,7 +800,7 @@ async def perform_login(
                 (config_path / f).write_bytes(data)
             return False
     else:
-        logger.info("step 1: mail.com 域（Chrome 输入邮箱 + MailCatcher 接码）")
+        logger.info("step 1: %s（Chrome 输入邮箱 + MailCatcher API 接码）", provider)
 
     # Step 2: Chrome CDP 全流程（输入邮箱 → magic link → OAuth）
     logger.info("step 2: Chrome CDP 全流程登录...")
@@ -799,6 +812,7 @@ async def perform_login(
         token=token_171,
         config_dir=str(config_path),
         magic_link=magic_link_171,
+        mail_provider=provider,
     )
     if not result or not result.get("success"):
         logger.error("Chrome CDP 登录失败 — restoring old credentials")
@@ -855,8 +869,8 @@ def main():
     # 兼容旧调用（Worker bootstrap 可能还传这些参数）
     parser.add_argument("--provider", default=None, help=argparse.SUPPRESS)
     parser.add_argument("--mail-password", default=None, help=argparse.SUPPRESS)
-    parser.add_argument("--login-method", default=None, choices=["171mail", "mailcom"],
-                        help="Login method: 171mail (API) or mailcom (Chrome CDP). Auto-detected by email suffix if not specified.")
+    parser.add_argument("--login-method", default=None, choices=["171mail", "mailcom", "onet", "gazeta"],
+                        help="Mailbox method. Auto-detected by email suffix if not specified.")
     args = parser.parse_args()
 
     email = args.email
@@ -864,24 +878,26 @@ def main():
         email = input("Email: ").strip()
 
     # 按 --login-method 参数 → saved provider → 邮箱后缀 判断登录方式
+    detected_method = detect_login_method(email)
+    saved = load_email_tokens().get(email)
+    saved_provider = saved.get("provider") if isinstance(saved, dict) else None
     if args.login_method:
-        use_webmail = args.login_method == "mailcom"
+        login_method = args.login_method
+    elif detected_method != "171mail":
+        login_method = detected_method
+    elif saved_provider in ("171mail", "mailcom", "onet", "gazeta"):
+        login_method = saved_provider
     else:
-        saved_provider = (load_email_tokens().get(email) or {}).get("provider")
-        if saved_provider:
-            use_webmail = saved_provider == "mailcom"
-        else:
-            use_webmail = is_mailcom_domain(email)
+        login_method = detected_method
 
     # token: 171mail 的接码 token，或 mail.com 的邮箱密码
-    saved = load_email_tokens().get(email)
     token = args.token or args.mail_password
     if not token and saved:
-        token = saved.get("token") or saved.get("mail_password")
+        token = (saved.get("token") or saved.get("mail_password")) if isinstance(saved, dict) else saved
         if token:
             logger.info("found saved token for %s", email)
     if not token:
-        token = input("mail.com 密码: " if use_webmail else "171mail Token: ").strip()
+        token = input("接码 Token / 密码: " if login_method != "171mail" else "171mail Token: ").strip()
 
     config_dir = args.config_dir
     if not config_dir:
@@ -890,14 +906,13 @@ def main():
             config_dir = str(Path.home() / ".claude-account-new")
 
     if args.save_token or not get_email_token(email):
-        provider_label = "mailcom" if use_webmail else "171mail"
-        save_email_token(email, token, provider=provider_label)
+        save_email_token(email, token, provider=login_method)
 
     ok = asyncio.run(perform_login(
         email=email,
         token_171=token,
         config_dir=config_dir,
-        provider="mailcom" if use_webmail else "171mail",
+        provider=login_method,
     ))
 
     if ok and args.add_to_pool:

--- a/scripts/auto_login.py
+++ b/scripts/auto_login.py
@@ -63,7 +63,7 @@ OAUTH_URL_RE = re.compile(r"https://claude\.com/cai/oauth/authorize\?[^\s]+")
 _COOKIE_ATTR_KEYS = {"path", "domain", "expires", "max-age", "samesite", "secure", "httponly"}
 _DROP_COOKIES = {"__cf_bm", "_cfuvid"}
 
-EMAIL_POLL_TIMEOUT = 300  # mail.com IMAP 拉取可能延迟几分钟
+EMAIL_POLL_TIMEOUT = 300  # MailCatcher 同步解析可能延迟几分钟
 
 # mail.com 家族域名——这些邮箱走 Chrome CDP（MailCatcher 接码），
 # 其余走 171mail（API 接码）。根据邮箱后缀自动判断，不需要用户手动选 provider。
@@ -754,6 +754,38 @@ def add_to_pool(account_id: str, config_dir: str, email: str):
 # Main login flow
 # ---------------------------------------------------------------------------
 
+
+_CREDENTIAL_FILES = (".claude.json", ".credentials.json")
+
+
+def _snapshot_credentials(config_path: Path) -> dict[str, tuple[bytes, int]]:
+    """Read the complete credential snapshot before removing either file."""
+    snapshot: dict[str, tuple[bytes, int]] = {}
+    for name in _CREDENTIAL_FILES:
+        path = config_path / name
+        if path.exists():
+            snapshot[name] = (path.read_bytes(), path.stat().st_mode & 0o777)
+    try:
+        for name in _CREDENTIAL_FILES:
+            (config_path / name).unlink(missing_ok=True)
+    except Exception:
+        _restore_credentials(config_path, snapshot)
+        raise
+    return snapshot
+
+
+def _restore_credentials(
+    config_path: Path, snapshot: dict[str, tuple[bytes, int]],
+) -> None:
+    """Remove partial login output and restore the exact pre-login state."""
+    for name in _CREDENTIAL_FILES:
+        (config_path / name).unlink(missing_ok=True)
+    for name, (data, mode) in snapshot.items():
+        path = config_path / name
+        path.write_bytes(data)
+        path.chmod(mode)
+
+
 async def perform_login(
     *,
     email: str,
@@ -764,10 +796,11 @@ async def perform_login(
 ) -> bool:
     """统一登录流程（Chrome CDP，不用 Playwright/mitmproxy）。
 
-    171mail 域：API 拿 cookies → 注入 Chrome → OAuth Authorize
-    mail.com 域：Chrome 打开 claude.ai → 输入邮箱 → MailCatcher 接码 → magic link → OAuth Authorize
+    171mail：通过 171mail API 预取 magic link。
+    mail.com / Onet / Gazeta：Chrome 输入邮箱后，使用 MailCatcher
+    平台签发的查询 token 接收 magic link（不是邮箱密码）。
     两者共享 Step 2-4（CLI auth login + Chrome CDP OAuth + code#state 交给 CLI）。
-    provider: 显式指定 "171mail" 或 "mailcom"，None 则按邮箱域名自动判断。
+    provider: 显式指定接码渠道，None 则按邮箱域名自动判断。
     """
     config_path = Path(config_dir).expanduser()
     config_path.mkdir(parents=True, exist_ok=True)
@@ -775,82 +808,80 @@ async def perform_login(
     provider = provider or detect_login_method(email)
     _use_mailcatcher = uses_mailcatcher_api(provider)
 
-    # Backup old credentials — only delete after successful login to avoid
-    # leaving the account in a "no credentials" state if login fails.
-    _backup_creds = {}
-    for f in [".claude.json", ".credentials.json"]:
-        fp = config_path / f
-        if fp.exists():
-            _backup_creds[f] = fp.read_bytes()
-            fp.unlink()
+    try:
+        backup_creds = _snapshot_credentials(config_path)
+    except OSError as exc:
+        logger.error("unable to prepare credential snapshot: %s", exc)
+        return False
 
-    # Step 1: 171mail 域先通过 API 拿 magic link（mail.com 域在 Chrome+MailCatcher 里拿）
-    magic_link_171: str | None = None
-    if not _use_mailcatcher:
-        logger.info("step 1: 171mail — triggering + polling magic link...")
-        try:
+    login_succeeded = False
+    try:
+        # Step 1: 171mail 域先通过 API 拿 magic link（其他渠道由 MailCatcher 取码）
+        magic_link_171: str | None = None
+        if not _use_mailcatcher:
+            logger.info("step 1: 171mail — triggering + polling magic link...")
             async with httpx.AsyncClient(timeout=30) as mc:
                 device_id, client_sha = await _trigger_send(mc, email)
                 send_ts = time.time()
                 magic_link_171 = await _poll_magic_link(mc, token_171, send_ts, EMAIL_POLL_TIMEOUT)
                 logger.info("got magic link (%d chars)", len(magic_link_171))
-        except MailServiceError as exc:
-            logger.error("171mail error: %s — restoring old credentials", exc)
-            for f, data in _backup_creds.items():
-                (config_path / f).write_bytes(data)
+        else:
+            logger.info("step 1: %s（Chrome 输入邮箱 + MailCatcher API 接码）", provider)
+
+        # Step 2: Chrome CDP 全流程（输入邮箱 → magic link → OAuth）
+        logger.info("step 2: Chrome CDP 全流程登录...")
+        script_dir = Path(__file__).resolve().parent
+        sys.path.insert(0, str(script_dir))
+        from cdp_login import cdp_login
+        result = await cdp_login(
+            email=email,
+            token=token_171,
+            config_dir=str(config_path),
+            magic_link=magic_link_171,
+            mail_provider=provider,
+        )
+        if not result or not result.get("success"):
+            logger.error("Chrome CDP 登录失败")
             return False
-    else:
-        logger.info("step 1: %s（Chrome 输入邮箱 + MailCatcher API 接码）", provider)
 
-    # Step 2: Chrome CDP 全流程（输入邮箱 → magic link → OAuth）
-    logger.info("step 2: Chrome CDP 全流程登录...")
-    script_dir = Path(__file__).resolve().parent
-    sys.path.insert(0, str(script_dir))
-    from cdp_login import cdp_login
-    result = await cdp_login(
-        email=email,
-        token=token_171,
-        config_dir=str(config_path),
-        magic_link=magic_link_171,
-        mail_provider=provider,
-    )
-    if not result or not result.get("success"):
-        logger.error("Chrome CDP 登录失败 — restoring old credentials")
-        for f, data in _backup_creds.items():
-            (config_path / f).write_bytes(data)
-        return False
-
-    # Merge default settings into settings.json (preserve existing hooks)
-    settings_path = config_path / "settings.json"
-    _default_cc_settings = {
-        "permissions": {
-            "defaultMode": "bypassPermissions",
-            "additionalDirectories": ["/home/ubuntu/Claude-Code-Manager"],
-        },
-        "model": "claude-opus-4-6",
-        "effortLevel": "medium",
-        "skipDangerousModePermissionPrompt": True,
-        "hasCompletedOnboarding": True,
-        "theme": "dark",
-        "showThinkingSummaries": True,
-    }
-    existing_settings: dict = {}
-    if settings_path.exists():
-        try:
-            existing_settings = json.loads(settings_path.read_text(encoding="utf-8")) or {}
-        except (json.JSONDecodeError, OSError):
+        # Merge default settings into settings.json (preserve existing hooks)
+        settings_path = config_path / "settings.json"
+        default_cc_settings = {
+            "permissions": {
+                "defaultMode": "bypassPermissions",
+                "additionalDirectories": ["/home/ubuntu/Claude-Code-Manager"],
+            },
+            "model": "claude-opus-4-6",
+            "effortLevel": "medium",
+            "skipDangerousModePermissionPrompt": True,
+            "hasCompletedOnboarding": True,
+            "theme": "dark",
+            "showThinkingSummaries": True,
+        }
+        existing_settings: dict = {}
+        if settings_path.exists():
+            try:
+                existing_settings = json.loads(settings_path.read_text(encoding="utf-8")) or {}
+            except (json.JSONDecodeError, OSError):
+                existing_settings = {}
+        if not isinstance(existing_settings, dict):
             existing_settings = {}
-    if not isinstance(existing_settings, dict):
-        existing_settings = {}
-    saved_hooks = existing_settings.get("hooks")
-    merged = {**existing_settings, **_default_cc_settings}
-    if saved_hooks is not None:
-        merged["hooks"] = saved_hooks
-    settings_path.write_text(json.dumps(merged, indent=2))
-    logger.info("merged default settings.json to %s", settings_path)
+        saved_hooks = existing_settings.get("hooks")
+        merged = {**existing_settings, **default_cc_settings}
+        if saved_hooks is not None:
+            merged["hooks"] = saved_hooks
+        settings_path.write_text(json.dumps(merged, indent=2))
+        logger.info("merged default settings.json to %s", settings_path)
 
-    logger.info("登录成功: %s", email)
-    return True
+        login_succeeded = True
+        logger.info("登录成功: %s", email)
+        return True
+    except Exception as exc:
+        logger.exception("login failed for %s: %s", email, exc)
+        return False
+    finally:
+        if not login_succeeded:
+            _restore_credentials(config_path, backup_creds)
 
 
 # ---------------------------------------------------------------------------
@@ -860,7 +891,10 @@ async def perform_login(
 def main():
     parser = argparse.ArgumentParser(description="Auto-login Claude account")
     parser.add_argument("--email", help="Claude account email")
-    parser.add_argument("--token", help="接码 token（171mail 用）或 mail.com 邮箱密码（mail.com 域自动识别）")
+    parser.add_argument(
+        "--token",
+        help="171mail token，或 MailCatcher 平台签发的查询 token（不是邮箱密码）",
+    )
     parser.add_argument("--config-dir", help="CLAUDE_CONFIG_DIR for this account")
     parser.add_argument("--add-to-pool", metavar="ACCOUNT_ID",
                         help="Add to ~/.claude-pool/accounts.json with this ID after login")
@@ -890,14 +924,14 @@ def main():
     else:
         login_method = detected_method
 
-    # token: 171mail 的接码 token，或 mail.com 的邮箱密码
+    # --mail-password / mail_password 是历史字段名，其值仍必须是接码 API token。
     token = args.token or args.mail_password
     if not token and saved:
         token = (saved.get("token") or saved.get("mail_password")) if isinstance(saved, dict) else saved
         if token:
             logger.info("found saved token for %s", email)
     if not token:
-        token = input("接码 Token / 密码: " if login_method != "171mail" else "171mail Token: ").strip()
+        token = input("MailCatcher 查询 Token: " if login_method != "171mail" else "171mail Token: ").strip()
 
     config_dir = args.config_dir
     if not config_dir:

--- a/scripts/capture_browser_url.py
+++ b/scripts/capture_browser_url.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Capture Claude CLI's browser URL without launching a second Chrome."""
+import os
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    target = os.environ.get("CCM_BROWSER_URL_FILE")
+    if not target or len(sys.argv) < 2:
+        return 2
+    path = Path(target)
+    path.write_text(sys.argv[-1], encoding="utf-8")
+    path.chmod(0o600)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cdp_login.py
+++ b/scripts/cdp_login.py
@@ -1,11 +1,34 @@
 """Chrome CDP 登录模块（从 auto_login.py 调用）。"""
-import asyncio, json, os, re, select, shutil, subprocess, sys, tempfile, time
+import asyncio, datetime, json, os, re, select, shutil, subprocess, sys, tempfile, time
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 import httpx, websockets
 
 MAILCATCHER = "https://mail.claude-code-manager.com"
 CDP_PORT = 9222
+
+
+def _mail_timestamp(data: dict) -> float | None:
+    """Return the message timestamp across current and legacy API schemas."""
+    raw = data.get("date") or data.get("Date")
+    if raw:
+        value = str(raw).strip()
+        try:
+            return datetime.datetime.fromisoformat(
+                value.replace("Z", "+00:00")
+            ).timestamp()
+        except ValueError:
+            try:
+                return parsedate_to_datetime(value).timestamp()
+            except (TypeError, ValueError):
+                pass
+
+    subject = str(data.get("subject") or "")
+    match = re.search(r"\|\s+(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})", subject)
+    if match:
+        return time.mktime(time.strptime(match.group(1), "%Y-%m-%d %H:%M:%S"))
+    return None
 
 
 async def poll_mailcatcher_magic_link(token: str, after_ts: float, timeout_s: int = 360) -> str | None:
@@ -18,7 +41,15 @@ async def poll_mailcatcher_magic_link(token: str, after_ts: float, timeout_s: in
                     f"{MAILCATCHER}/api/v1/message",
                     params={"token": token, "type": "claude"},
                 )
+                status_code = getattr(response, "status_code", 200)
+                if status_code in {401, 403}:
+                    raise RuntimeError("MailCatcher API rejected the query token")
+                if status_code >= 400:
+                    response.raise_for_status()
                 payload = response.json()
+                if not isinstance(payload, dict):
+                    await asyncio.sleep(2)
+                    continue
                 if payload.get("code") == 202:
                     print("  MailCatcher task still processing")
                     await asyncio.sleep(3)
@@ -27,18 +58,18 @@ async def poll_mailcatcher_magic_link(token: str, after_ts: float, timeout_s: in
                     message = payload.get("message") or payload.get("error") or "unknown error"
                     raise RuntimeError(f"MailCatcher API rejected the mailbox token: {message}")
                 data = payload.get("data") or {}
+                if not isinstance(data, dict):
+                    await asyncio.sleep(2)
+                    continue
             except (httpx.HTTPError, ValueError) as exc:
                 print(f"  MailCatcher retry after {type(exc).__name__}")
                 await asyncio.sleep(2)
                 continue
-            subject = data.get("subject", "")
             code = data.get("code", "")
-            if code.startswith("http") and subject:
-                match = re.search(r"\|\s+(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})", subject)
-                if match:
-                    received_at = time.mktime(time.strptime(match.group(1), "%Y-%m-%d %H:%M:%S"))
-                    if received_at >= after_ts - 10:
-                        return code
+            received_at = _mail_timestamp(data)
+            if code.startswith("http") and received_at is not None:
+                if received_at >= int(after_ts):
+                    return code
             await asyncio.sleep(2)
     return None
 
@@ -124,20 +155,95 @@ async def _wait_cli_oauth_url(cli, capture_path: Path | None, timeout: int):
         await asyncio.sleep(0.1)
     return None, captured
 
+
+def _stop_process(process) -> None:
+    """Terminate and reap a child process without masking the login result."""
+    if process is None:
+        return
+    try:
+        if process.poll() is None:
+            process.kill()
+    except (OSError, ProcessLookupError):
+        pass
+    try:
+        process.wait(timeout=5)
+    except (OSError, ProcessLookupError, subprocess.TimeoutExpired):
+        pass
+
+
+class _LoginResources:
+    """Own all resources that must survive across the CDP login flow."""
+
+    def __init__(self) -> None:
+        self.cli = None
+        self.chrome = None
+        self.chrome_stderr = None
+        self.temporary_auth_dir: Path | None = None
+
+    def cleanup(self) -> None:
+        chrome, self.chrome = self.chrome, None
+        cli, self.cli = self.cli, None
+        chrome_stderr, self.chrome_stderr = self.chrome_stderr, None
+        temporary_auth_dir, self.temporary_auth_dir = self.temporary_auth_dir, None
+        _stop_process(chrome)
+        _stop_process(cli)
+        if chrome_stderr is not None:
+            try:
+                chrome_stderr.close()
+            except OSError:
+                pass
+        if temporary_auth_dir is not None:
+            shutil.rmtree(temporary_auth_dir, ignore_errors=True)
+
+
+def _commit_temporary_credentials(source_dir: Path, target_dir: Path) -> None:
+    """Commit every credential file produced in the isolated auth directory."""
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for name in (".credentials.json", ".claude.json"):
+        source = source_dir / name
+        if not source.exists():
+            continue
+        target = target_dir / name
+        target.write_bytes(source.read_bytes())
+        target.chmod(0o600)
+
+
 async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = "",
+                    cookies_171: list[dict] | None = None, magic_link: str | None = None,
+                    mail_provider: str = "171mail") -> dict | None:
+    """Run CDP login and deterministically release preflight/browser resources."""
+    resources = _LoginResources()
+    try:
+        return await _cdp_login(
+            email=email,
+            token=token,
+            config_dir=config_dir,
+            oauth_url=oauth_url,
+            cookies_171=cookies_171,
+            magic_link=magic_link,
+            mail_provider=mail_provider,
+            resources=resources,
+        )
+    finally:
+        resources.cleanup()
+
+
+async def _cdp_login(email: str, token: str, config_dir: str, oauth_url: str = "",
                      cookies_171: list[dict] | None = None, magic_link: str | None = None,
-                     mail_provider: str = "171mail") -> dict | None:
+                     mail_provider: str = "171mail", resources: _LoginResources | None = None) -> dict | None:
     """Chrome CDP 登录全流程。
 
     magic_link: 171mail 预取的 magic link，有则直接导航，无则走 MailCatcher 接码。
     cookies_171: 已废弃，保留参数兼容但不使用。
     """
+    resources = resources or _LoginResources()
     temporary_auth_dir = None
     oauth_capture_path = None
     cli = None
     captured = b""
     if mail_provider in {"onet", "gazeta"}:
         temporary_auth_dir = Path(tempfile.mkdtemp(prefix="ccm-claude-auth-"))
+        resources.temporary_auth_dir = temporary_auth_dir
         oauth_capture_path = temporary_auth_dir / "oauth-url"
         cli_env = {
             "CLAUDE_CONFIG_DIR": str(temporary_auth_dir),
@@ -152,13 +258,12 @@ async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = ""
             stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT, bufsize=0,
         )
+        resources.cli = cli
         print(f"  Preflight CLI pid={cli.pid}")
         oauth_url, captured = await _wait_cli_oauth_url(cli, oauth_capture_path, 30)
         if not oauth_url:
-            if cli.poll() is None: cli.kill()
             diagnostic = re.sub(r"https?://\S+", "[URL]", captured.decode(errors="replace"))
             print(f"  Preflight CLI produced no OAuth URL: {diagnostic[:500]}")
-            shutil.rmtree(temporary_auth_dir, ignore_errors=True)
             return None
         print(f"  Preflight OAuth URL ({len(oauth_url)} chars)")
 
@@ -174,12 +279,14 @@ async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = ""
     # 不加会让渲染进程因共享内存不足直接崩溃 → CDP 9222 端口起不来，
     # 后面连 http://127.0.0.1:9222/json 报 ConnectError（登录整段失败）。
     chrome_env = _ensure_display(dict(os.environ))
+    resources.chrome_stderr = open("/tmp/chrome-cdp-stderr.log", "w")
     chrome = subprocess.Popen(["google-chrome", "--no-sandbox", "--disable-gpu",
         "--disable-dev-shm-usage", "--disable-software-rasterizer",
         "--no-first-run", "--disable-extensions", "--window-size=1365,900",
         f"--remote-debugging-port={CDP_PORT}", "--user-data-dir=/tmp/chrome-test-login",
         "about:blank"], stdout=subprocess.DEVNULL,
-        stderr=open("/tmp/chrome-cdp-stderr.log", "w"), env=chrome_env)
+        stderr=resources.chrome_stderr, env=chrome_env)
+    resources.chrome = chrome
     print(f"Chrome pid={chrome.pid}")
 
     # 3. Connect CDP (poll until ready)
@@ -198,9 +305,12 @@ async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = ""
             pass
     if not tabs:
         print("  Chrome CDP not ready after 30s")
-        chrome.kill()
         return None
-    ws_url = next(t["webSocketDebuggerUrl"] for t in tabs if t["type"] == "page")
+    page_tab = next((t for t in tabs if t.get("type") == "page"), None)
+    if not page_tab or not page_tab.get("webSocketDebuggerUrl"):
+        print("  Chrome CDP returned no page tab")
+        return None
+    ws_url = page_tab["webSocketDebuggerUrl"]
 
     try:
         # Mailbox decoding may take over a minute. This is a loopback CDP
@@ -234,11 +344,14 @@ async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = ""
                 return None
             await asyncio.sleep(0.5)
             r = None
+            mail_request_ts = time.time()
             for _ in range(15):
+                attempt_ts = time.time()
                 r = await cdp_eval(ws, JS_BTN.format(
                     cond="t.includes('Continue with email')||t==='Continue'",
                 ))
                 if str(r).startswith("clicked:"):
+                    mail_request_ts = attempt_ts
                     break
                 await asyncio.sleep(2)
             print(f"  Button: {r}")
@@ -254,10 +367,9 @@ async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = ""
                 print(f"  Using pre-fetched magic link ({len(magic_link)} chars)")
                 link = magic_link
             else:
-                # mail.com 路径：poll MailCatcher
-                send_ts = time.time()
+                # MailCatcher 路径：mail.com / Onet / Gazeta
                 print("  Polling MailCatcher...")
-                link = await poll_mailcatcher_magic_link(token, send_ts)
+                link = await poll_mailcatcher_magic_link(token, mail_request_ts)
                 if link:
                     print(f"  Got magic link ({len(link)} chars)")
                 if not link:
@@ -293,6 +405,7 @@ async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = ""
                 cli = subprocess.Popen(["claude", "auth", "login", "--email", email],
                     env=cli_env, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT, bufsize=0)
+                resources.cli = cli
                 print(f"  CLI pid={cli.pid}")
                 oauth_url, captured = await _wait_cli_oauth_url(cli, None, 60)
             else:
@@ -538,9 +651,9 @@ async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = ""
                         creds = json.loads(cred_path.read_text())
                         if creds.get("claudeAiOauth", {}).get("accessToken"):
                             if temporary_auth_dir:
-                                target_cred_path = Path(config_dir) / ".credentials.json"
-                                target_cred_path.write_bytes(cred_path.read_bytes())
-                                target_cred_path.chmod(0o600)
+                                _commit_temporary_credentials(
+                                    temporary_auth_dir, Path(config_dir),
+                                )
                             print("SUCCESS!")
                             return {"code": code, "state": state, "success": True}
                     except Exception:
@@ -550,11 +663,7 @@ async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = ""
             print("FAILED: authorize (no code/state obtained)")
             return None
     finally:
-        chrome.kill(); chrome.wait()
-        if cli is not None and cli.poll() is None:
-            cli.kill()
-        if temporary_auth_dir:
-            shutil.rmtree(temporary_auth_dir, ignore_errors=True)
+        resources.cleanup()
 
 
 if __name__ == "__main__":

--- a/scripts/cdp_login.py
+++ b/scripts/cdp_login.py
@@ -1,11 +1,46 @@
 """Chrome CDP 登录模块（从 auto_login.py 调用）。"""
-import asyncio, json, os, re, select, shutil, subprocess, sys, time
+import asyncio, json, os, re, select, shutil, subprocess, sys, tempfile, time
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 import httpx, websockets
 
 MAILCATCHER = "https://mail.claude-code-manager.com"
 CDP_PORT = 9222
+
+
+async def poll_mailcatcher_magic_link(token: str, after_ts: float, timeout_s: int = 360) -> str | None:
+    """Poll the mailbox decoder, tolerating slow or malformed responses."""
+    deadline = time.time() + timeout_s
+    async with httpx.AsyncClient(timeout=120, headers={"User-Agent": "Mozilla/5.0"}) as client:
+        while time.time() < deadline:
+            try:
+                response = await client.get(
+                    f"{MAILCATCHER}/api/v1/message",
+                    params={"token": token, "type": "claude"},
+                )
+                payload = response.json()
+                if payload.get("code") == 202:
+                    print("  MailCatcher task still processing")
+                    await asyncio.sleep(3)
+                    continue
+                if payload.get("code") != 200:
+                    message = payload.get("message") or payload.get("error") or "unknown error"
+                    raise RuntimeError(f"MailCatcher API rejected the mailbox token: {message}")
+                data = payload.get("data") or {}
+            except (httpx.HTTPError, ValueError) as exc:
+                print(f"  MailCatcher retry after {type(exc).__name__}")
+                await asyncio.sleep(2)
+                continue
+            subject = data.get("subject", "")
+            code = data.get("code", "")
+            if code.startswith("http") and subject:
+                match = re.search(r"\|\s+(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})", subject)
+                if match:
+                    received_at = time.mktime(time.strptime(match.group(1), "%Y-%m-%d %H:%M:%S"))
+                    if received_at >= after_ts - 10:
+                        return code
+            await asyncio.sleep(2)
+    return None
 
 async def cdp_eval(ws, expr, timeout=10):
     mid = int(time.time()*1000) % 100000
@@ -66,13 +101,67 @@ async def handle_cf(ws, ctx, timeout=60):
         await asyncio.sleep(5)
     return False
 
+async def _wait_cli_oauth_url(cli, capture_path: Path | None, timeout: int):
+    captured = b""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        rl, _, _ = select.select([cli.stdout], [], [], 0.2)
+        if rl:
+            try: captured += os.read(cli.stdout.fileno(), 8192)
+            except Exception: break
+        match = re.search(rb"(https://claude\.com/cai/oauth/authorize\S+)", captured)
+        if match:
+            return match.group(1).decode(), captured
+        if capture_path and capture_path.exists():
+            candidate = capture_path.read_text(encoding="utf-8").strip()
+            if candidate.startswith("https://claude.com/cai/oauth/authorize"):
+                return candidate, captured
+        if cli.poll() is not None:
+            try: captured += cli.stdout.read() or b""
+            except Exception: pass
+            match = re.search(rb"(https://claude\.com/cai/oauth/authorize\S+)", captured)
+            return (match.group(1).decode() if match else None), captured
+        await asyncio.sleep(0.1)
+    return None, captured
+
 async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = "",
-                     cookies_171: list[dict] | None = None, magic_link: str | None = None) -> dict | None:
+                     cookies_171: list[dict] | None = None, magic_link: str | None = None,
+                     mail_provider: str = "171mail") -> dict | None:
     """Chrome CDP 登录全流程。
 
     magic_link: 171mail 预取的 magic link，有则直接导航，无则走 MailCatcher 接码。
     cookies_171: 已废弃，保留参数兼容但不使用。
     """
+    temporary_auth_dir = None
+    oauth_capture_path = None
+    cli = None
+    captured = b""
+    if mail_provider in {"onet", "gazeta"}:
+        temporary_auth_dir = Path(tempfile.mkdtemp(prefix="ccm-claude-auth-"))
+        oauth_capture_path = temporary_auth_dir / "oauth-url"
+        cli_env = {
+            "CLAUDE_CONFIG_DIR": str(temporary_auth_dir),
+            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+            "HOME": os.environ.get("HOME", str(Path.home())),
+            "NO_COLOR": "1", "TERM": "dumb",
+            "BROWSER": str(Path(__file__).with_name("capture_browser_url.py")),
+            "CCM_BROWSER_URL_FILE": str(oauth_capture_path),
+        }
+        cli = subprocess.Popen(
+            ["claude", "auth", "login", "--email", email], env=cli_env,
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT, bufsize=0,
+        )
+        print(f"  Preflight CLI pid={cli.pid}")
+        oauth_url, captured = await _wait_cli_oauth_url(cli, oauth_capture_path, 30)
+        if not oauth_url:
+            if cli.poll() is None: cli.kill()
+            diagnostic = re.sub(r"https?://\S+", "[URL]", captured.decode(errors="replace"))
+            print(f"  Preflight CLI produced no OAuth URL: {diagnostic[:500]}")
+            shutil.rmtree(temporary_auth_dir, ignore_errors=True)
+            return None
+        print(f"  Preflight OAuth URL ({len(oauth_url)} chars)")
+
     # 1. Kill old chrome and clean profile
     subprocess.run(["pkill", "-f", "chrome.*remote-debugging"], capture_output=True)
     await asyncio.sleep(2)
@@ -114,9 +203,13 @@ async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = ""
     ws_url = next(t["webSocketDebuggerUrl"] for t in tabs if t["type"] == "page")
 
     try:
-        async with websockets.connect(ws_url, max_size=10_000_000) as ws:
+        # Mailbox decoding may take over a minute. This is a loopback CDP
+        # connection, so websocket keepalive timeouts only create false
+        # disconnects while we await the external mailbox API.
+        async with websockets.connect(
+            ws_url, max_size=10_000_000, ping_interval=None, ping_timeout=None,
+        ) as ws:
             await ws.send(json.dumps({"id": 1, "method": "Page.enable"}))
-            await ws.send(json.dumps({"id": 0, "method": "Network.enable"}))
             await asyncio.sleep(0.5)
 
             # 4. Login page
@@ -128,11 +221,31 @@ async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = ""
             # 5. Enter email
             JS_SET = """(function(){{var inputs=[...document.querySelectorAll('input[type={type}]')].filter(i=>i.offsetParent!==null);if(!inputs.length)return 'no input';var inp=inputs[0];var s=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,'value').set;s.call(inp,'{value}');inp.dispatchEvent(new Event('input',{{bubbles:true}}));inp.dispatchEvent(new Event('change',{{bubbles:true}}));return 'set'}})()"""
             JS_BTN = """(function(){{var btns=[...document.querySelectorAll('button')].filter(b=>b.offsetParent!==null);for(var b of btns){{var t=b.textContent.trim();if({cond}){{b.click();return 'clicked:'+t}}}}return 'no match'}})()"""
-            r = await cdp_eval(ws, JS_SET.format(type="email", value=email))
+            r = None
+            for _ in range(15):
+                r = await cdp_eval(ws, JS_SET.format(type="email", value=email))
+                if r == "set":
+                    break
+                await asyncio.sleep(2)
             print(f"  Email: {r}")
+            if r != "set":
+                await cdp_screenshot(ws, "/tmp/cdp_login_no_email.png")
+                print("  Email input did not appear")
+                return None
             await asyncio.sleep(0.5)
-            r = await cdp_eval(ws, JS_BTN.format(cond="t.includes('Continue with email')"))
+            r = None
+            for _ in range(15):
+                r = await cdp_eval(ws, JS_BTN.format(
+                    cond="t.includes('Continue with email')||t==='Continue'",
+                ))
+                if str(r).startswith("clicked:"):
+                    break
+                await asyncio.sleep(2)
             print(f"  Button: {r}")
+            if not str(r).startswith("clicked:"):
+                await cdp_screenshot(ws, "/tmp/cdp_login_no_continue.png")
+                print("  Continue button not found")
+                return None
             await asyncio.sleep(3)
 
             # 6. Get magic link
@@ -144,23 +257,9 @@ async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = ""
                 # mail.com 路径：poll MailCatcher
                 send_ts = time.time()
                 print("  Polling MailCatcher...")
-                link = None
-                async with httpx.AsyncClient(timeout=30, headers={"User-Agent": "Mozilla/5.0"}) as mc:
-                    deadline = time.time() + 120
-                    while time.time() < deadline:
-                        r = await mc.get(f"{MAILCATCHER}/api/v1/message", params={"token": token, "type": "claude"})
-                        d = r.json().get("data", {})
-                        subj = d.get("subject", "")
-                        code = d.get("code", "")
-                        if code.startswith("http") and subj:
-                            m = re.search(r"\|\s+(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})", subj)
-                            if m:
-                                t = time.mktime(time.strptime(m.group(1), "%Y-%m-%d %H:%M:%S"))
-                                if t >= send_ts - 10:
-                                    link = code
-                                    print(f"  Got magic link ({len(link)} chars)")
-                                    break
-                        await asyncio.sleep(2)
+                link = await poll_mailcatcher_magic_link(token, send_ts)
+                if link:
+                    print(f"  Got magic link ({len(link)} chars)")
                 if not link:
                     print("  TIMEOUT waiting for magic link")
                     return None
@@ -180,26 +279,32 @@ async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = ""
             await cdp_screenshot(ws, "/tmp/cdp_magiclink.png")
 
             # 8. Launch CLI
-            cli = subprocess.Popen(["claude", "auth", "login", "--email", email],
-                env={"CLAUDE_CONFIG_DIR": config_dir, "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"), "HOME": os.environ.get("HOME", str(Path.home())), "NO_COLOR": "1", "TERM": "dumb"},
-                stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=0)
-            print(f"  CLI pid={cli.pid}")
-
-            # Read OAuth URL
-            oauth_url = None
-            captured = b""
-            dl = time.time() + 15
-            while time.time() < dl:
-                if cli.poll() is not None: break
-                rl, _, _ = select.select([cli.stdout], [], [], 0.2)
-                if rl:
-                    try: captured += os.read(cli.stdout.fileno(), 8192)
-                    except: break
-                m = re.search(rb"(https://claude\.com/cai/oauth/authorize\S+)", captured)
-                if m: oauth_url = m.group(1).decode(); break
-                await asyncio.sleep(0.1)
+            # A timed-out/killed `claude auth login` can leave this directory
+            # lock behind.  The next CLI then waits forever before printing its
+            # OAuth URL.  This login task owns config_dir exclusively, so the
+            # stale per-account lock is safe to remove before spawning the CLI.
+            shutil.rmtree(Path(config_dir) / ".claude.json.lock", ignore_errors=True)
+            cli_config_dir = Path(config_dir)
+            if temporary_auth_dir:
+                cli_config_dir = temporary_auth_dir
+                print("  Using clean CLI auth state")
+            if cli is None:
+                cli_env = {"CLAUDE_CONFIG_DIR": str(cli_config_dir), "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"), "HOME": os.environ.get("HOME", str(Path.home())), "NO_COLOR": "1", "TERM": "dumb"}
+                cli = subprocess.Popen(["claude", "auth", "login", "--email", email],
+                    env=cli_env, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT, bufsize=0)
+                print(f"  CLI pid={cli.pid}")
+                oauth_url, captured = await _wait_cli_oauth_url(cli, None, 60)
+            else:
+                print(f"  Reusing preflight CLI pid={cli.pid}")
             if not oauth_url:
-                cli.kill(); print("  NO OAuth URL"); return None
+                diagnostic = captured.decode(errors="replace")
+                diagnostic = re.sub(r"https?://\S+", "[URL]", diagnostic)
+                returncode = cli.poll()
+                if returncode is None:
+                    cli.kill()
+                print(f"  NO OAuth URL; exit={returncode}; CLI output: {diagnostic[:500]}")
+                return None
             print(f"  OAuth URL ({len(oauth_url)} chars)")
 
             # 9. Navigate to OAuth URL
@@ -342,6 +447,7 @@ async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = ""
                 if not code:
                     # Last resort: click Authorize and watch page navigation + CDP Network events
                     print("  Fallback: clicking Authorize + watching navigation + network...")
+                    await ws.send(json.dumps({"id": 9000, "method": "Network.enable"}))
                     JS_CLICK_AUTH = """(function(){var btn=[...document.querySelectorAll("button")].find(b=>b.textContent.trim()==="Authorize");if(btn){btn.click();return "clicked";}return "no button";})()"""
                     click_r = await cdp_eval(ws, JS_CLICK_AUTH, timeout=10)
                     print(f"  Click: {click_r}")
@@ -426,11 +532,15 @@ async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = ""
                     print(f"  CLI output: {cli_out.decode(errors='replace')[:300]}")
                 except: pass
                 print(f"  CLI exit code: {cli.poll()}")
-                cred_path = Path(config_dir) / ".credentials.json"
+                cred_path = cli_config_dir / ".credentials.json"
                 if cred_path.exists():
                     try:
                         creds = json.loads(cred_path.read_text())
                         if creds.get("claudeAiOauth", {}).get("accessToken"):
+                            if temporary_auth_dir:
+                                target_cred_path = Path(config_dir) / ".credentials.json"
+                                target_cred_path.write_bytes(cred_path.read_bytes())
+                                target_cred_path.chmod(0o600)
                             print("SUCCESS!")
                             return {"code": code, "state": state, "success": True}
                     except Exception:
@@ -441,6 +551,10 @@ async def cdp_login(email: str, token: str, config_dir: str, oauth_url: str = ""
             return None
     finally:
         chrome.kill(); chrome.wait()
+        if cli is not None and cli.poll() is None:
+            cli.kill()
+        if temporary_auth_dir:
+            shutil.rmtree(temporary_auth_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/scripts/codex_login.py
+++ b/scripts/codex_login.py
@@ -6,7 +6,7 @@ Flow:
 3. Drive headful real-Chrome Playwright browser through OpenAI login pages:
    - Email field → fill email → Continue
    - Password field → fill password (if present; passwordless accounts skip)
-   - OTP field → poll 171mail for 6-digit code → fill → Continue
+   - OTP field → poll 171mail API or Onet/Gazeta webmail in a second Chrome tab
    - Consent/Authorize button → click
 4. Codex captures the callback, exchanges token, writes CODEX_HOME/auth.json
 5. Smoke-test with `codex exec`
@@ -15,6 +15,7 @@ Prerequisites:
 - Xvfb running on :99 (DISPLAY set)
 - google-chrome-stable installed
 - playwright + playwright-stealth installed
+- Onet/Gazeta webmail credentials are supplied as the receiver token
 - codex CLI installed
 """
 
@@ -47,8 +48,15 @@ ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 AUTHORIZE_URL_RE = re.compile(r"(https://auth\.openai\.com/oauth/authorize\S+)")
 
 MAIL_API_BASE = "https://b.171mail.com/api/v1"
+MAIL_DECODE_API = "https://mail.claude-code-manager.com/api/v1/message"
 MAIL_POLL_TIMEOUT = 120
 MAIL_POLL_INTERVAL = 3
+
+WEBMAIL_PROVIDERS = {"onet.pl": "onet", "gazeta.pl": "gazeta"}
+WEBMAIL_LOGIN_URLS = {
+    "onet": "https://onet.pl/poczta",
+    "gazeta": "https://oauth.gazeta.pl",
+}
 
 EMAIL_SELECTOR = 'input[type="email"], input[name="email"]'
 PASSWORD_SELECTOR = 'input[type="password"]'
@@ -59,22 +67,28 @@ CONTINUE_BUTTON_TEXTS = (
 )
 
 
-# --- 171mail OTP polling ---
+# --- OTP polling (171mail API) ---
 
-async def poll_verification_code(token: str, after_ts: float, timeout_s: int = MAIL_POLL_TIMEOUT) -> str:
-    """Poll 171mail for OpenAI 6-digit verification code."""
+
+def detect_mail_provider(email: str) -> str:
+    domain = email.rsplit("@", 1)[-1].strip().lower()
+    return WEBMAIL_PROVIDERS.get(domain, "171mail")
+
+async def poll_verification_code(token: str, after_ts: float, timeout_s: int = MAIL_POLL_TIMEOUT,
+                                 email: str = "", provider: str | None = None) -> str:
+    """Poll the matching mailbox provider for an OpenAI 6-digit code."""
     import datetime
 
     deadline = time.time() + timeout_s
     seen: set[tuple[str, str]] = set()
+    provider = provider or detect_mail_provider(email)
 
-    async with httpx.AsyncClient(timeout=15.0) as client:
+    request_timeout = 45.0 if provider in WEBMAIL_LOGIN_URLS else 15.0
+    async with httpx.AsyncClient(timeout=request_timeout) as client:
         while time.time() < deadline:
             try:
-                resp = await client.get(
-                    f"{MAIL_API_BASE}/message",
-                    params={"token": token, "type": "gpt"},
-                )
+                url = MAIL_DECODE_API if provider in WEBMAIL_LOGIN_URLS else f"{MAIL_API_BASE}/message"
+                resp = await client.get(url, params={"token": token, "type": "gpt"})
                 payload = resp.json()
             except Exception:
                 await asyncio.sleep(MAIL_POLL_INTERVAL)
@@ -110,7 +124,7 @@ async def poll_verification_code(token: str, after_ts: float, timeout_s: int = M
             combined = f"{subject} {code} {body}"
             m = re.search(r"\b(\d{6})\b", combined)
             if m:
-                logger.info("Got verification code from 171mail")
+                logger.info("Got verification code from %s", provider)
                 return m.group(1)
 
             seen.add(key)
@@ -136,9 +150,159 @@ async def _click_continue(page, logs: list[str]) -> bool:
     return False
 
 
+async def _first_visible(page, selectors: str):
+    locator = page.locator(selectors)
+    for index in range(await locator.count()):
+        candidate = locator.nth(index)
+        if await candidate.is_visible():
+            return candidate
+    return None
+
+
+async def _click_matching_button(page, pattern: re.Pattern) -> bool:
+    buttons = page.locator("button, input[type=submit], [role=button]")
+    for index in range(await buttons.count()):
+        button = buttons.nth(index)
+        if not await button.is_visible() or not await button.is_enabled():
+            continue
+        text = " ".join(filter(None, [
+            await button.inner_text(), await button.get_attribute("value"),
+            await button.get_attribute("aria-label"),
+        ]))
+        if pattern.search(text):
+            await button.click()
+            return True
+    return False
+
+
+async def _switch_to_email_code(page, logs: list[str]) -> bool:
+    """Switch OpenAI password screen to passwordless email-code login."""
+    pattern = re.compile(
+        r"continue with (?:email )?code|use (?:an? )?(?:email )?code|"
+        r"email me a code|log in with (?:an? )?(?:one[- ]time )?code|"
+        r"sign in with (?:an? )?(?:one[- ]time )?code|"
+        r"try another (?:way|method)",
+        re.I,
+    )
+    candidates = page.locator("button, a, [role=button]")
+    for index in range(await candidates.count()):
+        candidate = candidates.nth(index)
+        if not await candidate.is_visible():
+            continue
+        text = " ".join(filter(None, [
+            await candidate.inner_text(), await candidate.get_attribute("aria-label"),
+        ]))
+        if pattern.search(text):
+            await candidate.click()
+            for _ in range(10):
+                await page.wait_for_timeout(500)
+                otp_field = await _first_visible(page, OTP_SELECTOR)
+                password_field = await _first_visible(page, PASSWORD_SELECTOR)
+                if otp_field or not password_field:
+                    logs.append(f"Switched to email-code login via '{text.strip()[:60]}'")
+                    return True
+            logs.append(f"Email-code action did not change the login page: '{text.strip()[:60]}'")
+            return False
+    return False
+
+
+async def _visible_action_labels(page) -> list[str]:
+    labels: list[str] = []
+    candidates = page.locator("button, a, [role=button]")
+    for index in range(min(await candidates.count(), 40)):
+        candidate = candidates.nth(index)
+        if not await candidate.is_visible():
+            continue
+        text = " ".join(filter(None, [
+            await candidate.inner_text(), await candidate.get_attribute("aria-label"),
+        ])).strip()
+        if text:
+            labels.append(text[:100])
+    return labels
+
+
+async def _poll_webmail_verification_code(context, *, provider: str, email: str,
+                                            password: str, timeout_s: int,
+                                            logs: list[str]) -> str:
+    """Use a second Chrome tab to log into Onet/Gazeta and read OpenAI OTP."""
+    mailbox = await context.new_page()
+    try:
+        logs.append(f"Opening {provider} webmail")
+        await mailbox.goto(WEBMAIL_LOGIN_URLS[provider], timeout=60000, wait_until="domcontentloaded")
+        await mailbox.wait_for_timeout(4000)
+
+        # Onet places a RODO consent dialog over the form. Gazeta can show a
+        # similar regional consent dialog, so handle both before locating fields.
+        await _click_matching_button(
+            mailbox, re.compile(r"Przejdź do serwisu|Akceptuj|Zgadzam|Accept|Continue", re.I),
+        )
+        await mailbox.wait_for_timeout(1500)
+
+        username = await _first_visible(
+            mailbox,
+            "input[type=email], input[autocomplete=username], input[name*=login i], "
+            "input[name*=email i], input[name*=user i], input[type=text]",
+        )
+        if not username:
+            raise RuntimeError(f"{provider} webmail login field not found (url={mailbox.url[:100]})")
+        await username.fill(email)
+
+        password_field = await _first_visible(
+            mailbox, "input[type=password], input[autocomplete=current-password], input[name*=pass i]",
+        )
+        if not password_field:
+            if not await _click_matching_button(mailbox, re.compile(r"Dalej|Zaloguj|Next|Continue|Sign in|Log in", re.I)):
+                await username.press("Enter")
+            await mailbox.wait_for_timeout(2500)
+            password_field = await _first_visible(
+                mailbox, "input[type=password], input[autocomplete=current-password], input[name*=pass i]",
+            )
+        if not password_field:
+            raise RuntimeError(f"{provider} webmail password field not found (url={mailbox.url[:100]})")
+        await password_field.fill(password)
+        if not await _click_matching_button(mailbox, re.compile(r"Zaloguj|Sign in|Log in|Continue", re.I)):
+            await password_field.press("Enter")
+        await mailbox.wait_for_timeout(7000)
+
+        deadline = time.time() + timeout_s
+        opened_message = False
+        while time.time() < deadline:
+            page_text = await mailbox.locator("body").inner_text(timeout=10000)
+            if re.search(r"błędne hasło|nieprawidłowe hasło|incorrect password|invalid password", page_text, re.I):
+                raise RuntimeError(f"{provider} webmail rejected the email/password")
+            match = re.search(
+                r"(?:verification code|security code|kod(?: weryfikacyjny)?|code)\D{0,80}(\d{6})(?!\d)",
+                page_text, re.I,
+            )
+            if match:
+                logs.append(f"Got OpenAI verification code from {provider} webmail")
+                return match.group(1)
+
+            if not opened_message:
+                candidates = mailbox.get_by_text(re.compile(r"OpenAI|ChatGPT", re.I))
+                for index in range(min(await candidates.count(), 20)):
+                    candidate = candidates.nth(index)
+                    if await candidate.is_visible():
+                        await candidate.click()
+                        opened_message = True
+                        await mailbox.wait_for_timeout(3000)
+                        break
+                if opened_message:
+                    continue
+
+            await mailbox.reload(timeout=60000, wait_until="domcontentloaded")
+            await mailbox.wait_for_timeout(4000)
+            opened_message = False
+
+        await mailbox.screenshot(path=f"/tmp/codex_{provider}_webmail_timeout.png", full_page=True)
+        raise RuntimeError(f"No fresh OpenAI verification code in {provider} webmail within {timeout_s}s")
+    finally:
+        await mailbox.close()
+
+
 async def _run_state_machine(
     page, email: str, password: str, token_171: str,
-    timeout: int, auth_path: Path, logs: list[str],
+    timeout: int, auth_path: Path, logs: list[str], mail_provider: str | None = None,
 ) -> None:
     otp_poll_start = time.time()
     deadline = time.time() + timeout
@@ -151,26 +315,38 @@ async def _run_state_machine(
             logs.append("auth.json appeared — browser flow complete")
             return
 
-        email_field = await page.query_selector(EMAIL_SELECTOR)
+        email_field = await _first_visible(page, EMAIL_SELECTOR)
         if email_field and not await email_field.input_value():
             await email_field.fill(email)
             logs.append("Email filled")
             await _click_continue(page, logs)
             continue
 
-        password_field = await page.query_selector(PASSWORD_SELECTOR)
+        password_field = await _first_visible(page, PASSWORD_SELECTOR)
         if password_field and not await password_field.input_value():
             if not password:
-                raise RuntimeError("Login page shows password field but no password configured")
+                if await _switch_to_email_code(page, logs):
+                    await page.wait_for_timeout(1500)
+                    continue
+                labels = await _visible_action_labels(page)
+                logs.append(f"Password page actions: {labels}")
+                await page.screenshot(path="/tmp/codex_openai_password_page.png", full_page=True)
+                raise RuntimeError(
+                    "OpenAI login shows a password field and no email-code option; "
+                    "provide the OpenAI password"
+                )
             await password_field.fill(password)
             logs.append("Password filled")
             await _click_continue(page, logs)
             continue
 
-        otp_field = await page.query_selector(OTP_SELECTOR)
+        otp_field = await _first_visible(page, OTP_SELECTOR)
         if otp_field and not otp_done:
-            logs.append("OTP field present, polling 171mail...")
-            code = await poll_verification_code(token_171, after_ts=otp_poll_start)
+            provider = mail_provider or detect_mail_provider(email)
+            logs.append(f"OTP field present, polling {provider}...")
+            code = await poll_verification_code(
+                token_171, after_ts=otp_poll_start, email=email, provider=provider,
+            )
             await otp_field.fill(code)
             otp_done = True
             logs.append(f"OTP entered (len={len(code)})")
@@ -180,6 +356,9 @@ async def _run_state_machine(
         # No fillable field — try clicking Continue (consent page)
         await _click_continue(page, logs)
 
+    labels = await _visible_action_labels(page)
+    logs.append(f"Timed-out page actions: {labels}")
+    await page.screenshot(path="/tmp/codex_openai_login_timeout.png", full_page=True)
     raise RuntimeError(f"Login flow did not complete within {timeout}s (url={str(page.url)[:80]})")
 
 
@@ -191,6 +370,7 @@ async def codex_login(
     codex_home: str,
     password: str = "",
     timeout: int = DEFAULT_LOGIN_TIMEOUT,
+    mail_provider: str | None = None,
 ) -> dict:
     """Run the full automated Codex login flow. Returns result dict."""
     t0 = time.time()
@@ -274,7 +454,9 @@ async def codex_login(
                 page = await context.new_page()
                 logs.append("Navigating to authorize URL")
                 await page.goto(auth_url, timeout=45000, wait_until="domcontentloaded")
-                await _run_state_machine(page, email, password, token_171, timeout, auth_path, logs)
+                await _run_state_machine(
+                    page, email, password, token_171, timeout, auth_path, logs, mail_provider,
+                )
             finally:
                 await browser.close()
 
@@ -363,11 +545,13 @@ def add_to_codex_pool(account_id: str, email: str, codex_home: str):
 # --- CLI entry ---
 
 async def main():
-    parser = argparse.ArgumentParser(description="Automated Codex login via Playwright + 171mail")
+    parser = argparse.ArgumentParser(description="Automated Codex login via Playwright + mailbox OTP")
     parser.add_argument("--email", required=True, help="OpenAI account email")
-    parser.add_argument("--token", required=True, help="171mail token for receiving OTP")
+    parser.add_argument("--token", required=True, help="171mail token, or Onet/Gazeta mailbox password")
     parser.add_argument("--codex-home", help="CODEX_HOME directory (default: ~/.codex or ~/.codex-<account-id>)")
     parser.add_argument("--password", default="", help="Account password (empty for passwordless)")
+    parser.add_argument("--mail-provider", choices=["171mail", "onet", "gazeta"], default=None,
+                        help="OTP mailbox provider (default: detect from email suffix)")
     parser.add_argument("--add-to-pool", metavar="ACCOUNT_ID", help="Add to codex pool after login")
     parser.add_argument("--save-token", action="store_true", help="Save 171mail token for future use")
     parser.add_argument("--timeout", type=int, default=DEFAULT_LOGIN_TIMEOUT)
@@ -393,7 +577,11 @@ async def main():
                 tokens = json.loads(tokens_path.read_text())
             except Exception:
                 pass
-        tokens[args.email] = args.token
+        tokens[args.email] = {
+            "token": args.token,
+            "provider": args.mail_provider or detect_mail_provider(args.email),
+            "password": args.password,
+        }
         tokens_path.write_text(json.dumps(tokens, indent=2))
         os.chmod(tokens_path, 0o600)
 
@@ -403,6 +591,7 @@ async def main():
         codex_home=codex_home,
         password=args.password,
         timeout=args.timeout,
+        mail_provider=args.mail_provider,
     )
 
     for line in result.get("logs", []):

--- a/scripts/codex_login.py
+++ b/scripts/codex_login.py
@@ -6,7 +6,7 @@ Flow:
 3. Drive headful real-Chrome Playwright browser through OpenAI login pages:
    - Email field → fill email → Continue
    - Password field → fill password (if present; passwordless accounts skip)
-   - OTP field → poll 171mail API or Onet/Gazeta webmail in a second Chrome tab
+   - OTP field → poll 171mail or MailCatcher with a provider-issued API token
    - Consent/Authorize button → click
 4. Codex captures the callback, exchanges token, writes CODEX_HOME/auth.json
 5. Smoke-test with `codex exec`
@@ -14,8 +14,8 @@ Flow:
 Prerequisites:
 - Xvfb running on :99 (DISPLAY set)
 - google-chrome-stable installed
-- playwright + playwright-stealth installed
-- Onet/Gazeta webmail credentials are supplied as the receiver token
+- playwright installed
+- Onet/Gazeta use the query token issued by MailCatcher (never a mailbox password)
 - codex CLI installed
 """
 
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import datetime
 import json
 import logging
 import os
@@ -30,6 +31,7 @@ import re
 import shutil
 import sys
 import time
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 
 import httpx
@@ -53,10 +55,7 @@ MAIL_POLL_TIMEOUT = 120
 MAIL_POLL_INTERVAL = 3
 
 WEBMAIL_PROVIDERS = {"onet.pl": "onet", "gazeta.pl": "gazeta"}
-WEBMAIL_LOGIN_URLS = {
-    "onet": "https://onet.pl/poczta",
-    "gazeta": "https://oauth.gazeta.pl",
-}
+MAILCATCHER_PROVIDERS = {"onet", "gazeta"}
 
 EMAIL_SELECTOR = 'input[type="email"], input[name="email"]'
 PASSWORD_SELECTOR = 'input[type="password"]'
@@ -74,51 +73,105 @@ def detect_mail_provider(email: str) -> str:
     domain = email.rsplit("@", 1)[-1].strip().lower()
     return WEBMAIL_PROVIDERS.get(domain, "171mail")
 
+
+def _mail_timestamp(data: dict) -> float | None:
+    """Return the message timestamp across 171mail/MailCatcher schemas."""
+    raw = data.get("date") or data.get("Date")
+    if raw:
+        value = str(raw).strip()
+        try:
+            return datetime.datetime.fromisoformat(
+                value.replace("Z", "+00:00")
+            ).timestamp()
+        except ValueError:
+            try:
+                return parsedate_to_datetime(value).timestamp()
+            except (TypeError, ValueError):
+                pass
+
+    subject = str(data.get("subject") or "")
+    match = re.search(r"\|\s+(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})", subject)
+    if match:
+        return time.mktime(time.strptime(match.group(1), "%Y-%m-%d %H:%M:%S"))
+    return None
+
+
 async def poll_verification_code(token: str, after_ts: float, timeout_s: int = MAIL_POLL_TIMEOUT,
                                  email: str = "", provider: str | None = None) -> str:
     """Poll the matching mailbox provider for an OpenAI 6-digit code."""
-    import datetime
-
     deadline = time.time() + timeout_s
-    seen: set[tuple[str, str]] = set()
+    seen: set[tuple[str, str, str]] = set()
     provider = provider or detect_mail_provider(email)
+    uses_mailcatcher = provider in MAILCATCHER_PROVIDERS
 
-    request_timeout = 45.0 if provider in WEBMAIL_LOGIN_URLS else 15.0
+    # The synchronous MailCatcher endpoint may wait up to 90 seconds for its
+    # worker.  Cutting the request off at 45 seconds creates duplicate jobs.
+    request_timeout = 120.0 if uses_mailcatcher else 15.0
     async with httpx.AsyncClient(timeout=request_timeout) as client:
         while time.time() < deadline:
             try:
-                url = MAIL_DECODE_API if provider in WEBMAIL_LOGIN_URLS else f"{MAIL_API_BASE}/message"
+                url = MAIL_DECODE_API if uses_mailcatcher else f"{MAIL_API_BASE}/message"
                 resp = await client.get(url, params={"token": token, "type": "gpt"})
+                status_code = getattr(resp, "status_code", 200)
+                if status_code in {401, 403}:
+                    raise RuntimeError("Mailbox API rejected the query token")
+                if status_code >= 400:
+                    resp.raise_for_status()
                 payload = resp.json()
-            except Exception:
+            except (httpx.HTTPError, ValueError):
                 await asyncio.sleep(MAIL_POLL_INTERVAL)
                 continue
 
+            if not isinstance(payload, dict):
+                await asyncio.sleep(MAIL_POLL_INTERVAL)
+                continue
+
+            # MailCatcher has a documented top-level job/result code.  Keep the
+            # pre-existing 171mail behavior, whose response need not expose it.
+            response_code = payload.get("code")
+            if uses_mailcatcher:
+                if response_code == 202:
+                    await asyncio.sleep(MAIL_POLL_INTERVAL)
+                    continue
+                if response_code != 200:
+                    message = payload.get("message") or payload.get("error") or "unknown error"
+                    raise RuntimeError(f"Mailbox API rejected the query token: {message}")
+
             data = payload.get("data") or {}
+            if not isinstance(data, dict):
+                await asyncio.sleep(MAIL_POLL_INTERVAL)
+                continue
             subject = data.get("subject") or ""
             code = data.get("code") or ""
             body = data.get("body") or ""
-            date_str = data.get("Date") or ""
+            date_str = data.get("date") or data.get("Date") or ""
 
             if not (subject or code or body):
                 await asyncio.sleep(MAIL_POLL_INTERVAL)
                 continue
 
-            key = (subject, date_str)
+            key = (subject, str(date_str), str(code))
             if key in seen:
                 await asyncio.sleep(MAIL_POLL_INTERVAL)
                 continue
 
-            # Check freshness
-            if date_str:
-                try:
-                    mail_ts = datetime.datetime.fromisoformat(date_str).timestamp()
-                    if mail_ts < after_ts - 120:
-                        seen.add(key)
-                        await asyncio.sleep(MAIL_POLL_INTERVAL)
-                        continue
-                except ValueError:
-                    pass
+            # MailCatcher's contract returns lowercase ``date``.  It may also
+            # encode the timestamp in the subject for older deployments.  Do
+            # not accept an undated MailCatcher response: the first poll often
+            # still exposes the previous login's OTP.
+            mail_ts = _mail_timestamp(data)
+            # MailCatcher timestamps may have only whole-second precision.
+            # Its result must belong to this request; retain 171mail's legacy
+            # grace window to avoid changing that provider's established flow.
+            freshness_cutoff = int(after_ts) if uses_mailcatcher else after_ts - 120
+            if mail_ts is not None and mail_ts < freshness_cutoff:
+                seen.add(key)
+                await asyncio.sleep(MAIL_POLL_INTERVAL)
+                continue
+            if uses_mailcatcher and mail_ts is None:
+                seen.add(key)
+                await asyncio.sleep(MAIL_POLL_INTERVAL)
+                continue
 
             # Extract 6-digit OTP
             combined = f"{subject} {code} {body}"
@@ -157,22 +210,6 @@ async def _first_visible(page, selectors: str):
         if await candidate.is_visible():
             return candidate
     return None
-
-
-async def _click_matching_button(page, pattern: re.Pattern) -> bool:
-    buttons = page.locator("button, input[type=submit], [role=button]")
-    for index in range(await buttons.count()):
-        button = buttons.nth(index)
-        if not await button.is_visible() or not await button.is_enabled():
-            continue
-        text = " ".join(filter(None, [
-            await button.inner_text(), await button.get_attribute("value"),
-            await button.get_attribute("aria-label"),
-        ]))
-        if pattern.search(text):
-            await button.click()
-            return True
-    return False
 
 
 async def _switch_to_email_code(page, logs: list[str]) -> bool:
@@ -219,85 +256,6 @@ async def _visible_action_labels(page) -> list[str]:
         if text:
             labels.append(text[:100])
     return labels
-
-
-async def _poll_webmail_verification_code(context, *, provider: str, email: str,
-                                            password: str, timeout_s: int,
-                                            logs: list[str]) -> str:
-    """Use a second Chrome tab to log into Onet/Gazeta and read OpenAI OTP."""
-    mailbox = await context.new_page()
-    try:
-        logs.append(f"Opening {provider} webmail")
-        await mailbox.goto(WEBMAIL_LOGIN_URLS[provider], timeout=60000, wait_until="domcontentloaded")
-        await mailbox.wait_for_timeout(4000)
-
-        # Onet places a RODO consent dialog over the form. Gazeta can show a
-        # similar regional consent dialog, so handle both before locating fields.
-        await _click_matching_button(
-            mailbox, re.compile(r"Przejdź do serwisu|Akceptuj|Zgadzam|Accept|Continue", re.I),
-        )
-        await mailbox.wait_for_timeout(1500)
-
-        username = await _first_visible(
-            mailbox,
-            "input[type=email], input[autocomplete=username], input[name*=login i], "
-            "input[name*=email i], input[name*=user i], input[type=text]",
-        )
-        if not username:
-            raise RuntimeError(f"{provider} webmail login field not found (url={mailbox.url[:100]})")
-        await username.fill(email)
-
-        password_field = await _first_visible(
-            mailbox, "input[type=password], input[autocomplete=current-password], input[name*=pass i]",
-        )
-        if not password_field:
-            if not await _click_matching_button(mailbox, re.compile(r"Dalej|Zaloguj|Next|Continue|Sign in|Log in", re.I)):
-                await username.press("Enter")
-            await mailbox.wait_for_timeout(2500)
-            password_field = await _first_visible(
-                mailbox, "input[type=password], input[autocomplete=current-password], input[name*=pass i]",
-            )
-        if not password_field:
-            raise RuntimeError(f"{provider} webmail password field not found (url={mailbox.url[:100]})")
-        await password_field.fill(password)
-        if not await _click_matching_button(mailbox, re.compile(r"Zaloguj|Sign in|Log in|Continue", re.I)):
-            await password_field.press("Enter")
-        await mailbox.wait_for_timeout(7000)
-
-        deadline = time.time() + timeout_s
-        opened_message = False
-        while time.time() < deadline:
-            page_text = await mailbox.locator("body").inner_text(timeout=10000)
-            if re.search(r"błędne hasło|nieprawidłowe hasło|incorrect password|invalid password", page_text, re.I):
-                raise RuntimeError(f"{provider} webmail rejected the email/password")
-            match = re.search(
-                r"(?:verification code|security code|kod(?: weryfikacyjny)?|code)\D{0,80}(\d{6})(?!\d)",
-                page_text, re.I,
-            )
-            if match:
-                logs.append(f"Got OpenAI verification code from {provider} webmail")
-                return match.group(1)
-
-            if not opened_message:
-                candidates = mailbox.get_by_text(re.compile(r"OpenAI|ChatGPT", re.I))
-                for index in range(min(await candidates.count(), 20)):
-                    candidate = candidates.nth(index)
-                    if await candidate.is_visible():
-                        await candidate.click()
-                        opened_message = True
-                        await mailbox.wait_for_timeout(3000)
-                        break
-                if opened_message:
-                    continue
-
-            await mailbox.reload(timeout=60000, wait_until="domcontentloaded")
-            await mailbox.wait_for_timeout(4000)
-            opened_message = False
-
-        await mailbox.screenshot(path=f"/tmp/codex_{provider}_webmail_timeout.png", full_page=True)
-        raise RuntimeError(f"No fresh OpenAI verification code in {provider} webmail within {timeout_s}s")
-    finally:
-        await mailbox.close()
 
 
 async def _run_state_machine(
@@ -547,13 +505,16 @@ def add_to_codex_pool(account_id: str, email: str, codex_home: str):
 async def main():
     parser = argparse.ArgumentParser(description="Automated Codex login via Playwright + mailbox OTP")
     parser.add_argument("--email", required=True, help="OpenAI account email")
-    parser.add_argument("--token", required=True, help="171mail token, or Onet/Gazeta mailbox password")
+    parser.add_argument(
+        "--token", required=True,
+        help="171mail token, or the query token issued by MailCatcher for Onet/Gazeta",
+    )
     parser.add_argument("--codex-home", help="CODEX_HOME directory (default: ~/.codex or ~/.codex-<account-id>)")
     parser.add_argument("--password", default="", help="Account password (empty for passwordless)")
     parser.add_argument("--mail-provider", choices=["171mail", "onet", "gazeta"], default=None,
                         help="OTP mailbox provider (default: detect from email suffix)")
     parser.add_argument("--add-to-pool", metavar="ACCOUNT_ID", help="Add to codex pool after login")
-    parser.add_argument("--save-token", action="store_true", help="Save 171mail token for future use")
+    parser.add_argument("--save-token", action="store_true", help="Save mailbox API token for future use")
     parser.add_argument("--timeout", type=int, default=DEFAULT_LOGIN_TIMEOUT)
     args = parser.parse_args()
 
@@ -566,24 +527,6 @@ async def main():
                 codex_home = str(Path.home() / f".codex-{args.add_to_pool}")
         else:
             codex_home = str(Path.home() / ".codex")
-
-    # Save token if requested
-    if args.save_token:
-        tokens_path = Path.home() / ".codex-pool" / "email_tokens.json"
-        tokens_path.parent.mkdir(parents=True, exist_ok=True)
-        tokens = {}
-        if tokens_path.exists():
-            try:
-                tokens = json.loads(tokens_path.read_text())
-            except Exception:
-                pass
-        tokens[args.email] = {
-            "token": args.token,
-            "provider": args.mail_provider or detect_mail_provider(args.email),
-            "password": args.password,
-        }
-        tokens_path.write_text(json.dumps(tokens, indent=2))
-        os.chmod(tokens_path, 0o600)
 
     result = await codex_login(
         email=args.email,
@@ -599,6 +542,25 @@ async def main():
 
     if result["ok"]:
         print(f"\n✓ Login successful ({result.get('elapsed', 0):.1f}s)")
+        # Keep failed or rejected credentials out of the reusable pool file.
+        if args.save_token:
+            tokens_path = Path.home() / ".codex-pool" / "email_tokens.json"
+            tokens_path.parent.mkdir(parents=True, exist_ok=True)
+            tokens = {}
+            if tokens_path.exists():
+                try:
+                    tokens = json.loads(tokens_path.read_text())
+                except Exception:
+                    pass
+            if not isinstance(tokens, dict):
+                tokens = {}
+            tokens[args.email] = {
+                "token": args.token,
+                "provider": args.mail_provider or detect_mail_provider(args.email),
+                "password": args.password,
+            }
+            tokens_path.write_text(json.dumps(tokens, indent=2))
+            os.chmod(tokens_path, 0o600)
         if args.add_to_pool:
             add_to_codex_pool(args.add_to_pool, args.email, codex_home)
             print(f"  Added to pool as '{args.add_to_pool}'")

--- a/uv.lock
+++ b/uv.lock
@@ -453,6 +453,7 @@ dependencies = [
     { name = "httpx" },
     { name = "mcp" },
     { name = "paramiko" },
+    { name = "playwright" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
@@ -493,6 +494,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "paramiko", specifier = ">=3.0.0" },
+    { name = "playwright", specifier = ">=1.61.0" },
     { name = "psycopg2-binary", marker = "extra == 'postgres'", specifier = ">=2.9.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
@@ -966,6 +968,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.61.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/ee/31e4e0db36588b817a10b299a0285082545fde7d36543c2abe498bb3d61a/playwright-1.61.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:ff138c3a604f69911e9d42fd036e55c2a171e5616edf04c1e7f60a2a285540b0", size = 43421877, upload-time = "2026-06-29T10:32:48.428Z" },
+    { url = "https://files.pythonhosted.org/packages/42/35/71395dd3ecc798965be4a3ef8c443217d4abca168e7cb34536304f9489e6/playwright-1.61.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:009588c2a7e499bc5a8b425b61fa65490968bbda9cd69e0cf2cff10f8304659a", size = 42205016, upload-time = "2026-06-29T10:32:52.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/44/323164cf5cd1647bdefce76ffce27651aadb959d089b48f53ea40918276e/playwright-1.61.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:9f7de4536088d12037c13a52b7ea34b59270b78926bb56935070597ffac6b1af", size = 43421884, upload-time = "2026-06-29T10:32:55.773Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/a35bf179e4ba2522c1893635094a64e407572547bd61528820fc0abc87fe/playwright-1.61.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:54f3b39f6eab832e33458c1dd7da0b5682aedab3b09ae731b5c59fa12fd2024e", size = 47421381, upload-time = "2026-06-29T10:32:59.903Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/eb/e3f922348ec17c315f98c463f72faa1181a1c3de0bfe31a8d2edf6561723/playwright-1.61.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93454322ade8c11d5d6c211bfd91bdfb9ffb4810e3e026371bcbc4bec1b7ee4c", size = 47120545, upload-time = "2026-06-29T10:33:03.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a6/5be4e52b40a9c0c8a073e7c5b0785c05cf5a9ea8f8a7b5b260e32d970342/playwright-1.61.0-py3-none-win32.whl", hash = "sha256:372d55a6f1248fa1dd47599686980cb8fb5bbe6fcda59eab793eb657c11d8a9b", size = 37844841, upload-time = "2026-06-29T10:33:07.361Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fd/2b78036e5fbe9d5f5645bbe08a1eac7160c51243c0093963edbcf67c35d9/playwright-1.61.0-py3-none-win_amd64.whl", hash = "sha256:35c6cc4589a5d00964a59d7b3e59641e0aac0c02f15479a7af77d20f6bc79597", size = 37844846, upload-time = "2026-06-29T10:33:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/1b0f3c4ee4eb0514bc805b5c2f9a223e5b6de4f11a926f5235d51d0fc81b/playwright-1.61.0-py3-none-win_arm64.whl", hash = "sha256:e9fcbffcf557a8620fdedd92491eb59a32d18e23d6f3b4f6214b952be324fe51", size = 33955127, upload-time = "2026-06-29T10:33:14.008Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1189,6 +1210,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add Onet/Gazeta mailbox providers to the CCM frontend and pool APIs
- route Claude magic-link polling through the mailbox service while preserving the standard OAuth authorization flow
- make Claude OAuth automation reliable with current Claude CLI behavior, slow mailbox decoding, and CDP event handling
- add Onet/Gazeta OTP support for Codex login

## Verification

- `pytest backend/tests/test_claude_login_mailbox.py backend/tests/test_codex_login_mailbox.py -q` (4 passed)
- Python compile checks for the modified login scripts
- end-to-end Onet Claude login: magic link received, OAuth authorized, CLI returned `Login successful`, and account added to the pool