### PR TITLE
fix: reconcile persisted chat messages by log id

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -26,6 +26,7 @@ from backend.api.uploads import (
     validate_upload_attachments,
 )
 from backend.schemas.task import TaskResponse, TaskRoutingExpectation
+from backend.services.chat_event_identity import persisted_chat_event
 from backend.services.task_queue import task_is_pr_review_superseded
 from backend.services.worker_proxy import get_task_operation_lock
 from backend.services.worker_relay import (
@@ -592,14 +593,14 @@ async def send_chat_message(
     # Broadcast user message to task channel
     from backend.main import broadcaster
     image_urls = [a["url"] for a in attachments if a.get("is_image")]
-    broadcast_data = {
+    broadcast_data = persisted_chat_event(user_log, {
         "event_type": "user_message",
         "role": "user",
         "content": display_content,
         "raw_content": model_message,
         "image_urls": image_urls,
         "attachments": attachments,
-    }
+    })
     if sender_display_name:
         broadcast_data["sender_name"] = sender_display_name
     await broadcaster.broadcast(f"task:{task_id}", broadcast_data)
@@ -984,13 +985,13 @@ async def _send_shared_chat(
     await db.commit()
 
     # Broadcast to local frontend WITH prefix
-    await broadcaster.broadcast(f"task:{task.id}", {
+    await broadcaster.broadcast(f"task:{task.id}", persisted_chat_event(user_log, {
         "event_type": "user_message",
         "role": "user",
         "content": prefixed,
         "raw_content": body.message,
         "sender_name": sender_name,
-    })
+    }))
 
     # Proxy to sharer
     try:
@@ -1101,7 +1102,7 @@ async def _send_worker_chat(
             log_metadata["file_paths"] = all_paths
         if sender_display_name:
             log_metadata["sender_name"] = sender_display_name
-        db.add(LogEntry(
+        user_log = LogEntry(
             instance_id=None,
             task_id=current.id,
             event_type="user_message",
@@ -1109,17 +1110,18 @@ async def _send_worker_chat(
             content=display_content,
             raw_json=json.dumps(log_metadata) if log_metadata else None,
             is_error=False,
-        ))
+        )
+        db.add(user_log)
         await db.commit()
 
         # 2. Broadcast to the Manager frontend.
-        broadcast_data = {
+        broadcast_data = persisted_chat_event(user_log, {
             "event_type": "user_message",
             "role": "user",
             "content": display_content,
             "raw_content": model_message,
             "image_paths": body.image_paths or [],
-        }
+        })
         if sender_display_name:
             broadcast_data["sender_name"] = sender_display_name
         await broadcaster.broadcast(f"task:{current.id}", broadcast_data)
@@ -1559,7 +1561,7 @@ async def _store_injected_message(
         })
     if sender_display_name:
         raw_metadata["sender_name"] = sender_display_name
-    db.add(LogEntry(
+    entry = LogEntry(
         instance_id=instance_id,
         task_id=task.id,
         event_type="user_message",
@@ -1567,10 +1569,11 @@ async def _store_injected_message(
         content=display_content,
         raw_json=json.dumps(raw_metadata, ensure_ascii=False),
         is_error=False,
-    ))
+    )
+    db.add(entry)
     await db.commit()
 
-    event: dict[str, Any] = {
+    event: dict[str, Any] = persisted_chat_event(entry, {
         "event_type": "user_message",
         "role": "user",
         "content": display_content,
@@ -1582,7 +1585,7 @@ async def _store_injected_message(
             for attachment in attachments
             if attachment["is_image"]
         ],
-    }
+    })
     if sender_display_name:
         event["sender_name"] = sender_display_name
     await broadcaster.broadcast(f"task:{task.id}", event)

--- a/backend/api/shared_access.py
+++ b/backend/api/shared_access.py
@@ -16,6 +16,7 @@ from backend.database import get_db
 from backend.models.task import Task
 from backend.models.task_share import TaskShare
 from backend.models.log_entry import LogEntry
+from backend.services.chat_event_identity import persisted_chat_event
 
 logger = logging.getLogger(__name__)
 
@@ -178,13 +179,13 @@ async def shared_chat(
 
     # Broadcast
     from backend.main import broadcaster
-    await broadcaster.broadcast(f"task:{task_id}", {
+    await broadcaster.broadcast(f"task:{task_id}", persisted_chat_event(user_log, {
         "event_type": "user_message",
         "role": "user",
         "content": prefixed,
         "sender_name": sender,
         "raw_content": body.message,
-    })
+    }))
 
     # Enqueue
     from backend.main import dispatcher

--- a/backend/services/chat_event_identity.py
+++ b/backend/services/chat_event_identity.py
@@ -1,0 +1,43 @@
+"""Authoritative identity fields for persisted Task Chat events."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+from backend.models.log_entry import LogEntry
+
+
+def _utc_isoformat(value: datetime) -> str:
+    """Serialize CCM's UTC-naive database timestamps as explicit UTC."""
+
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def persisted_chat_event(
+    entry: LogEntry,
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Attach the local committed LogEntry identity to a WS payload.
+
+    Callers must commit (or at least flush) ``entry`` before using this helper.
+    Identity fields intentionally override any remote/untrusted values already
+    present in ``payload``.
+    """
+
+    if entry.id is None or entry.task_id is None or entry.timestamp is None:
+        raise RuntimeError(
+            "Persisted chat events require a flushed LogEntry id, task_id, "
+            "and timestamp"
+        )
+    return {
+        **payload,
+        "id": entry.id,
+        "task_id": entry.task_id,
+        "timestamp": _utc_isoformat(entry.timestamp),
+    }

--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -33,6 +33,7 @@ from backend.services.context_compaction import (
     context_tokens_used,
     is_context_window_exceeded,
 )
+from backend.services.chat_event_identity import persisted_chat_event
 from backend.services.instance_capacity import (
     active_capacity_predicate,
     instance_capacity_lock,
@@ -11399,6 +11400,11 @@ Codex 中工具会显示为上述 mcp__ccm_monitor_agent__* canonical 名称；
                 if monitor_log is not None:
                     msg.source_log_id = monitor_log.id
                     launch_kwargs["source_log_id"] = monitor_log.id
+                    if broadcast_data is not None:
+                        broadcast_data = persisted_chat_event(
+                            monitor_log,
+                            broadcast_data,
+                        )
             if broadcast_data is not None:
                 await self.broadcaster.broadcast(
                     f"task:{task_id}", broadcast_data

--- a/backend/services/shared_relay.py
+++ b/backend/services/shared_relay.py
@@ -17,6 +17,7 @@ from sqlalchemy import select
 from backend.models.log_entry import LogEntry
 from backend.models.task import Task
 from backend.models.task_share import SharedTaskReceived
+from backend.services.chat_event_identity import persisted_chat_event
 
 logger = logging.getLogger(__name__)
 
@@ -208,6 +209,7 @@ class SharedRelay:
                 return  # self-sent, already stored locally
 
         # Write chat events to local log_entries
+        persisted_data = None
         if event_type in CHAT_EVENT_TYPES:
             raw_json = data.get("raw_json")
             metadata_keys = (
@@ -219,7 +221,7 @@ class SharedRelay:
                     k: data[k] for k in metadata_keys if data.get(k) is not None
                 })
             async with self.db_factory() as db:
-                db.add(LogEntry(
+                entry = LogEntry(
                     instance_id=None,
                     task_id=local_task_id,
                     event_type=event_type,
@@ -230,8 +232,17 @@ class SharedRelay:
                     tool_output=data.get("tool_output"),
                     raw_json=raw_json,
                     is_error=data.get("is_error", False),
-                ))
+                )
+                db.add(entry)
                 await db.commit()
+                persisted_data = persisted_chat_event(
+                    entry,
+                    {
+                        key: value
+                        for key, value in data.items()
+                        if key != "raw_json"
+                    },
+                )
 
             if data.get("role") == "assistant" and event_type in ("message", "result"):
                 async with self.db_factory() as db:
@@ -253,7 +264,10 @@ class SharedRelay:
                         await db.commit()
 
         # Broadcast to local frontend (mirror the event on local task channel)
-        await self.broadcaster.broadcast(f"task:{local_task_id}", data)
+        await self.broadcaster.broadcast(
+            f"task:{local_task_id}",
+            persisted_data or data,
+        )
 
     async def backfill_history(self, shared: SharedTaskReceived):
         """Pull full chat history from sharer and store locally."""

--- a/backend/services/worker_relay.py
+++ b/backend/services/worker_relay.py
@@ -30,6 +30,7 @@ from backend.models.log_entry import LogEntry
 from backend.models.monitor_session import MonitorCheck, MonitorSession
 from backend.models.task import Task
 from backend.models.worker import Worker
+from backend.services.chat_event_identity import persisted_chat_event
 from backend.services.task_queue import PR_REVIEW_SUPERSEDED_METADATA_KEY
 
 _TASK_STATUSES = frozenset(
@@ -802,6 +803,7 @@ class WorkerRelay:
             return
 
         # 2) chat 事件双写 LogEntry（instance_id=None；广播 payload 无 raw_json，存 None）
+        persisted_forward = None
         if event_type in CHAT_EVENT_TYPES:
             async with self.db_factory() as db:
                 guard_values = {"status": observed.status}
@@ -818,7 +820,7 @@ class WorkerRelay:
                 if guarded.rowcount != 1:
                     await db.rollback()
                     return
-                db.add(LogEntry(
+                entry = LogEntry(
                     instance_id=None,
                     task_id=task_id,
                     event_type=event_type,
@@ -830,8 +832,17 @@ class WorkerRelay:
                     raw_json=data.get("raw_json"),
                     is_error=data.get("is_error", False),
                     loop_iteration=data.get("loop_iteration"),
-                ))
+                )
+                db.add(entry)
                 await db.commit()
+                persisted_forward = persisted_chat_event(
+                    entry,
+                    {
+                        key: value
+                        for key, value in data.items()
+                        if key not in ("instance_id", "raw_json")
+                    },
+                )
             # session_id 同步：worker 广播前 pop 了 session_id，首条事件到达时从 Worker 拉取
             if event_type == "system_init":
                 session_observed = await self._observe_task_generation(
@@ -1087,7 +1098,9 @@ class WorkerRelay:
                 await db.commit()
 
         # 4) 镜像广播到来源同名 channel（剥 worker 的 instance_id，对 Manager 无意义）
-        forward = {k: v for k, v in data.items() if k != "instance_id"}
+        forward = persisted_forward or {
+            k: v for k, v in data.items() if k != "instance_id"
+        }
         if channel.startswith("task:"):
             await self.broadcaster.broadcast(f"task:{task_id}", forward)
         elif channel == "tasks":

--- a/backend/tests/test_api_chat_plan.py
+++ b/backend/tests/test_api_chat_plan.py
@@ -1164,7 +1164,63 @@ async def test_shared_chat_sender_prefix_is_display_only(client, session_factory
         )).scalar_one()
     assert stored.content == "[Remote Alice] [TODO] keep the tag"
     assert json.loads(stored.raw_json)["raw_content"] == "[TODO] keep the tag"
-    assert mock_broadcaster.broadcast.call_args.args[1]["content"] == stored.content
+    event = mock_broadcaster.broadcast.call_args.args[1]
+    assert event["content"] == stored.content
+    assert event["id"] == stored.id
+    assert event["task_id"] == task_id
+    assert event["timestamp"].endswith("Z")
+
+
+@pytest.mark.asyncio
+async def test_shared_relay_replaces_remote_chat_identity_with_local_log_entry(
+    client,
+    session_factory,
+):
+    """A shadow Task must never expose the sharer's database id as local."""
+    from types import SimpleNamespace
+
+    from backend.services.shared_relay import SharedRelay
+
+    created = await client.post("/api/tasks", json={
+        "title": "Shadow",
+        "description": "shared relay",
+        "target_repo": "/tmp",
+    })
+    task_id = created.json()["id"]
+    broadcaster = MagicMock()
+    broadcaster.broadcast = AsyncMock()
+    relay = SharedRelay(session_factory, broadcaster)
+
+    await relay._handle(
+        {
+            "data": {
+                "id": 987654,
+                "task_id": 44,
+                "event_type": "message",
+                "role": "assistant",
+                "content": "remote answer",
+                "timestamp": "2026-07-30T01:02:03Z",
+            },
+        },
+        SimpleNamespace(local_task_id=task_id),
+    )
+
+    async with session_factory() as db:
+        stored = (
+            await db.execute(
+                select(LogEntry).where(
+                    LogEntry.task_id == task_id,
+                    LogEntry.event_type == "message",
+                )
+            )
+        ).scalar_one()
+
+    event = broadcaster.broadcast.call_args.args[1]
+    assert event["id"] == stored.id
+    assert event["id"] != 987654
+    assert event["task_id"] == task_id
+    assert event["timestamp"].endswith("Z")
+    assert event["content"] == "remote answer"
 
 
 @pytest.mark.asyncio
@@ -2212,7 +2268,23 @@ async def test_inject_delivers_to_pty_session(client, session_factory):
     casts = [c for c in mock_broadcaster.broadcast.call_args_list
              if c[0][1].get("source") == "inject"]
     assert len(casts) == 1
-    assert casts[0][0][1]["raw_content"] == "focus on tests"
+    event = casts[0][0][1]
+    assert event["raw_content"] == "focus on tests"
+    assert event["task_id"] == task_id
+    assert isinstance(event["id"], int)
+    assert event["id"] > 0
+    assert event["timestamp"].endswith("Z")
+
+    async with session_factory() as db:
+        stored = (
+            await db.execute(
+                select(LogEntry).where(
+                    LogEntry.task_id == task_id,
+                    LogEntry.event_type == "user_message",
+                )
+            )
+        ).scalar_one()
+    assert event["id"] == stored.id
 
 
 @pytest.mark.asyncio
@@ -2287,6 +2359,9 @@ async def test_inject_delivers_uploaded_image_to_pty_and_persists_metadata(
             )
         ).scalar_one()
     metadata = json.loads(stored.raw_json)
+    assert events[0]["id"] == stored.id
+    assert events[0]["task_id"] == task_id
+    assert events[0]["timestamp"].endswith("Z")
     assert metadata["source"] == "inject"
     assert metadata["raw_content"] == ""
     assert metadata["file_paths"] == [str(upload_path)]
@@ -2346,6 +2421,19 @@ async def test_codex_inject_steers_without_pty_mode(
         if call.args[1].get("source") == "inject"
     ]
     assert len(injected) == 1
+    async with session_factory() as db:
+        stored = (
+            await db.execute(
+                select(LogEntry).where(
+                    LogEntry.task_id == task_id,
+                    LogEntry.event_type == "user_message",
+                )
+            )
+        ).scalar_one()
+    event = injected[0].args[1]
+    assert event["id"] == stored.id
+    assert event["task_id"] == task_id
+    assert event["timestamp"].endswith("Z")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_message_pipeline.py
+++ b/backend/tests/test_message_pipeline.py
@@ -9,6 +9,8 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import datetime
 
+from sqlalchemy import select
+
 from backend.services.stream_parser import StreamParser
 from backend.services.instance_manager import InstanceManager
 from backend.models.instance import Instance
@@ -991,7 +993,35 @@ async def test_chat_send_broadcasts_user_message(client, session_factory):
         if c[0][0] == f"task:{task_id}" and c[0][1].get("event_type") == "user_message"
     ]
     assert len(task_broadcasts) == 1
-    assert task_broadcasts[0][0][1]["content"] == "hello"
+    event = task_broadcasts[0][0][1]
+    assert event["content"] == "hello"
+    assert event["task_id"] == task_id
+    assert isinstance(event["id"], int)
+    assert event["id"] > 0
+    assert event["timestamp"].endswith("Z")
+
+    async with session_factory() as db:
+        stored = (
+            await db.execute(
+                select(LogEntry).where(
+                    LogEntry.task_id == task_id,
+                    LogEntry.event_type == "user_message",
+                )
+            )
+        ).scalar_one()
+    assert event["id"] == stored.id
+
+    history_response = await client.get(
+        f"/api/tasks/{task_id}/chat/history?compact=true&limit=200"
+    )
+    assert history_response.status_code == 200
+    history_row = next(
+        row
+        for row in history_response.json()
+        if row["event_type"] == "user_message"
+    )
+    assert history_row["id"] == stored.id
+    assert history_row["timestamp"] == event["timestamp"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_service_dispatcher.py
+++ b/backend/tests/test_service_dispatcher.py
@@ -5147,6 +5147,31 @@ async def test_queued_codex_busy_launch_rolls_back_status_and_temp_skills(
         assert task.status == "completed"
         assert task.enabled_skills == {"base": True}
     assert msg.source_logged is True
+    from backend.models.log_entry import LogEntry
+
+    async with db_factory() as db:
+        stored = (
+            await db.execute(
+                select(LogEntry).where(
+                    LogEntry.task_id == task_id,
+                    LogEntry.event_type == "user_message",
+                )
+            )
+        ).scalar_one()
+    user_events = [
+        call.args[1]
+        for call in d.broadcaster.broadcast.await_args_list
+        if (
+            len(call.args) >= 2
+            and call.args[0] == f"task:{task_id}"
+            and call.args[1].get("event_type") == "user_message"
+        )
+    ]
+    assert len(user_events) == 1
+    assert user_events[0]["source"] == "monitor"
+    assert user_events[0]["id"] == stored.id
+    assert user_events[0]["task_id"] == task_id
+    assert user_events[0]["timestamp"].endswith("Z")
     assert not d._launching_instances
 
 

--- a/backend/tests/test_worker_relay_proxy.py
+++ b/backend/tests/test_worker_relay_proxy.py
@@ -729,8 +729,13 @@ async def test_relay_chat_event_stored_and_forwarded(relay, broadcaster, session
 
     await relay._handle({
         "channel": f"task:{t.id}",
-        "data": {"event_type": "message", "role": "assistant", "content": "hi",
-                 "instance_id": 7},
+        "data": {
+            "id": 987654,
+            "event_type": "message",
+            "role": "assistant",
+            "content": "hi",
+            "instance_id": 7,
+        },
     }, w)
 
     async with session_factory() as db:
@@ -740,8 +745,19 @@ async def test_relay_chat_event_stored_and_forwarded(relay, broadcaster, session
     assert logs[0].instance_id is None
     assert logs[0].content == "hi"
     assert task.has_unread is True
-    # 镜像广播到同名 channel，且剥掉 worker 的 instance_id
-    assert broadcaster.sent == [(f"task:{t.id}", {"event_type": "message", "role": "assistant", "content": "hi"})]
+    # 镜像广播到同名 channel，剥掉 worker 的 instance_id，并以 Manager
+    # 本地 LogEntry 身份覆盖远端数据库 id。
+    assert len(broadcaster.sent) == 1
+    channel, event = broadcaster.sent[0]
+    assert channel == f"task:{t.id}"
+    assert event["event_type"] == "message"
+    assert event["role"] == "assistant"
+    assert event["content"] == "hi"
+    assert "instance_id" not in event
+    assert event["id"] == logs[0].id
+    assert event["id"] != 987654
+    assert event["task_id"] == t.id
+    assert event["timestamp"].endswith("Z")
 
 
 async def test_relay_skips_user_message_and_unsubscribed(relay, broadcaster, session_factory):
@@ -4814,7 +4830,11 @@ async def test_worker_chat_sender_prefix_is_display_only(session_factory, monkey
         )).scalar_one()
     assert stored.content == "[Worker Alice] [FIX] preserve this tag"
     assert json.loads(stored.raw_json)["raw_content"] == "[FIX] preserve this tag"
-    assert broadcaster.sent[0][1]["content"] == stored.content
+    event = broadcaster.sent[0][1]
+    assert event["content"] == stored.content
+    assert event["id"] == stored.id
+    assert event["task_id"] == t.id
+    assert event["timestamp"].endswith("Z")
 
 
 async def test_chat_proxy_rejects_secrets(client, session_factory, monkeypatch):

--- a/frontend/src/components/Chat/ChatView.test.tsx
+++ b/frontend/src/components/Chat/ChatView.test.tsx
@@ -1429,6 +1429,81 @@ describe('ChatView', () => {
       expect(screen.getByText('live while snapshot is in flight')).toBeInTheDocument();
     });
 
+    it('pages from the HTTP boundary when an older persisted WS row is retained', async () => {
+      const latest = Array.from({ length: 200 }, (_, index): ChatMessage => ({
+        id: 210 + index,
+        role: 'assistant',
+        event_type: 'message',
+        content: `latest-${index}`,
+        tool_name: null,
+        tool_input: null,
+        tool_output: null,
+        is_error: false,
+        loop_iteration: null,
+        timestamp: `2026-07-30T10:${String(index % 60).padStart(2, '0')}:00Z`,
+        image_urls: null,
+        attachments: null,
+      }));
+      const injected: ChatMessage = {
+        id: 10,
+        role: 'user',
+        event_type: 'user_message',
+        content: '[Admin] early steer',
+        raw_content: 'early steer',
+        tool_name: null,
+        tool_input: null,
+        tool_output: null,
+        is_error: false,
+        loop_iteration: null,
+        timestamp: '2026-07-30T09:00:00Z',
+        image_urls: null,
+        attachments: null,
+        source: 'inject',
+      };
+      vi.mocked(api.getTaskChatHistory)
+        .mockResolvedValueOnce(latest)
+        .mockResolvedValueOnce([injected]);
+
+      render(
+        <ChatView
+          task={makeTask({ id: 16, description: null })}
+          projects={projects}
+          onBack={onBack}
+        />,
+      );
+      await screen.findByText('latest-199');
+
+      act(() => {
+        capturedOnMessage?.({
+          channel: 'task:16',
+          data: {
+            ...injected,
+            task_id: 16,
+          },
+        });
+      });
+      expect(screen.getAllByText('[Admin] early steer')).toHaveLength(1);
+
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Load older messages' }),
+      );
+
+      await waitFor(() => {
+        expect(api.getTaskChatHistory).toHaveBeenNthCalledWith(
+          2,
+          16,
+          true,
+          200,
+          210,
+        );
+      });
+      await waitFor(() => {
+        expect(screen.getAllByText('[Admin] early steer')).toHaveLength(1);
+      });
+      expect(api.injectTaskMessage).not.toHaveBeenCalled();
+      expect(api.sendTaskChat).not.toHaveBeenCalled();
+    });
+
     it('backfills again after the task-channel subscription is acknowledged', async () => {
       const task = makeTask({ id: 13 });
       render(<ChatView task={task} projects={projects} onBack={onBack} />);
@@ -1953,6 +2028,70 @@ describe('聊天图片附件展示（2026-07-16 用户反馈：发图后图片�
 
     expect(screen.getByText('[Admin] 检查训练状态')).toBeInTheDocument();
     expect(screen.queryByText('检查训练状态')).not.toBeInTheDocument();
+  });
+
+  it('权威用户消息即使不是最后一条，也会替换此前的实时气泡', async () => {
+    const task = makeTask({ id: 120, description: null });
+    render(<ChatView task={task} projects={projects} onBack={onBack} onTaskUpdated={onTaskUpdated} />);
+    await waitFor(() => expect(api.getTaskChatHistory).toHaveBeenCalled());
+
+    await act(async () => {
+      wsUserMessage(120, {
+        content: '检查训练状态',
+        raw_content: '检查训练状态',
+      });
+      capturedOnMessage!({
+        channel: 'task:120',
+        data: {
+          id: 700,
+          event_type: 'message',
+          role: 'assistant',
+          content: '正在检查',
+          timestamp: '2026-07-30T10:00:01Z',
+        },
+      });
+      wsUserMessage(120, {
+        id: 699,
+        content: '[Admin] 检查训练状态',
+        raw_content: '检查训练状态',
+        timestamp: '2026-07-30T10:00:00Z',
+      });
+    });
+
+    expect(screen.getByText('[Admin] 检查训练状态')).toBeInTheDocument();
+    expect(screen.queryByText('检查训练状态')).not.toBeInTheDocument();
+    expect(screen.getByText('正在检查')).toBeInTheDocument();
+  });
+
+  it('同一个持久化用户消息重放时按 id 原位更新而不追加', async () => {
+    const task = makeTask({ id: 121, description: null });
+    render(<ChatView task={task} projects={projects} onBack={onBack} onTaskUpdated={onTaskUpdated} />);
+    await waitFor(() => expect(api.getTaskChatHistory).toHaveBeenCalled());
+
+    await act(async () => {
+      wsUserMessage(121, {
+        id: 801,
+        content: '[Admin] 只显示一次',
+        raw_content: '只显示一次',
+      });
+      capturedOnMessage!({
+        channel: 'task:121',
+        data: {
+          id: 802,
+          event_type: 'message',
+          role: 'assistant',
+          content: '中间输出',
+        },
+      });
+      wsUserMessage(121, {
+        id: 801,
+        content: '[Admin] 只显示一次',
+        raw_content: '只显示一次',
+      });
+    });
+
+    expect(screen.getAllByText('[Admin] 只显示一次')).toHaveLength(1);
+    expect(screen.getByText('中间输出')).toBeInTheDocument();
   });
 
   it('Capacitor（手机 App）下附件相对 URL 必须拼上远程服务器地址', async () => {

--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -404,6 +404,19 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
   const isProcessing = sending || backgroundActive || ['in_progress', 'executing'].includes(effectiveStatus);
   const [hasMoreHistory, setHasMoreHistory] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
+  const historyCursorRef = useRef<{
+    taskId: number;
+    beforeId: number | null;
+  }>({
+    taskId: task.id,
+    beforeId: null,
+  });
+  if (historyCursorRef.current.taskId !== task.id) {
+    historyCursorRef.current = {
+      taskId: task.id,
+      beforeId: null,
+    };
+  }
   const HISTORY_PAGE_SIZE = 200;
 
   const navigateUserMessage = useCallback((direction: 'up' | 'down') => {
@@ -821,46 +834,67 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
       const persistedId = Number(msg.data.id);
       const isPersisted = Number.isFinite(persistedId) && persistedId > 0;
       const eventTimestamp = (msg.data.timestamp as string) || new Date().toISOString();
+      const entry: ChatMessage = {
+        id: isPersisted ? persistedId : Date.now() + Math.random(),
+        role: 'user',
+        event_type: 'user_message',
+        content,
+        tool_name: null,
+        tool_input: null,
+        tool_output: null,
+        is_error: false,
+        loop_iteration: null,
+        timestamp: eventTimestamp,
+        image_urls: imageUrls,
+        attachments,
+        source,
+        raw_content: rawContent,
+        persisted: isPersisted,
+      };
       setSending(true);
       setMessages((prev) => {
+        if (isPersisted) {
+          return mergeChatHistory([entry], prev);
+        }
+
         // Reconcile the optimistic bubble with the authoritative broadcast.
         // The optimistic content can be raw text while the server content is
         // prefixed with the sender name, so display content alone is not a
         // stable identity. raw_content is the canonical user input.
-        const last = prev[prev.length - 1];
-        const matchesOptimistic = Boolean(
-          last
-          && last.role === 'user'
-          && last.event_type === 'user_message'
-          && (
-            last.content === content
-            || (
-              rawContent !== null
-              && last.raw_content === rawContent
+        let optimisticIndex = -1;
+        for (let index = prev.length - 1; index >= 0; index -= 1) {
+          const candidate = prev[index];
+          if (
+            !candidate.persisted
+            && candidate.role === 'user'
+            && candidate.event_type === 'user_message'
+            && (
+              candidate.content === content
+              || (
+                rawContent !== null
+                && candidate.raw_content === rawContent
+              )
             )
-          )
-        );
-        if (last && matchesOptimistic) {
-          return [...prev.slice(0, -1), {
-            ...last,
-            id: isPersisted ? persistedId : last.id,
+          ) {
+            optimisticIndex = index;
+            break;
+          }
+        }
+        if (optimisticIndex >= 0) {
+          const optimistic = prev[optimisticIndex];
+          const next = [...prev];
+          next[optimisticIndex] = {
+            ...optimistic,
             content,
             source,
-            raw_content: rawContent ?? last.raw_content,
+            raw_content: rawContent ?? optimistic.raw_content,
             timestamp: eventTimestamp,
-            image_urls: imageUrls?.length ? imageUrls : last.image_urls,
-            attachments: attachments?.length ? attachments : last.attachments,
-            persisted: isPersisted || last.persisted,
-          }];
+            image_urls: imageUrls?.length ? imageUrls : optimistic.image_urls,
+            attachments: attachments?.length ? attachments : optimistic.attachments,
+          };
+          return next;
         }
-        return [...prev, {
-          id: isPersisted ? persistedId : Date.now() + Math.random(), role: 'user', event_type: 'user_message',
-          content, tool_name: null, tool_input: null, tool_output: null,
-          is_error: false, loop_iteration: null,
-          timestamp: eventTimestamp,
-          image_urls: imageUrls, attachments: attachments, source, raw_content: rawContent,
-          persisted: isPersisted,
-        }];
+        return [...prev, entry];
       });
       return;
     }
@@ -934,20 +968,20 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
       persisted: isPersisted,
     };
     setMessages((prev) => {
+      const current = isPersisted
+        ? prev.filter((candidate) => !candidate.pty_cold_start)
+        : prev;
+      if (isPersisted) {
+        return mergeChatHistory([entry], current);
+      }
       if (itemId) {
-        const index = prev.findIndex((candidate) => candidate.stream_item_id === itemId);
+        const index = current.findIndex((candidate) => candidate.stream_item_id === itemId);
         if (index >= 0) {
-          const next = [...prev];
+          const next = [...current];
           next[index] = entry;
           return next;
         }
       }
-      // A PTY recovery notice describes only the active reconnect interval.
-      // The first durable event proves recovery progressed, so retire the
-      // notice instead of allowing later history merges to move it downward.
-      const current = isPersisted
-        ? prev.filter((candidate) => !candidate.pty_cold_start)
-        : prev;
       return [...current, entry];
     });
   }, [markAskUserResolved, task.id, task.worker_id]);
@@ -964,6 +998,22 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
           !((m.event_type === 'message' || m.event_type === 'result') && !m.content)
         )
         .map((m) => ({ ...m, persisted: true }));
+      const pageOldestId = filtered.reduce<number | null>(
+        (oldest, message) => (
+          oldest === null ? message.id : Math.min(oldest, message.id)
+        ),
+        null,
+      );
+      if (
+        pageOldestId !== null
+        && historyCursorRef.current.taskId === task.id
+      ) {
+        historyCursorRef.current.beforeId = (
+          historyCursorRef.current.beforeId === null
+            ? pageOldestId
+            : Math.min(historyCursorRef.current.beforeId, pageOldestId)
+        );
+      }
       setHasMoreHistory(msgs.length >= HISTORY_PAGE_SIZE);
       const existingIds = new Set(
         filtered.filter((m) => m.event_type === 'ask_user_question').map((m) => m.request_id)
@@ -1002,12 +1052,16 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
 
   const loadMoreHistory = useCallback(() => {
     if (loadingMore || !hasMoreHistory || messages.length === 0) return;
-    const oldestId = messages[0]?.id;
-    if (!oldestId) return;
+    const oldestHistoryId = (
+      historyCursorRef.current.taskId === task.id
+        ? historyCursorRef.current.beforeId
+        : null
+    );
+    if (oldestHistoryId === null) return;
     const container = messagesContainerRef.current;
     if (container) scrollRestorationRef.current = container.scrollHeight;
     setLoadingMore(true);
-    api.getTaskChatHistory(task.id, true, HISTORY_PAGE_SIZE, oldestId).then((msgs) => {
+    api.getTaskChatHistory(task.id, true, HISTORY_PAGE_SIZE, oldestHistoryId).then((msgs) => {
       const filtered = msgs
         .filter((m) =>
           !isLegacyCodexCollabCompleted(m) &&
@@ -1015,7 +1069,14 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
         )
         .map((m) => ({ ...m, persisted: true }));
       if (filtered.length > 0) {
-        setMessages((prev) => [...filtered, ...prev]);
+        const pageOldestId = filtered.reduce(
+          (oldest, message) => Math.min(oldest, message.id),
+          filtered[0].id,
+        );
+        if (historyCursorRef.current.taskId === task.id) {
+          historyCursorRef.current.beforeId = pageOldestId;
+        }
+        setMessages((prev) => mergeChatHistory(filtered, prev));
       }
       setHasMoreHistory(msgs.length >= HISTORY_PAGE_SIZE);
     }).catch(() => {}).finally(() => setLoadingMore(false));

--- a/frontend/src/components/Chat/messageMerge.test.ts
+++ b/frontend/src/components/Chat/messageMerge.test.ts
@@ -104,3 +104,47 @@ describe('mergeChatHistory ephemeral events', () => {
     ]);
   });
 });
+
+describe('mergeChatHistory persisted identity', () => {
+  it('keeps a persisted injected message outside the latest page in id order', () => {
+    const injected = message({
+      id: 10,
+      role: 'user',
+      event_type: 'user_message',
+      content: '[Admin] steer the active turn',
+      raw_content: 'steer the active turn',
+      source: 'inject',
+      persisted: true,
+    });
+    const latest = [
+      message({ id: 210, content: 'tool output', persisted: true }),
+      message({ id: 211, content: 'final answer', persisted: true }),
+    ];
+
+    expect(
+      mergeChatHistory(latest, [injected, ...latest]).map((entry) => entry.id),
+    ).toEqual([10, 210, 211]);
+  });
+
+  it('deduplicates an older page by id without collapsing equal text at different ids', () => {
+    const first = message({
+      id: 20,
+      role: 'user',
+      event_type: 'user_message',
+      content: 'same text',
+      persisted: true,
+    });
+    const second = message({
+      id: 21,
+      role: 'user',
+      event_type: 'user_message',
+      content: 'same text',
+      persisted: true,
+    });
+
+    const merged = mergeChatHistory([first], [first, second]);
+
+    expect(merged.map((entry) => entry.id)).toEqual([20, 21]);
+    expect(merged.filter((entry) => entry.content === 'same text')).toHaveLength(2);
+  });
+});

--- a/plans/chat-user-message-reconciliation-fix.md
+++ b/plans/chat-user-message-reconciliation-fix.md
@@ -1,0 +1,224 @@
+# CCM 聊天旧消息重复/移位修复计划
+
+## 1. 背景与现象
+
+用户在 Task Chat 的运行中 turn 里通过“💉 注入”发送补充指令。消息最初显示在正确位置，但 CCM 完成回复后，部分旧消息又出现在对话底部；加载更早记录后，还可能同时看到原位置和底部副本。
+
+该问题也可能影响普通用户消息，只是长 turn 中的注入消息更容易触发。
+
+## 2. 已确认根因
+
+当前链路为：
+
+1. `/api/tasks/{id}/inject` 先通过 Claude PTY 或 Codex `turn/steer` 完成真实注入。
+2. 注入成功后，后端创建并提交一条 `LogEntry(event_type="user_message")`。
+3. 后端向 `task:{id}` 广播该消息，但广播体没有携带已提交日志的 `id` 和权威 `timestamp`。
+4. 前端收到事件后只能生成临时 ID，并把它视为未持久化的实时消息。
+5. turn 结束时，`ChatView` 重新请求最近 200 条历史。
+6. 长 turn 的 thinking/tool/message 事件可能把较早的注入日志挤出最新一页。
+7. `mergeChatHistory()` 会保留这条“未持久化实时消息”，并将它追加在所有持久化消息之后，因此旧消息看起来被再次发送。
+8. 加载更早分页时，真实持久化行又可能被插入，形成两个可见副本。
+
+这属于展示层身份和分页对账错误，不会再次调用 `/inject`、`turn/steer` 或 Dispatcher enqueue。原始指令只在首次成功注入时影响当前 turn。
+
+## 3. 修复目标
+
+- 每条已持久化 Task Chat 消息在 WebSocket 和 HTTP 历史中使用同一个数据库 `LogEntry.id`。
+- 已持久化实时消息即使不在最新 200 条快照中，也必须保持原有时间顺序。
+- WebSocket 重复投递、重连回填、turn 结束刷新和向前分页均不得产生重复气泡。
+- 相同文本可以由用户真实发送多次，不能按文本全局去重。
+- 注入消息的 `source="inject"`、发送者前缀和附件元数据保持不变。
+- 修复普通消息及其他同类 Task `user_message` 入口，避免只修截图中的单一路径。
+- 不引入数据库迁移，不改变模型收到的 prompt，也不改变任务调度语义。
+
+## 4. 非目标
+
+- 不重写完整聊天状态管理架构。
+- 不修改 Discussion 独立消息系统。
+- 不改变历史分页大小或删除已有聊天记录。
+- 不把 UI 去重当作发送幂等机制；本计划只处理一次成功发送后的展示一致性。
+- 不用文本内容、时间窗口或发送者名字作为持久消息的最终身份。
+
+## 5. 消息身份契约
+
+所有“先写入本地 `log_entries`，再广播到本地 Task Chat”的事件必须满足：
+
+```json
+{
+  "event_type": "user_message",
+  "id": 12345,
+  "task_id": 88,
+  "timestamp": "2026-07-30T11:41:00.123456Z",
+  "role": "user",
+  "content": "[Admin] ...",
+  "raw_content": "...",
+  "source": "inject"
+}
+```
+
+约束：
+
+- `id` 必须是当前 CCM 数据库中已提交的 `LogEntry.id`。
+- `timestamp` 必须来自同一条 `LogEntry`，并使用统一的 UTC ISO-8601 格式。
+- 广播只能发生在数据库提交成功之后。
+- 远程 Worker/Shared 事件若复制到本地数据库，必须使用本地副本 ID；不能把远端 ID 冒充本地 ID。
+- 未持久化的 delta、权限卡片等临时事件不强制具有 `LogEntry.id`。
+- 兼容旧端事件：缺少 `id` 时保留现有 occurrence-count/fingerprint 降级逻辑，但不得用它覆盖新契约。
+
+## 6. 实施阶段
+
+### Phase 1：先补回归测试，固定故障
+
+在修改实现前增加最小可复现测试：
+
+1. 当前消息列表包含一条实时注入消息。
+2. 随后加入超过 200 条持久化回复事件，使注入消息不在最新 HTTP 快照内。
+3. 模拟 `process_exit` 后刷新历史。
+4. 断言注入消息只出现一次，且仍排在对应回复之前。
+5. 再加载包含该注入日志的较早分页。
+6. 断言仍只有一条，`source`、附件和时间不丢失。
+
+同时增加以下边界用例：
+
+- 同一个持久化 ID 经 WebSocket 投递两次，只显示一次。
+- WebSocket 与 HTTP 快照并发返回同一个 ID，只显示一次。
+- 两条内容完全相同但 ID 不同的用户消息，两条都保留。
+- 普通 optimistic 用户气泡被权威 WebSocket 行替换，不出现一临时一持久两份。
+- 历史刷新只调用 GET，不再次调用 `injectTaskMessage` 或 `sendTaskChat`。
+
+### Phase 2：后端广播权威持久化身份
+
+审计所有 Task `user_message` 的“落库 + 广播”入口：
+
+| 路径 | 预期处理 |
+|------|----------|
+| `backend/api/chat.py::send_chat_message` | 广播 `user_log.id/timestamp` |
+| `backend/api/chat.py::_store_injected_message` | 保留 `LogEntry` 对象并广播其 ID/时间 |
+| `backend/api/chat.py::_send_shared_chat` | 广播本地 `user_log` 身份 |
+| `backend/api/chat.py::_send_worker_chat` | 不再匿名 `db.add()`，保留本地日志对象 |
+| `backend/api/shared_access.py` | owner 端共享消息广播本地日志身份 |
+| `backend/services/dispatcher.py` | Monitor/Sub-Agent 注入日志提交后补充 ID/时间 |
+| `backend/services/shared_relay.py` | 复制远端事件后，用本地新行身份覆盖远端身份再广播 |
+
+实现要求：
+
+- 提取一个窄范围的 payload helper，统一添加 `id`、`task_id`、UTC `timestamp`，避免各入口再次遗漏。
+- helper 只序列化已经 flush/commit 的 `LogEntry`；不负责数据库写入或广播。
+- 保留各入口已有的 `raw_content`、`source`、`attachments`、`image_urls`、`sender_name` 等展示字段。
+- 继续保持“提交成功后广播”；若广播失败，HTTP 历史仍是最终事实源。
+- 不修改 Codex/Claude transport 调用次数和顺序。
+
+### Phase 3：前端改为按持久化 ID upsert
+
+调整 `ChatView` 和消息合并逻辑：
+
+1. WebSocket 消息包含合法正整数 `id` 时，立即标记 `persisted=true`。
+2. 当前列表已存在相同持久化 ID 时执行原位更新，不追加新气泡。
+3. 普通发送的 optimistic 气泡与权威行对账后，替换临时气泡并继承权威 ID。
+4. 对账不能只检查数组最后一项；状态/系统事件插入时仍应找到对应 optimistic 用户气泡。
+5. 内容相同但 ID 不同的持久化消息不得折叠。
+6. 最新历史快照不包含的旧持久化实时消息继续保留，并与快照行按数据库 ID 排序。
+7. “加载更早消息”也通过 ID 合并，不再直接无条件 prepend。
+8. 分页游标从已加载的持久化历史行取得；不得使用 `Date.now()` 生成的临时 UI ID。
+9. 对无 ID 的旧后端事件保留 occurrence-count fingerprint 兼容逻辑，且只作为降级路径。
+
+如现有 optimistic 对账测试证明仅靠 `raw_content` 无法区分并发的相同文本消息，再单独引入可选 `client_message_id`；首轮修复不主动扩大到发送幂等协议。
+
+### Phase 4：跨路径验证
+
+后端测试至少覆盖：
+
+- 普通 local chat：数据库行 ID、广播 ID、历史 ID 三者相同。
+- Claude PTY 注入：transport 一次、日志一条、广播一次且带 ID。
+- Codex steer 注入：transport 一次、日志一条、广播一次且带 ID。
+- 注入失败：不落日志、不广播成功消息。
+- Worker local display copy：使用 Manager 本地日志 ID。
+- Shared owner/shadow/relay：本地广播使用本地 ID，不复用远端 ID。
+- Monitor/Sub-Agent 来源消息：保留 source 并带持久化 ID。
+
+前端测试至少覆盖：
+
+- 最新 200 条快照排除旧注入消息。
+- `process_exit`、订阅确认、WebSocket 重连分别触发历史刷新。
+- WebSocket 先到、HTTP 后到和 HTTP 先到、WebSocket 后到两种竞态。
+- 向前分页包含已在内存中的持久化消息。
+- 重复 ID、相同文本不同 ID、附件注入、发送者前缀。
+- 普通消息与注入消息都不会移动到回复之后。
+
+## 7. 预计修改文件
+
+- `backend/api/chat.py`
+- `backend/api/shared_access.py`
+- `backend/services/dispatcher.py`
+- `backend/services/shared_relay.py`
+- 一个小型后端 chat-event payload helper（若现有模块没有合适位置）
+- `frontend/src/components/Chat/ChatView.tsx`
+- `frontend/src/components/Chat/messageMerge.ts`
+- `backend/tests/test_api_chat_plan.py`
+- `backend/tests/test_message_pipeline.py`
+- Shared/Worker/Dispatcher 对应测试文件
+- `frontend/src/components/Chat/ChatView.test.tsx`
+- `frontend/src/components/Chat/messageMerge.test.ts`
+
+本修复不需要 Alembic migration；项目架构不变时不更新 `AGENTS.md`。
+
+## 8. 验收标准
+
+### 功能验收
+
+- 在一个产生超过 200 条可见日志的 turn 中连续注入 3 条消息。
+- turn 运行中，3 条消息显示在各自注入时的位置。
+- turn 完成后，3 条消息仍各出现一次，且没有移动到回复底部。
+- 刷新页面、断开并恢复 WebSocket、重新进入 Task 后结果不变。
+- 点击“Load older messages”直到包含这些消息，仍各出现一次。
+- 消息的“💉 注入”标签、发送者前缀、附件和原时间保持正确。
+- Network/后端 mock 证明每次用户操作只有一次 `/inject` 或 `/chat` 写请求；历史刷新不会产生新的模型输入。
+
+### 数据验收
+
+- 每次成功注入对应一条 `log_entries.event_type="user_message"`。
+- WebSocket `id` 与历史 API 返回的该行 `id` 一致。
+- 相同文本连续发送两次会生成两个不同 ID，并显示两次。
+- Shared/Worker 场景中的 ID 属于当前展示该 Task 的本地数据库。
+
+### 回归验收
+
+- ChatView、messageMerge、chat API、注入、Worker/Shared relay 和 Dispatcher 定向测试全部通过。
+- 前端 build/typecheck 通过。
+- 不改变 Claude/Codex 收到的实际消息文本、附件输入和发送次数。
+- 不引入数据库迁移或历史数据清理脚本。
+
+## 9. 风险与控制
+
+| 风险 | 控制措施 |
+|------|----------|
+| 将远端 ID 当成本地 ID | relay 落库后强制用本地 `LogEntry.id` 覆盖 payload |
+| 相同文本被错误折叠 | 持久化消息只按 ID 去重；fingerprint 仅用于无 ID 兼容 |
+| optimistic 气泡残留 | 对账搜索未持久化候选，不只检查最后一条 |
+| 分页重复 | older-page 合并统一按 ID upsert |
+| 时间显示偏移 | 广播与历史统一 UTC ISO-8601 格式 |
+| 广播早于提交形成幽灵消息 | 明确保持 commit-before-broadcast |
+| 修复扩大到其他消息系统 | 限定 Task Chat；Discussion 单独评估 |
+
+## 10. 发布与回滚
+
+发布顺序建议：
+
+1. 后端先部署，使新 WebSocket 事件开始携带权威 ID。
+2. 再部署前端 ID-based upsert；前端仍兼容短时间内的无 ID 事件。
+3. 用一个长 Codex turn 和一个 Claude PTY turn 做生产烟测。
+4. 观察是否仍出现底部旧消息、重复分页或异常消息缺失。
+
+回滚不涉及数据库：
+
+- 前后端代码可独立回滚。
+- 已写入的 `LogEntry` 无需清理。
+- 新增 WebSocket 字段对旧前端应为向后兼容字段。
+
+## 11. 完成定义
+
+- 根因测试在旧实现上稳定失败、在新实现上通过。
+- 所有 Task `user_message` 本地持久化广播入口均完成审计。
+- 长 turn、重连、刷新、分页和相同文本边界均通过验收。
+- 代码评审确认不存在二次 transport/enqueue。
+- 生产烟测完成且无重复/移位消息。


### PR DESCRIPTION
## Summary

- 为所有已落库的 Task Chat 广播补充本地 `LogEntry.id`、`task_id` 和统一 UTC `timestamp`，Shared/Worker relay 会用本地副本身份覆盖远端 ID
- 前端按持久化 ID upsert WebSocket 与 HTTP 历史，修复 optimistic 气泡对账、turn 完成刷新后旧注入消息移到底部以及 older-page 重复
- 分页游标改为 HTTP 页面的持久化边界，避免被内存中保留的更早实时消息干扰
- 增加 local/inject/Monitor/Shared/Worker 及长历史分页回归测试，并附修复计划书

## Root cause

注入消息落库后广播未携带权威日志 ID。前端只能生成临时 ID；当长 turn 超过最近 200 条历史时，刷新会保留这条“未持久化”实时消息并追加到底部，随后加载旧页又会插入真实数据库行，形成移位或重复气泡。

本修复不改变 Claude/Codex transport 调用、prompt 或调度语义，也不需要数据库迁移。

## Verification

- `npm exec vitest -- run src/components/Chat/ChatView.test.tsx src/components/Chat/messageMerge.test.ts` — 85 passed（隔离提交工作树）
- `npm run build` — passed（隔离提交工作树）
- 后端 local/inject/Monitor/Shared/Worker 定向 pytest — 9 passed
- `git diff HEAD^ HEAD --check` — passed

## Live API smoke test

真实 Codex 长 turn 顺序执行 105 次工具调用，并在运行中连续注入 3 条消息：

- 最终持久化 219 行，最新页返回 ID 20–219，older page（`before_id=20`）返回 ID 1–19
- 合并结果为 219 行 / 219 个唯一 ID，重复 ID 为空
- 三条注入 user message 的持久化 ID 分别为 5、16、20，每条恰好出现一次且位置保持不变
- Task 正常完成，最终模型回复确认收到全部三条注入消息