### PR TITLE
fix: make task artifact paths downloadable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ claude-manager/
 
 - **优先级**: 数字越小优先级越高 (P0 > P1 > P2)，排序用 `.asc()`
 - **Session 绑定**: `session_id` 和 `last_cwd` 在 **Task** 上（不是 Instance），因为 instance 是轮换执行不同 task 的 worker
-- **Task 产物下载**: 聊天 Markdown 的文件链接统一走 `/api/tasks/{id}/artifacts/download`；相对路径按 `last_cwd`、容器 `/workspace` 按项目根映射，且受 Task ACL 保护。本地工作区根必须是无符号链接的绝对路径，并从稳定的 `/` 目录 FD 逐级 `O_NOFOLLOW` 锚定；产物路径只做基于该锚点的词法相对化，再逐级 no-follow 打开，以 `fstat` 校验同一文件描述符并按校验时大小限量流式返回，禁止混用路径解析与目录 FD 或“先查路径、后重开路径”的 TOCTOU。Worker 文件只经 Manager 流式代理，绝不能退回管理员级任意绝对路径下载接口
+- **Task 产物下载**: Claude/Codex 的任务前导统一要求产物使用 Markdown 文件链接；聊天渲染还会把普通文本中带扩展名的绝对 POSIX 文件路径兜底转为链接（既有链接、代码和 HTML 不改写）。文件链接统一走 `/api/tasks/{id}/artifacts/download`；相对路径按 `last_cwd`、容器 `/workspace` 按项目根映射，且受 Task ACL 保护。本地工作区根必须是无符号链接的绝对路径，并从稳定的 `/` 目录 FD 逐级 `O_NOFOLLOW` 锚定；产物路径只做基于该锚点的词法相对化，再逐级 no-follow 打开，以 `fstat` 校验同一文件描述符并按校验时大小限量流式返回，禁止混用路径解析与目录 FD 或“先查路径、后重开路径”的 TOCTOU。Worker 文件只经 Manager 流式代理，绝不能退回管理员级任意绝对路径下载接口
 - **Instance 并发容量**: `max_concurrent_instances` 约束所有仍有运行证据的实例：正常 `idle/running` 会占槽，`error/stopped` 仅在 PID 与反向 owner 证据都已清除后才是免费历史。API 创建与 Dispatcher 补槽共用 `instance_capacity_lock`，idle 选择到 launch 之间用 owner reservation；运行时下调 cap 不强杀现有 turn，但在占用降到 cap 以下前禁止新领取。物理删除仍走 `DELETE /api/instances/cleanup`
 - **Claude Code 调用**: `claude -p [prompt] --dangerously-skip-permissions --output-format stream-json --verbose`
 - **Resume**: `claude -p [follow-up] --resume [session_id]` — 必须使用和原始 session 相同的 cwd

--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -138,6 +138,12 @@ _DOC_SYNC_NOTE = (
     "若两者是 symlink 关系则改一处即可，无需额外操作）。"
 )
 
+_TASK_ARTIFACT_LINK_NOTE = (
+    "如果在任务工作区创建或修改了供用户查看、下载的产物文件，最终回复必须把每个产物写成 "
+    "Markdown 链接，不要只输出裸文件路径。链接目标优先使用相对当前工作目录的路径；"
+    "路径包含空格时用尖括号包裹，例如 `[下载报告](<reports/final report.pdf>)`。"
+)
+
 
 def _agent_doc_preamble(provider: str | None) -> str:
     """First-line prompt preamble pointing the agent at the project doc.
@@ -148,9 +154,9 @@ def _agent_doc_preamble(provider: str | None) -> str:
     Claude still needs the explicit CLAUDE.md workflow reminder.
     """
     if (provider or "claude").lower() == "codex":
-        return _DOC_SYNC_NOTE
+        return f"{_DOC_SYNC_NOTE}\n{_TASK_ARTIFACT_LINK_NOTE}"
     read_line = "请阅读项目根目录的 CLAUDE.md 了解项目规范和任务完成后的 git 流程。"
-    return f"{read_line}\n{_DOC_SYNC_NOTE}"
+    return f"{read_line}\n{_DOC_SYNC_NOTE}\n{_TASK_ARTIFACT_LINK_NOTE}"
 
 
 # Priority levels for the per-task message queue

--- a/backend/tests/test_service_dispatcher.py
+++ b/backend/tests/test_service_dispatcher.py
@@ -8072,6 +8072,19 @@ async def test_build_task_prompt_carries_doc_sync_note(db_factory):
 
 
 @pytest.mark.asyncio
+async def test_build_task_prompt_requires_downloadable_artifact_links(db_factory):
+    """Claude/Codex 都不能只报告无法点击的裸产物路径。"""
+    d = _make_dispatcher(db_factory)
+    for provider in ("claude", "codex"):
+        prompt = await d._build_task_prompt(
+            Task(title="t", description="create report", provider=provider)
+        )
+        assert "Markdown 链接" in prompt
+        assert "不要只输出裸文件路径" in prompt
+        assert "[下载报告](<reports/final report.pdf>)" in prompt
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("provider", "ordinary_preamble"),
     [

--- a/frontend/src/components/Chat/ChatView.test.tsx
+++ b/frontend/src/components/Chat/ChatView.test.tsx
@@ -2398,6 +2398,66 @@ describe('聊天图片附件展示（2026-07-16 用户反馈：发图后图片�
     clickSpy.mockRestore();
     vi.unstubAllGlobals();
   });
