### PR TITLE
fix chat sender prefix display

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -38,6 +38,27 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/tasks", tags=["chat"])
 
 
+async def _sender_display_name(
+    request: Request,
+    db: AsyncSession,
+) -> str | None:
+    """Resolve the presentation identity without changing access ownership."""
+    user_id = getattr(request.state, "user_id", None)
+    if user_id:
+        from backend.models.user import User
+
+        sender = await db.get(User, user_id)
+        if sender:
+            return sender.name
+
+    # The deployment service token is a real super-admin identity, but it is
+    # intentionally not bound to a disabled/deleted User row.  Give it the
+    # same stable presentation name returned by the frontend login fallback.
+    if getattr(request.state, "auth_type", None) == "token":
+        return "Admin"
+    return None
+
+
 class ChatMessage(BaseModel):
     message: str
     image_paths: list[str] | None = None  # kept for backwards compatibility
@@ -462,16 +483,11 @@ async def send_chat_message(
 
     # Keep sender identity presentation-only.  The raw text is what the model
     # receives; the prefixed form is only stored/broadcast for the chat UI.
-    user_id = getattr(request.state, "user_id", None)
     model_message = body.message
     display_content = model_message
-    sender_display_name = None
-    if user_id:
-        from backend.models.user import User
-        sender = await db.get(User, user_id)
-        if sender:
-            sender_display_name = sender.name
-            display_content = f"[{sender.name}] {model_message}"
+    sender_display_name = await _sender_display_name(request, db)
+    if sender_display_name:
+        display_content = f"[{sender_display_name}] {model_message}"
 
     # Explicit commands append their invocation instructions. Permanently
     # enabled skills are advertised by the launch-time skill directory; merely
@@ -981,13 +997,9 @@ async def _send_worker_chat(task: Task, body: ChatMessage, db: AsyncSession, req
         display_content = model_message
         sender_display_name = None
         if request:
-            uid = getattr(request.state, "user_id", None)
-            if uid:
-                from backend.models.user import User
-                sender = await db.get(User, uid)
-                if sender:
-                    sender_display_name = sender.name
-                    display_content = f"[{sender.name}] {model_message}"
+            sender_display_name = await _sender_display_name(request, db)
+            if sender_display_name:
+                display_content = f"[{sender_display_name}] {model_message}"
 
         worker = await worker_proxy.require_ready_worker(observed.worker_id)
 
@@ -1445,15 +1457,9 @@ async def _inject_display_content(
     raw_content: str,
 ) -> tuple[str, str | None]:
     display_content = raw_content
-    sender_display_name = None
-    user_id = getattr(request.state, "user_id", None)
-    if user_id:
-        from backend.models.user import User
-
-        sender = await db.get(User, user_id)
-        if sender:
-            sender_display_name = sender.name
-            display_content = f"[{sender.name}] {raw_content}"
+    sender_display_name = await _sender_display_name(request, db)
+    if sender_display_name:
+        display_content = f"[{sender_display_name}] {raw_content}"
     return display_content, sender_display_name
 
 

--- a/backend/tests/test_api_chat_plan.py
+++ b/backend/tests/test_api_chat_plan.py
@@ -1053,6 +1053,63 @@ async def test_chat_sender_prefix_is_display_only(session_factory):
 
 
 @pytest.mark.asyncio
+async def test_service_token_sender_prefix_is_display_only(session_factory):
+    """A service-token request has an Admin label even without a bound User."""
+    import json
+    from types import SimpleNamespace
+    from sqlalchemy import select
+
+    from backend.api.chat import ChatMessage, send_chat_message
+    from backend.models.log_entry import LogEntry
+
+    async with session_factory() as db:
+        task = Task(
+            title="Token prefix test",
+            description="d",
+            target_repo="/tmp",
+            session_id="token-prefix-session",
+        )
+        db.add(task)
+        await db.commit()
+        await db.refresh(task)
+
+        mock_d = _mock_dispatcher()
+        mock_broadcaster = MagicMock()
+        mock_broadcaster.broadcast = AsyncMock()
+        request = SimpleNamespace(state=SimpleNamespace(
+            user_id=None,
+            user_role="super_admin",
+            auth_type="token",
+        ))
+
+        with patch("backend.main.dispatcher", mock_d), \
+             patch("backend.main.broadcaster", mock_broadcaster):
+            await send_chat_message(
+                task.id,
+                ChatMessage(message="[BUG] keep this raw"),
+                request,
+                db,
+            )
+
+        stored = (await db.execute(
+            select(LogEntry).where(
+                LogEntry.task_id == task.id,
+                LogEntry.event_type == "user_message",
+            )
+        )).scalar_one()
+
+    assert mock_d.enqueue_message.call_args.kwargs["prompt"] == "[BUG] keep this raw"
+    assert stored.content == "[Admin] [BUG] keep this raw"
+    assert json.loads(stored.raw_json) == {
+        "raw_content": "[BUG] keep this raw",
+        "sender_name": "Admin",
+    }
+    event = mock_broadcaster.broadcast.call_args.args[1]
+    assert event["content"] == "[Admin] [BUG] keep this raw"
+    assert event["raw_content"] == "[BUG] keep this raw"
+
+
+@pytest.mark.asyncio
 async def test_shared_chat_sender_prefix_is_display_only(client, session_factory):
     """Shared-task sender names are shown in chat but excluded from enqueue."""
     import json

--- a/frontend/src/components/Chat/ChatView.test.tsx
+++ b/frontend/src/components/Chat/ChatView.test.tsx
@@ -1875,6 +1875,31 @@ describe('聊天图片附件展示（2026-07-16 用户反馈：发图后图片�
     expect(imgs.length).toBeGreaterThan(0);
   });
 
+  it('用带用户名的服务端消息替换无前缀乐观消息，不显示两个气泡', async () => {
+    const task = makeTask({ id: 12 });
+    render(<ChatView task={task} projects={projects} onBack={onBack} onTaskUpdated={onTaskUpdated} />);
+    await waitFor(() => expect(api.getTaskChatHistory).toHaveBeenCalled());
+
+    await act(async () => {
+      wsUserMessage(12, {
+        content: '检查训练状态',
+        raw_content: '检查训练状态',
+      });
+    });
+    expect(screen.getByText('检查训练状态')).toBeInTheDocument();
+
+    await act(async () => {
+      wsUserMessage(12, {
+        id: 991,
+        content: '[Admin] 检查训练状态',
+        raw_content: '检查训练状态',
+      });
+    });
+
+    expect(screen.getByText('[Admin] 检查训练状态')).toBeInTheDocument();
+    expect(screen.queryByText('检查训练状态')).not.toBeInTheDocument();
+  });
+
   it('Capacitor（手机 App）下附件相对 URL 必须拼上远程服务器地址', async () => {
     (window as Record<string, unknown>).Capacitor = {};
     localStorage.setItem('cc_server_url', 'https://ccm.example.com');

--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -812,15 +812,35 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
       const eventTimestamp = (msg.data.timestamp as string) || new Date().toISOString();
       setSending(true);
       setMessages((prev) => {
-        // Skip if last message is an optimistic duplicate (same content, recent).
-        // 但服务端广播可能带附件而乐观回显没有 —— 去重时必须把附件合并进去，
-        // 整条丢弃会让刚发的图片消失（2026-07-16 用户反馈）
+        // Reconcile the optimistic bubble with the authoritative broadcast.
+        // The optimistic content can be raw text while the server content is
+        // prefixed with the sender name, so display content alone is not a
+        // stable identity. raw_content is the canonical user input.
         const last = prev[prev.length - 1];
-        if (last && last.role === 'user' && last.event_type === 'user_message' && last.content === content) {
-          if ((imageUrls?.length || attachments?.length) && !last.image_urls?.length && !last.attachments?.length) {
-            return [...prev.slice(0, -1), { ...last, image_urls: imageUrls, attachments }];
-          }
-          return prev;
+        const matchesOptimistic = Boolean(
+          last
+          && last.role === 'user'
+          && last.event_type === 'user_message'
+          && (
+            last.content === content
+            || (
+              rawContent !== null
+              && last.raw_content === rawContent
+            )
+          )
+        );
+        if (last && matchesOptimistic) {
+          return [...prev.slice(0, -1), {
+            ...last,
+            id: isPersisted ? persistedId : last.id,
+            content,
+            source,
+            raw_content: rawContent ?? last.raw_content,
+            timestamp: eventTimestamp,
+            image_urls: imageUrls?.length ? imageUrls : last.image_urls,
+            attachments: attachments?.length ? attachments : last.attachments,
+            persisted: isPersisted || last.persisted,
+          }];
         }
         return [...prev, {
           id: isPersisted ? persistedId : Date.now() + Math.random(), role: 'user', event_type: 'user_message',


### PR DESCRIPTION
## What changed

- reconcile optimistic user bubbles with authoritative WebSocket messages by `raw_content`
- display a stable `Admin` prefix for service-token chat requests
- keep sender prefixes presentation-only while preserving raw model prompts
- add frontend and backend regressions for prefix display and duplicate removal

## Root cause

The service token may intentionally have no active `User` row, so sender resolution returned no display name. The frontend also compared optimistic and authoritative messages by rendered content, which differs once the server adds a prefix.

## Validation

- ChatView tests: 74 passed
- frontend production build passed
- backend service-token prefix regression passed
- live development API verified stored `content` is prefixed while `raw_content` remains unchanged
