### PR TITLE
fix: preserve attachments when merging queued messages

### DIFF
--- a/frontend/src/components/Chat/ChatView.test.tsx
+++ b/frontend/src/components/Chat/ChatView.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ChatView } from './ChatView';
-import type { Task, Project, ChatMessage } from '../../api/client';
+import type { Task, Project, ChatMessage, UploadResult } from '../../api/client';
 
 // Mock dependencies
 vi.mock('../../api/client', () => ({
@@ -124,12 +124,23 @@ function makeTask(overrides: Partial<Task> = {}): Task {
   };
 }
 
+function makeUpload(id: string, filename = `${id}.txt`): UploadResult {
+  return {
+    id,
+    filename,
+    path: `/srv/uploads/${filename}`,
+    url: `/api/uploads/${filename}`,
+    is_image: false,
+  };
+}
+
 describe('ChatView', () => {
   const projects: Project[] = [];
   const onBack = vi.fn();
   const onTaskUpdated = vi.fn();
 
   beforeEach(() => {
+    localStorage.clear();
     vi.clearAllMocks();
     (api.getTaskChatHistory as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     (api.getAskUserPending as ReturnType<typeof vi.fn>).mockResolvedValue({ pending: [] });
@@ -693,6 +704,214 @@ describe('ChatView', () => {
       await waitFor(() => {
         expect(screen.queryByText('Queued messages (1)')).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe('queued message attachment editing', () => {
+    beforeEach(() => {
+      localStorage.clear();
+      vi.mocked(api.sendTaskChat).mockResolvedValue({});
+    });
+
+    it('moves merged queue attachments into the composer and sends their existing path', async () => {
+      const task = makeTask({ id: 410, status: 'executing' });
+      const attachment = makeUpload('merge-report', 'report.md');
+      localStorage.setItem(
+        `ccm-chat-queue-${task.id}`,
+        JSON.stringify([{ text: 'review the report', uploadResults: [attachment] }]),
+      );
+      const { rerender } = render(
+        <ChatView task={task} projects={projects} onBack={onBack} />,
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Merge' }));
+
+      expect(screen.queryByText('Queued messages (1)')).not.toBeInTheDocument();
+      expect(screen.getByRole('textbox')).toHaveValue('review the report');
+      expect(screen.getByText('report.md')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(JSON.parse(
+          localStorage.getItem(`ccm-chat-draft-uploads-${task.id}`) || '[]',
+        )).toEqual([attachment]);
+      });
+
+      rerender(
+        <ChatView
+          task={{ ...task, status: 'completed' }}
+          projects={projects}
+          onBack={onBack}
+        />,
+      );
+      await userEvent.click(await screen.findByTitle(/Send \(Ctrl\+Enter\)/));
+
+      await waitFor(() => {
+        expect(api.sendTaskChat).toHaveBeenCalledWith(
+          task.id,
+          'review the report',
+          [attachment.path],
+          undefined,
+          null,
+          {
+            provider: 'claude',
+            model: null,
+            codex_service_tier: 'default',
+          },
+        );
+      });
+    });
+
+    it('persists merged attachments with the text draft across a remount', async () => {
+      const task = makeTask({ id: 411, status: 'executing' });
+      const attachment = makeUpload('draft-notes', 'notes.txt');
+      localStorage.setItem(
+        `ccm-chat-queue-${task.id}`,
+        JSON.stringify([{ text: 'continue later', uploadResults: [attachment] }]),
+      );
+      const first = render(
+        <ChatView task={task} projects={projects} onBack={onBack} />,
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Merge' }));
+      await waitFor(() => {
+        expect(localStorage.getItem(`ccm-chat-draft-uploads-${task.id}`)).not.toBeNull();
+      });
+      first.unmount();
+
+      render(<ChatView task={task} projects={projects} onBack={onBack} />);
+
+      expect(screen.getByRole('textbox')).toHaveValue('continue later');
+      expect(screen.getByText('notes.txt')).toBeInTheDocument();
+      expect(screen.queryByText('Queued messages (1)')).not.toBeInTheDocument();
+    });
+
+    it('restores attachments when editing one queued message', async () => {
+      const task = makeTask({ id: 412, status: 'executing' });
+      const attachment = makeUpload('edit-evidence', 'evidence.txt');
+      localStorage.setItem(
+        `ccm-chat-queue-${task.id}`,
+        JSON.stringify([{ text: 'edit this', uploadResults: [attachment] }]),
+      );
+      render(<ChatView task={task} projects={projects} onBack={onBack} />);
+
+      await userEvent.click(screen.getByTitle('Edit in input'));
+
+      expect(screen.getByRole('textbox')).toHaveValue('edit this');
+      expect(screen.getByText('evidence.txt')).toBeInTheDocument();
+      expect(screen.queryByText('Queued messages (1)')).not.toBeInTheDocument();
+    });
+
+    it('keeps merged attachments when the edited message is queued again', async () => {
+      const task = makeTask({ id: 417, status: 'executing' });
+      const attachment = makeUpload('requeue-upload', 'requeue.txt');
+      localStorage.setItem(
+        `ccm-chat-queue-${task.id}`,
+        JSON.stringify([{ text: 'before edit', uploadResults: [attachment] }]),
+      );
+      render(<ChatView task={task} projects={projects} onBack={onBack} />);
+
+      await userEvent.click(screen.getByRole('button', { name: 'Merge' }));
+      const textbox = screen.getByRole('textbox');
+      await userEvent.clear(textbox);
+      await userEvent.type(textbox, 'after edit');
+      await userEvent.click(screen.getByTitle(/Add to queue/));
+
+      expect(screen.getByText('Queued messages (1)')).toBeInTheDocument();
+      expect(screen.getByText('after edit')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(JSON.parse(
+          localStorage.getItem(`ccm-chat-queue-${task.id}`) || '[]',
+        )).toEqual([{
+          text: 'after edit',
+          uploadResults: [attachment],
+        }]);
+      });
+    });
+
+    it('deduplicates attachments while preserving queued message order', async () => {
+      const task = makeTask({ id: 413, status: 'executing' });
+      const repeated = makeUpload('same-upload', 'same.txt');
+      const other = makeUpload('other-upload', 'other.txt');
+      localStorage.setItem(
+        `ccm-chat-queue-${task.id}`,
+        JSON.stringify([
+          { text: 'first', uploadResults: [repeated] },
+          { text: 'second', uploadResults: [repeated, other] },
+        ]),
+      );
+      render(<ChatView task={task} projects={projects} onBack={onBack} />);
+
+      await userEvent.click(screen.getByRole('button', { name: 'Merge' }));
+
+      expect(screen.getByRole('textbox')).toHaveValue('first\n\nsecond');
+      expect(screen.getAllByText('same.txt')).toHaveLength(1);
+      expect(screen.getAllByText('other.txt')).toHaveLength(1);
+    });
+
+    it('rejects an over-limit merge atomically and keeps the queue intact', async () => {
+      const task = makeTask({ id: 414, status: 'executing' });
+      const attachments = Array.from(
+        { length: 11 },
+        (_, index) => makeUpload(`limit-${index}`, `limit-${index}.txt`),
+      );
+      localStorage.setItem(
+        `ccm-chat-queue-${task.id}`,
+        JSON.stringify([
+          { text: 'first batch', uploadResults: attachments.slice(0, 6) },
+          { text: 'second batch', uploadResults: attachments.slice(6) },
+        ]),
+      );
+      render(<ChatView task={task} projects={projects} onBack={onBack} />);
+
+      await userEvent.click(screen.getByRole('button', { name: 'Merge' }));
+
+      expect(screen.getByText(/合并后将有 11 个附件/)).toBeInTheDocument();
+      expect(screen.getByText('Queued messages (2)')).toBeInTheDocument();
+      expect(screen.getByRole('textbox')).toHaveValue('');
+      expect(screen.queryByText('limit-0.txt')).not.toBeInTheDocument();
+    });
+
+    it('restores a merged attachment when sending fails', async () => {
+      const task = makeTask({ id: 415, status: 'executing' });
+      const attachment = makeUpload('retry-upload', 'retry.txt');
+      localStorage.setItem(
+        `ccm-chat-queue-${task.id}`,
+        JSON.stringify([{ text: 'retry this', uploadResults: [attachment] }]),
+      );
+      vi.mocked(api.sendTaskChat).mockRejectedValueOnce(new Error('send failed'));
+      const { rerender } = render(
+        <ChatView task={task} projects={projects} onBack={onBack} />,
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Merge' }));
+      rerender(
+        <ChatView
+          task={{ ...task, status: 'completed' }}
+          projects={projects}
+          onBack={onBack}
+        />,
+      );
+      await userEvent.click(await screen.findByTitle(/Send \(Ctrl\+Enter\)/));
+
+      expect(await screen.findByText(/send failed/)).toBeInTheDocument();
+      expect(screen.getByRole('textbox')).toHaveValue('retry this');
+      expect(screen.getByText('retry.txt')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(localStorage.getItem(`ccm-chat-draft-uploads-${task.id}`)).not.toBeNull();
+      });
+    });
+
+    it('keeps the existing text-only merge behavior', async () => {
+      const task = makeTask({ id: 416, status: 'executing' });
+      localStorage.setItem(
+        `ccm-chat-queue-${task.id}`,
+        JSON.stringify([{ text: 'plain follow-up' }]),
+      );
+      render(<ChatView task={task} projects={projects} onBack={onBack} />);
+
+      await userEvent.click(screen.getByRole('button', { name: 'Merge' }));
+
+      expect(screen.getByRole('textbox')).toHaveValue('plain follow-up');
+      expect(screen.queryByText('Queued messages (1)')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -13,7 +13,13 @@ import { FastModeBadge, TaskConfigBadge } from '../Tasks/TaskBadges';
 import { ExpandableText } from '../ExpandableText';
 import { formatMessageTime } from '../../config/timezone';
 import { useFileDrop } from '../../hooks/useFileDrop';
-import { useFileUpload } from '../../hooks/useFileUpload';
+import {
+  dedupeUploadResults,
+  isUploadResult,
+  MAX_FILES,
+  sameUploadResult,
+  useFileUpload,
+} from '../../hooks/useFileUpload';
 import { SubAgentIndicator } from './SubAgentIndicator';
 import { MonitorPanel } from './MonitorPanel';
 import {
@@ -34,6 +40,16 @@ interface ChatViewProps {
 interface QueuedMessage {
   text: string;
   uploadResults?: UploadResult[];
+}
+
+function loadStoredUploadResults(key: string): UploadResult[] {
+  try {
+    const parsed: unknown = JSON.parse(localStorage.getItem(key) || '[]');
+    if (!Array.isArray(parsed)) return [];
+    return dedupeUploadResults(parsed.filter(isUploadResult)).slice(0, MAX_FILES);
+  } catch {
+    return [];
+  }
 }
 
 type MessageGroup =
@@ -161,6 +177,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
   const forkSeedKey = `ccm-fork-seed-consumed-${task.id}`;
   const forkSeedUploadsKey = `ccm-fork-seed-uploads-${task.id}`;
   const forkSeedUploadsConsumedKey = `ccm-fork-seed-uploads-consumed-${task.id}`;
+  const draftUploadsKey = `ccm-chat-draft-uploads-${task.id}`;
   const [forkSeedUploads, setForkSeedUploads] = useState<UploadResult[]>(() => {
     try {
       if (localStorage.getItem(forkSeedUploadsConsumedKey)) return [];
@@ -224,7 +241,23 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
   const [stillRunning, setStillRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [dropError, setDropError] = useState<string | null>(null);
-  const fileUpload = useFileUpload();
+  const initialDraftUploads = useMemo(
+    () => loadStoredUploadResults(draftUploadsKey),
+    [draftUploadsKey],
+  );
+  const fileUpload = useFileUpload(initialDraftUploads);
+  const consumeForkSeedUploads = useCallback(() => {
+    if (forkSeedUploads.length === 0) return;
+    try {
+      localStorage.setItem(forkSeedUploadsConsumedKey, '1');
+      localStorage.removeItem(forkSeedUploadsKey);
+    } catch { /* storage may be unavailable */ }
+    setForkSeedUploads([]);
+  }, [
+    forkSeedUploads.length,
+    forkSeedUploadsConsumedKey,
+    forkSeedUploadsKey,
+  ]);
   const [selectedSecretIds, setSelectedSecretIds] = useState<number[]>([]);
   const [contextUsage, setContextUsage] = useState<ContextUsage | null>(task.context_window_usage ?? null);
   const [editingTitle, setEditingTitle] = useState(false);
@@ -348,13 +381,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
         current.trim() === text ? '' : current
       ));
       fileUpload.clear();
-      if (forkSeedUploads.length > 0) {
-        try {
-          localStorage.setItem(forkSeedUploadsConsumedKey, '1');
-          localStorage.removeItem(forkSeedUploadsKey);
-        } catch { /* storage may be unavailable */ }
-        setForkSeedUploads([]);
-      }
+      consumeForkSeedUploads();
     } catch (e) {
       setError(
         `未收到注入成功确认，消息和附件已保留；请先查看聊天记录或运行日志，再决定是否重试：${
@@ -376,6 +403,18 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
       else localStorage.removeItem(`ccm-chat-draft-${task.id}`);
     } catch { /* storage may be unavailable */ }
   }, [input, task.id]);
+  useEffect(() => {
+    try {
+      if (fileUpload.uploadedResults.length > 0) {
+        localStorage.setItem(
+          draftUploadsKey,
+          JSON.stringify(fileUpload.uploadedResults),
+        );
+      } else {
+        localStorage.removeItem(draftUploadsKey);
+      }
+    } catch { /* storage may be unavailable */ }
+  }, [draftUploadsKey, fileUpload.uploadedResults]);
   useEffect(() => {
     try {
       if (localStorage.getItem(forkSeedUploadsConsumedKey)) {
@@ -449,7 +488,19 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
       if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0] === 'string') {
         return (parsed as string[]).map(text => ({ text }));
       }
-      return parsed;
+      if (!Array.isArray(parsed)) return [];
+      return parsed.flatMap((item): QueuedMessage[] => {
+        if (!item || typeof item !== 'object') return [];
+        const candidate = item as Partial<QueuedMessage>;
+        if (typeof candidate.text !== 'string') return [];
+        const uploadResults = Array.isArray(candidate.uploadResults)
+          ? dedupeUploadResults(candidate.uploadResults.filter(isUploadResult))
+          : undefined;
+        return [{
+          text: candidate.text,
+          uploadResults: uploadResults?.length ? uploadResults : undefined,
+        }];
+      });
     } catch { return []; }
   });
   const messageQueueRef = useRef(messageQueue);
@@ -466,17 +517,54 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
     setMessageQueue(prev => prev.filter((_, i) => i !== index));
   }, []);
 
+  const restoreQueuedUploads = useCallback((items: QueuedMessage[]): boolean => {
+    const queuedUploads = dedupeUploadResults(
+      items.flatMap((item) => item.uploadResults || []),
+    );
+    const existingUploaded = dedupeUploadResults([
+      ...forkSeedUploads,
+      ...fileUpload.uploadedResults,
+    ]);
+    const additions = queuedUploads.filter(
+      (upload) => !existingUploaded.some(
+        (existing) => sameUploadResult(existing, upload),
+      ),
+    );
+    const uploadsWithoutResults = (
+      fileUpload.uploads.length - fileUpload.uploadedResults.length
+    );
+    const projectedCount = (
+      existingUploaded.length + uploadsWithoutResults + additions.length
+    );
+    if (projectedCount > MAX_FILES) {
+      setError(
+        `合并后将有 ${projectedCount} 个附件，单条消息最多支持 ${MAX_FILES} 个；`
+        + '请先删除部分附件或队列消息。',
+      );
+      return false;
+    }
+    if (!fileUpload.addUploadedResults(additions)) {
+      setError(
+        `合并后附件超过 ${MAX_FILES} 个，队列已保持原样；请先删除部分附件。`,
+      );
+      return false;
+    }
+    return true;
+  }, [fileUpload, forkSeedUploads]);
+
   const editQueueItem = useCallback((index: number) => {
     const item = messageQueueRef.current[index];
     if (!item) return;
+    if (!restoreQueuedUploads([item])) return;
     setInput(prev => prev.trim() ? `${prev.trim()}\n\n${item.text}` : item.text);
     setMessageQueue(prev => prev.filter((_, i) => i !== index));
     requestAnimationFrame(() => textareaRef.current?.focus());
-  }, []);
+  }, [restoreQueuedUploads]);
 
   const mergeQueueToInput = useCallback(() => {
     const queued = messageQueueRef.current;
     if (queued.length === 0) return;
+    if (!restoreQueuedUploads(queued)) return;
     setInput(prev => {
       const current = prev.trim();
       const merged = queued.map(q => q.text).join('\n\n');
@@ -484,7 +572,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
     });
     setMessageQueue([]);
     requestAnimationFrame(() => textareaRef.current?.focus());
-  }, []);
+  }, [restoreQueuedUploads]);
 
   const moveQueueItem = useCallback((index: number, direction: 'up' | 'down') => {
     setMessageQueue(prev => {
@@ -1303,9 +1391,16 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
 
   const handleSend = async (overrideText?: string, fromQueue?: boolean, preUploadedResults?: UploadResult[]) => {
     const text = (overrideText ?? input).trim();
-    const sendableAttachmentCount = fromQueue
-      ? (preUploadedResults?.length || 0)
-      : fileUpload.uploadedResults.length + forkSeedUploads.length;
+    const fileUploadResultsForTurn = dedupeUploadResults(
+      fileUpload.uploadedResults,
+    );
+    const uploadedResultsForTurn = fromQueue
+      ? dedupeUploadResults(preUploadedResults || [])
+      : dedupeUploadResults([
+        ...forkSeedUploads,
+        ...fileUploadResultsForTurn,
+      ]);
+    const sendableAttachmentCount = uploadedResultsForTurn.length;
     if (!text && sendableAttachmentCount === 0) return;
 
     if (!fromQueue && fileUpload.isUploading) {
@@ -1324,18 +1419,21 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
       }
       await handleInject(
         text,
-        [...forkSeedUploads, ...fileUpload.uploadedResults],
+        uploadedResultsForTurn,
       );
       return;
     }
 
     // If currently sending and not from auto-dequeue, add to queue (with already-uploaded results)
     if (isProcessing && !fromQueue) {
-      if (text || fileUpload.uploads.length > 0) {
-        const results = fileUpload.uploadedResults.length > 0 ? [...fileUpload.uploadedResults] : undefined;
-        addToQueue(text, results);
+      if (text || sendableAttachmentCount > 0) {
+        addToQueue(
+          text,
+          uploadedResultsForTurn.length > 0 ? uploadedResultsForTurn : undefined,
+        );
         setInput('');
         fileUpload.clear();
+        consumeForkSeedUploads();
       }
       return;
     }
@@ -1349,15 +1447,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
     let optimisticMessageId: number | null = null;
     try {
       let uploadedPaths: string[] | undefined;
-      let uploadedResults: UploadResult[] = [];
-      if (preUploadedResults && preUploadedResults.length > 0) {
-        uploadedResults = preUploadedResults;
-      } else if (fileUpload.uploadedResults.length > 0) {
-        uploadedResults = fileUpload.uploadedResults;
-      }
-      if (!fromQueue && forkSeedUploads.length > 0) {
-        uploadedResults = [...forkSeedUploads, ...uploadedResults];
-      }
+      const uploadedResults = uploadedResultsForTurn;
       if (uploadedResults.length > 0) uploadedPaths = uploadedResults.map((r) => r.path);
       if (!fromQueue) fileUpload.clear();
 
@@ -1394,11 +1484,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
         },
       );
       if (!fromQueue) {
-        try {
-          localStorage.setItem(forkSeedUploadsConsumedKey, '1');
-          localStorage.removeItem(forkSeedUploadsKey);
-        } catch { /* storage may be unavailable */ }
-        setForkSeedUploads([]);
+        consumeForkSeedUploads();
       }
       setModelOverride(null);
     } catch (e) {
@@ -1416,6 +1502,9 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
       }
       setError(errMsg);
       if (!fromQueue && text) setInput(text);
+      if (!fromQueue && fileUploadResultsForTurn.length > 0) {
+        fileUpload.addUploadedResults(fileUploadResultsForTurn);
+      }
       if (fromQueue && (text || preUploadedResults?.length)) {
         setMessageQueue(prev => [{ text, uploadResults: preUploadedResults }, ...prev]);
       }
@@ -2069,16 +2158,28 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
                   </button>
                 </div>
               ))}
-              {fileUpload.uploads.map((upload) => (
+              {fileUpload.uploads.map((upload) => {
+                const preview = upload.preview || (
+                  upload.result?.is_image
+                    ? resolveAssetUrl(upload.result.url)
+                    : ''
+                );
+                const filename = (
+                  upload.file?.name
+                  || upload.result?.filename
+                  || upload.result?.url.split('/').pop()
+                  || 'attachment'
+                );
+                return (
                 <div key={upload.id} className="relative rounded overflow-hidden border border-gray-600">
-                  {upload.preview ? (
+                  {preview ? (
                     <div className="w-14 h-14">
-                      <img src={upload.preview} alt="" className="w-full h-full object-cover" />
+                      <img src={preview} alt={filename} className="w-full h-full object-cover" />
                     </div>
                   ) : (
                     <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-gray-800 text-xs text-gray-300 max-w-[150px]">
                       <Paperclip size={12} className="shrink-0" />
-                      <span className="truncate">{upload.file.name}</span>
+                      <span className="truncate">{filename}</span>
                     </div>
                   )}
                   {upload.status === 'uploading' && (
@@ -2099,6 +2200,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
                   )}
                   <button
                     type="button"
+                    aria-label={`Remove ${filename}`}
                     onClick={() => fileUpload.removeFile(upload.id)}
                     disabled={injecting}
                     className="absolute top-0 right-0 bg-gray-900/80 rounded-bl p-0.5 text-gray-300 hover:text-foreground"
@@ -2106,7 +2208,8 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
                     <X size={10} />
                   </button>
                 </div>
-              ))}
+              );
+              })}
             </div>
           )}
           <div className="space-y-1.5">
@@ -2123,7 +2226,11 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
             <button
               type="button"
               onClick={() => fileInputRef.current?.click()}
-              disabled={injecting || (!task.session_id && !task.shared_from_id) || fileUpload.uploads.length >= 10}
+              disabled={
+                injecting
+                || (!task.session_id && !task.shared_from_id)
+                || fileUpload.uploads.length + forkSeedUploads.length >= MAX_FILES
+              }
               className="p-2 text-gray-500 hover:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed"
               title="Attach files"
             >

--- a/frontend/src/components/Tasks/TaskForm.tsx
+++ b/frontend/src/components/Tasks/TaskForm.tsx
@@ -518,7 +518,9 @@ export function TaskForm({ onCreated }: TaskFormProps) {
             ) : (
               <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-gray-800 text-xs text-gray-300 max-w-[120px]">
                 <Paperclip size={12} className="shrink-0" />
-                <span className="truncate">{upload.file.name}</span>
+                <span className="truncate">
+                  {upload.file?.name || upload.result?.filename || 'attachment'}
+                </span>
               </div>
             )}
             {upload.status === 'uploading' && (

--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -1,9 +1,9 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useMemo, useRef } from 'react';
 import { api, type UploadResult } from '../api/client';
 
 export interface UploadEntry {
   id: string;
-  file: File;
+  file?: File;
   preview: string;
   status: 'uploading' | 'uploaded' | 'failed';
   result?: UploadResult;
@@ -11,19 +11,63 @@ export interface UploadEntry {
 }
 
 const MAX_FILE_SIZE = 50 * 1024 * 1024;
-const MAX_FILES = 10;
+export const MAX_FILES = 10;
 const BLOCKED_EXTENSIONS = new Set(['.exe']);
 const IMAGE_EXTS = ['.png', '.jpg', '.jpeg', '.gif', '.webp'];
 const isImageFile = (name: string) => IMAGE_EXTS.some(ext => name.toLowerCase().endsWith(ext));
 
-export function useFileUpload() {
-  const [uploads, setUploads] = useState<UploadEntry[]>([]);
+export function isUploadResult(value: unknown): value is UploadResult {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<UploadResult>;
+  return (
+    typeof candidate.id === 'string'
+    && candidate.id.length > 0
+    && (candidate.filename === null || typeof candidate.filename === 'string')
+    && typeof candidate.path === 'string'
+    && candidate.path.length > 0
+    && typeof candidate.url === 'string'
+    && candidate.url.length > 0
+    && typeof candidate.is_image === 'boolean'
+  );
+}
+
+export function sameUploadResult(left: UploadResult, right: UploadResult): boolean {
+  return left.id === right.id || left.path === right.path;
+}
+
+export function dedupeUploadResults(results: UploadResult[]): UploadResult[] {
+  const unique: UploadResult[] = [];
+  for (const result of results) {
+    if (!unique.some((existing) => sameUploadResult(existing, result))) {
+      unique.push(result);
+    }
+  }
+  return unique;
+}
+
+function restoredUploadEntry(result: UploadResult): UploadEntry {
+  return {
+    id: `uploaded:${result.id}:${result.path}`,
+    preview: '',
+    status: 'uploaded',
+    result,
+  };
+}
+
+export function useFileUpload(initialUploadedResults: UploadResult[] = []) {
+  const [uploads, setUploads] = useState<UploadEntry[]>(() =>
+    dedupeUploadResults(initialUploadedResults)
+      .slice(0, MAX_FILES)
+      .map(restoredUploadEntry)
+  );
   const uploadsRef = useRef<UploadEntry[]>([]);
   uploadsRef.current = uploads;
 
   const doUpload = useCallback(async (entry: UploadEntry) => {
+    const file = entry.file;
+    if (!file) return;
     try {
-      const results = await api.uploadImages([entry.file]);
+      const results = await api.uploadImages([file]);
       setUploads(prev => prev.map(u =>
         u.id === entry.id ? { ...u, status: 'uploaded' as const, result: results[0] } : u
       ));
@@ -73,6 +117,25 @@ export function useFileUpload() {
     newEntries.forEach(entry => doUpload(entry));
   }, [doUpload]);
 
+  const addUploadedResults = useCallback((incoming: UploadResult[]): boolean => {
+    const current = uploadsRef.current;
+    const existingResults = current
+      .map((entry) => entry.result)
+      .filter((result): result is UploadResult => !!result);
+    const additions = dedupeUploadResults(incoming).filter(
+      (result) => !existingResults.some((existing) => sameUploadResult(existing, result)),
+    );
+    if (current.length + additions.length > MAX_FILES) return false;
+    if (additions.length === 0) return true;
+    const next = [
+      ...current,
+      ...additions.map(restoredUploadEntry),
+    ];
+    uploadsRef.current = next;
+    setUploads(next);
+    return true;
+  }, []);
+
   const removeFile = useCallback((id: string) => {
     setUploads(prev => {
       const removed = prev.find(u => u.id === id);
@@ -90,21 +153,27 @@ export function useFileUpload() {
   }, [doUpload]);
 
   const clear = useCallback(() => {
-    setUploads(prev => {
-      prev.forEach(u => { if (u.preview) URL.revokeObjectURL(u.preview); });
-      return [];
-    });
+    const current = uploadsRef.current;
+    current.forEach(u => { if (u.preview) URL.revokeObjectURL(u.preview); });
+    uploadsRef.current = [];
+    setUploads([]);
   }, []);
+
+  const uploadedResults = useMemo(
+    () => uploads
+      .filter((u): u is UploadEntry & { result: UploadResult } => u.status === 'uploaded' && !!u.result)
+      .map(u => u.result),
+    [uploads],
+  );
 
   return {
     uploads,
     addFiles,
+    addUploadedResults,
     removeFile,
     retryFile,
     clear,
-    uploadedResults: uploads
-      .filter((u): u is UploadEntry & { result: UploadResult } => u.status === 'uploaded' && !!u.result)
-      .map(u => u.result),
+    uploadedResults,
     isUploading: uploads.some(u => u.status === 'uploading'),
     hasFailed: uploads.some(u => u.status === 'failed'),
     allDone: uploads.length > 0 && uploads.every(u => u.status !== 'uploading'),


### PR DESCRIPTION
## Summary

- restore queued attachments into the composer when using Merge or Edit in input
- persist restored attachment drafts across remounts and preserve them on send failure/requeue
- deduplicate attachments, enforce the 10-file limit atomically, and render restored previews safely

## Tests

- `TZ=UTC npm exec vitest -- run` (497 passed)
- `npm exec vitest -- run src/components/Chat/ChatView.test.tsx` (85 passed)
- `npm run build`
- `npm exec eslint -- src/hooks/useFileUpload.ts src/components/Chat/ChatView.test.tsx`
- `git diff --check`