+
+  it.each(['claude', 'codex'] as const)(
+    '%s 助手返回裸绝对文件路径时自动显示任务下载链接',
+    async (provider) => {
+      const artifactPath = '/home/ubuntu/Projects/调研coding agent/test-download.txt';
+      vi.mocked(api.getTaskChatHistory).mockResolvedValue([
+        {
+          id: 502,
+          role: 'assistant',
+          event_type: 'message',
+          content: `测试下载文件已生成：${artifactPath}\n\n文件约 1 KB。`,
+          tool_name: null,
+          tool_input: null,
+          tool_output: null,
+          is_error: false,
+          loop_iteration: null,
+          timestamp: null,
+          image_urls: null,
+          attachments: null,
+        },
+      ]);
+
+      render(
+        <ChatView
+          task={makeTask({ id: 89, provider })}
+          projects={projects}
+          onBack={onBack}
+        />,
+      );
+
+      const link = await screen.findByRole('link', { name: /test-download\.txt/ });
+      expect(decodeURI(link.getAttribute('href') || '')).toBe(artifactPath);
+      expect(link).toHaveAttribute('title', '下载任务文件');
+    },
+  );
+
+  it('不把代码中的绝对文件路径兜底改写为下载链接', async () => {
+    vi.mocked(api.getTaskChatHistory).mockResolvedValue([
+      {
+        id: 503,
+        role: 'assistant',
+        event_type: 'message',
+        content: '示例：`/home/ubuntu/report.txt`\n\n```text\n/home/ubuntu/output.txt\n```',
+        tool_name: null,
+        tool_input: null,
+        tool_output: null,
+        is_error: false,
+        loop_iteration: null,
+        timestamp: null,
+        image_urls: null,
+        attachments: null,
+      },
+    ]);
+
+    render(<ChatView task={makeTask({ id: 90 })} projects={projects} onBack={onBack} />);
+
+    expect(await screen.findByText('/home/ubuntu/report.txt')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'report.txt' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'output.txt' })).not.toBeInTheDocument();
+  });
 });
 
 describe('Codex app-server 增量消息', () => {

--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -27,6 +27,7 @@ import {
   mergeChatHistory,
 } from './messageMerge';
 import { TaskArtifactLink } from './TaskArtifactLink';
+import { remarkTaskArtifactPaths } from './taskArtifactMarkdown';
 
 interface ChatViewProps {
   task: Task;
@@ -2719,6 +2720,7 @@ function stripSenderPrefix(text: string): string {
 }
 
 const remarkPlugins = [remarkGfm];
+const taskRemarkPlugins = [remarkGfm, remarkTaskArtifactPaths];
 
 const markdownComponents: Components = {
   pre({ children }) {
@@ -2773,7 +2775,7 @@ const MarkdownContent = memo(function MarkdownContent({
   return (
     <div className={`markdown-body ${className || ''}`}>
     <ReactMarkdown
-      remarkPlugins={remarkPlugins}
+      remarkPlugins={taskRemarkPlugins}
       components={taskComponents}
     >
       {content}

--- a/frontend/src/components/Chat/LoopChatView.test.tsx
+++ b/frontend/src/components/Chat/LoopChatView.test.tsx
@@ -176,6 +176,22 @@ describe('LoopChatView', () => {
       clickSpy.mockRestore();
       vi.unstubAllGlobals();
     });
+
+    it('renders a bare absolute artifact path as a task download link', async () => {
+      const artifactPath = '/home/ubuntu/loop output/final-report.md';
+      vi.mocked(api.getTaskChatHistory).mockResolvedValue([
+        makeMsg({
+          id: 905,
+          content: `产物已生成：${artifactPath}`,
+        }),
+      ]);
+
+      render(<LoopChatView task={makeTask({ id: 42 })} onBack={onBack} />);
+
+      const link = await screen.findByRole('link', { name: /final-report\.md/ });
+      expect(decodeURI(link.getAttribute('href') || '')).toBe(artifactPath);
+      expect(link).toHaveAttribute('title', '下载任务文件');
+    });
   });
 
   describe('WebSocket message uses loop_iteration from backend', () => {

--- a/frontend/src/components/Chat/LoopChatView.tsx
+++ b/frontend/src/components/Chat/LoopChatView.tsx
@@ -10,6 +10,7 @@ import {
   mergeChatHistory,
 } from './messageMerge';
 import { TaskArtifactLink } from './TaskArtifactLink';
+import { remarkTaskArtifactPaths } from './taskArtifactMarkdown';
 
 interface LoopChatViewProps {
   task: Task;
@@ -232,7 +233,7 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-const remarkPlugins = [remarkGfm];
+const remarkPlugins = [remarkGfm, remarkTaskArtifactPaths];
 
 const markdownComponents: Components = {
   pre({ children }) {

--- a/frontend/src/components/Chat/taskArtifactMarkdown.ts
+++ b/frontend/src/components/Chat/taskArtifactMarkdown.ts
@@ -1,0 +1,120 @@
+interface MarkdownNode {
+  type: string;
+  value?: string;
+  url?: string;
+  children?: MarkdownNode[];
+}
+
+
+const SKIP_DESCENDANTS = new Set([
+  'code',
+  'inlineCode',
+  'link',
+  'linkReference',
+  'html',
+]);
+
+// Only infer absolute POSIX paths that end in a conventional file extension.
+// Requiring an extension keeps ordinary slash-separated prose and directories
+// as text. Spaces inside the path are supported; trailing prose is excluded by
+// stopping at the first extension followed by whitespace or punctuation.
+const ABSOLUTE_FILE_PATH_RE =
+  /(^|[\s:：([（])((?:\/(?!\/)[^\r\n<>{}\]`]*?)\.[A-Za-z0-9](?:[A-Za-z0-9+_-]{0,14}[A-Za-z0-9])?)(?=$|[\s。，、；;！!？?,)\]）}])/gu;
+
+
+function isMarkdownNode(value: unknown): value is MarkdownNode {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && typeof (value as { type?: unknown }).type === 'string',
+  );
+}
+
+
+function isTaskFilePath(path: string): boolean {
+  if (
+    !path.startsWith('/')
+    || path.startsWith('//')
+    || path.startsWith('/api/')
+    || path.startsWith('/ws')
+    || path.includes('\0')
+  ) {
+    return false;
+  }
+  const components = path.slice(1).split('/');
+  if (
+    components.length < 2
+    || components.some((component) => (
+      !component
+      || component !== component.trim()
+      || component.includes('\t')
+    ))
+  ) {
+    return false;
+  }
+  return /\.[A-Za-z0-9](?:[A-Za-z0-9+_-]{0,14}[A-Za-z0-9])?$/.test(
+    components[components.length - 1],
+  );
+}
+
+
+function splitBareArtifactPaths(value: string): MarkdownNode[] | null {
+  const nodes: MarkdownNode[] = [];
+  let cursor = 0;
+  let found = false;
+  ABSOLUTE_FILE_PATH_RE.lastIndex = 0;
+
+  for (const match of value.matchAll(ABSOLUTE_FILE_PATH_RE)) {
+    const boundary = match[1] || '';
+    const path = match[2];
+    if (!path || !isTaskFilePath(path) || match.index === undefined) continue;
+
+    const pathStart = match.index + boundary.length;
+    if (pathStart > cursor) {
+      nodes.push({ type: 'text', value: value.slice(cursor, pathStart) });
+    }
+    nodes.push({
+      type: 'link',
+      url: path,
+      // Preserve the assistant's visible text exactly; this fallback only
+      // adds link semantics and the download affordance.
+      children: [{ type: 'text', value: path }],
+    });
+    cursor = pathStart + path.length;
+    found = true;
+  }
+
+  if (!found) return null;
+  if (cursor < value.length) {
+    nodes.push({ type: 'text', value: value.slice(cursor) });
+  }
+  return nodes;
+}
+
+
+function transformTextNodes(parent: MarkdownNode): void {
+  if (!parent.children || SKIP_DESCENDANTS.has(parent.type)) return;
+
+  const transformed: MarkdownNode[] = [];
+  for (const child of parent.children) {
+    if (child.type === 'text' && typeof child.value === 'string') {
+      transformed.push(...(splitBareArtifactPaths(child.value) || [child]));
+      continue;
+    }
+    transformTextNodes(child);
+    transformed.push(child);
+  }
+  parent.children = transformed;
+}
+
+
+/**
+ * Turn bare absolute file paths in task chat prose into Markdown links.
+ * Existing links, inline code, code blocks, and HTML are deliberately left
+ * untouched. The task-scoped backend endpoint remains the security boundary.
+ */
+export function remarkTaskArtifactPaths() {
+  return (tree: unknown): void => {
+    if (isMarkdownNode(tree)) transformTextNodes(tree);
+  };
+}


### PR DESCRIPTION
## Summary

- tell both Claude and Codex task prompts to present generated artifacts as Markdown links
- turn bare absolute POSIX file paths in assistant prose into task-scoped download links
- preserve existing links, code, HTML, and backend task artifact security boundaries
- cover standard and loop chat views, including Chinese paths and spaces

## Tests

- `vitest run src/components/Chat/ChatView.test.tsx src/components/Chat/LoopChatView.test.tsx` (108 passed)
- `pytest -q backend/tests/test_service_dispatcher.py -k "build_task_prompt_provider_doc or build_task_prompt_carries_doc_sync_note or build_task_prompt_requires_downloadable_artifact_links"` (3 passed)
- `pytest -q backend/tests/test_api_task_artifacts.py` (15 passed)
- `eslint src/components/Chat/taskArtifactMarkdown.ts src/components/Chat/LoopChatView.tsx src/components/Chat/LoopChatView.test.tsx`
- `npm run build`