### PR TITLE
Fix stale task busy detection after instance reuse

### DIFF
--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -10637,6 +10637,20 @@ Codex 中工具会显示为上述 mcp__ccm_monitor_agent__* canonical 名称；
             return False
         instance_id = task.instance_id
 
+        instance = await db.get(Instance, instance_id, populate_existing=True)
+        if (
+            instance is not None
+            and instance.current_task_id is not None
+            and instance.current_task_id != task_id
+        ):
+            # The instance has been durably reassigned.  Consumer records and
+            # launch params are in-memory terminal bookkeeping and can briefly
+            # retain the previous task id after the slot is reused.  Combining
+            # one of those stale records with the new generation's live
+            # process would otherwise keep chat for the completed task queued
+            # forever.
+            return False
+
         lifecycle = self._running_tasks.get(instance_id)
         if lifecycle is not None and not lifecycle.done():
             # Fresh lifecycle preparation precedes Instance.current_task_id/PID
@@ -10667,7 +10681,6 @@ Codex 中工具会显示为上述 mcp__ccm_monitor_agent__* canonical 名称；
             # stronger identity during that terminal window.
             return True
 
-        instance = await db.get(Instance, instance_id, populate_existing=True)
         if instance is None or instance.current_task_id != task_id:
             return False
 

--- a/backend/tests/test_service_dispatcher.py
+++ b/backend/tests/test_service_dispatcher.py
@@ -6102,6 +6102,60 @@ async def test_queued_busy_detects_terminal_parent_consumer_and_fresh_lifecycle(
 
 
 @pytest.mark.asyncio
+async def test_queued_busy_ignores_stale_consumer_after_instance_reassignment(
+    db_factory,
+):
+    d = _make_dispatcher(db_factory)
+    async with db_factory() as db:
+        old_task = Task(
+            title="completed owner",
+            description="d",
+            status="completed",
+            session_id="old-session",
+        )
+        new_task = Task(
+            title="new owner",
+            description="d",
+            status="executing",
+            session_id="new-session",
+        )
+        db.add_all([old_task, new_task])
+        await db.flush()
+        instance = Instance(
+            name="reused-slot",
+            status="running",
+            pid=99124,
+            current_task_id=new_task.id,
+        )
+        db.add(instance)
+        await db.flush()
+        old_task.instance_id = instance.id
+        new_task.instance_id = instance.id
+        await db.commit()
+        old_task_id, instance_id = old_task.id, instance.id
+
+    live_new_process = MagicMock(returncode=None)
+    stale_old_consumer = asyncio.create_task(asyncio.Event().wait())
+    d.instance_manager.processes[instance_id] = live_new_process
+    d.instance_manager._tasks[instance_id] = stale_old_consumer
+    d.instance_manager._consumer_records = {
+        instance_id: MagicMock(
+            process=MagicMock(returncode=0),
+            task=stale_old_consumer,
+            task_id=old_task_id,
+        )
+    }
+    try:
+        async with db_factory() as db:
+            assert not await d._queued_task_has_live_generation(
+                db, old_task_id
+            )
+    finally:
+        stale_old_consumer.cancel()
+        await asyncio.gather(stale_old_consumer, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_queued_busy_detects_detached_pty_background_epoch(
     db_factory,
 ):


### PR DESCRIPTION
## What changed

- reject stale in-memory consumer ownership when an instance has been durably reassigned to another task
- add a regression test covering a completed task whose old instance slot is reused by a new live task

## Root cause

The queued-chat busy check could combine a stale consumer record for the completed task with the live process of the new task occupying the same instance. That made the completed task appear permanently busy and caused every chat message to be requeued after 120 seconds.

## Impact

Completed tasks can resume chat normally after their former worker instance is reused. This fixes the production Task 211 failure mode without weakening the existing foreground and detached-generation fences.

## Validation

- `pytest -q backend/tests/test_service_dispatcher.py` — 212 passed
- `git diff --check`
