### PR TITLE
fix(chat): keep mobile composer above software keyboard

### DIFF
--- a/docs/plans/2026-08-03-ios-inapp-keyboard-design.md
+++ b/docs/plans/2026-08-03-ios-inapp-keyboard-design.md
@@ -1,0 +1,46 @@
+# iOS In-App Keyboard Viewport Design
+
+## Problem
+
+The full-screen task chat uses a fixed overlay and also locks `body` with
+`position: fixed`. In iOS Feishu's WKWebView, opening the software keyboard
+shrinks the visual viewport without reliably changing the layout viewport.
+The chat therefore keeps its pre-keyboard height and its composer can remain
+behind the keyboard. The fact that one task sometimes works is incidental
+WebKit focus scrolling; all affected tasks use the same `ChatView`.
+
+## Chosen approach
+
+Keep the existing body scroll lock, but make the non-inline chat root follow
+`window.visualViewport`. A small reusable hook writes the current visual
+viewport height and top offset directly to the root element, listens for
+`resize` and `scroll`, and restores the original CSS fallback on cleanup. The
+message list is already a shrinking flex child, so reducing the root height
+naturally places the composer immediately above the keyboard without moving
+or reparenting the composer itself.
+
+The hook is enabled only for the full-screen chat. Desktop split view keeps
+its parent-controlled `h-full` layout. Browsers without `visualViewport`
+retain the current `fixed inset-0` behavior.
+
+## Alternatives rejected
+
+- Calling `scrollIntoView()` when the textarea receives focus is unreliable
+  when the document body is fixed and can move conversation content rather
+  than resize the usable chat area.
+- Removing the body scroll lock would let WebKit scroll the task list behind
+  the full-screen chat and reintroduce the issue that the lock was added to
+  solve.
+- Relying only on `100dvh` is not sufficient for iOS in-app webviews because
+  software-keyboard resizing support varies by WebKit version and embedding
+  configuration.
+
+## Verification
+
+Unit tests will simulate visual viewport resize and scroll events, verify the
+root receives the new height/top bounds, verify inline mode is untouched, and
+verify the fallback when the API is absent. The existing ChatView suite,
+TypeScript check, and production build must remain green. Final manual
+acceptance is opening a task in Feishu on iPhone, focusing the composer, and
+confirming the composer stays directly above the keyboard through typing,
+keyboard dismissal, and orientation changes.

--- a/docs/plans/2026-08-03-ios-inapp-keyboard.md
+++ b/docs/plans/2026-08-03-ios-inapp-keyboard.md
@@ -1,0 +1,93 @@
+# iOS In-App Keyboard Viewport Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Keep the full-screen task chat composer visible above the software keyboard in Feishu's iPhone WKWebView.
+
+**Architecture:** Add a focused React hook that synchronizes a fixed chat root with `window.visualViewport`, then connect it to the non-inline `ChatView`. Preserve the existing body scroll lock and CSS fallback.
+
+**Tech Stack:** React 19, TypeScript, Vitest, Testing Library, Tailwind CSS
+
+---
+
+### Task 1: Specify visual viewport synchronization
+
+**Files:**
+- Create: `frontend/src/hooks/useVisualViewportBounds.test.tsx`
+- Create: `frontend/src/hooks/useVisualViewportBounds.ts`
+
+**Step 1: Write the failing tests**
+
+Create a harness with a root ref and cover initial height/top synchronization,
+`resize`, `scroll`, cleanup, disabled mode, and a missing
+`window.visualViewport` fallback.
+
+**Step 2: Run the focused test and verify it fails**
+
+Run: `npx vitest run src/hooks/useVisualViewportBounds.test.tsx`
+
+Expected: FAIL because `useVisualViewportBounds` does not exist.
+
+**Step 3: Implement the minimal hook**
+
+Synchronize `height`, `top`, and `bottom` directly on the referenced element.
+Subscribe to visual viewport `resize`/`scroll` and window
+`orientationchange`; remove listeners and inline overrides on cleanup.
+
+**Step 4: Run the focused test and verify it passes**
+
+Run: `npx vitest run src/hooks/useVisualViewportBounds.test.tsx`
+
+Expected: PASS.
+
+### Task 2: Connect the full-screen task chat
+
+**Files:**
+- Modify: `frontend/src/components/Chat/ChatView.tsx`
+- Modify: `frontend/src/components/Chat/ChatView.test.tsx`
+
+**Step 1: Write the failing integration assertion**
+
+Render a non-inline ChatView with a mocked visual viewport and assert that its
+fixed root follows the visual viewport. Render inline mode and assert it does
+not receive viewport overrides.
+
+**Step 2: Run the ChatView tests and verify the new assertion fails**
+
+Run: `npx vitest run src/components/Chat/ChatView.test.tsx`
+
+Expected: the new viewport assertion fails.
+
+**Step 3: Attach the hook to ChatView**
+
+Add a root ref, enable synchronization only when `inline` is false, and keep
+the current fixed/full-height and body-lock fallbacks unchanged.
+
+**Step 4: Run the focused suites**
+
+Run: `npx vitest run src/hooks/useVisualViewportBounds.test.tsx src/components/Chat/ChatView.test.tsx`
+
+Expected: PASS.
+
+### Task 3: Verify and commit
+
+**Files:**
+- Verify all modified frontend files and documentation.
+
+**Step 1: Run TypeScript and production build**
+
+Run: `npx tsc -b && npm run build`
+
+Expected: PASS.
+
+**Step 2: Run the broader chat regression suite**
+
+Run: `npx vitest run src/components/Chat/ChatView.test.tsx src/components/Chat/SharedChatView.test.tsx src/components/Chat/LoopChatView.test.tsx`
+
+Expected: PASS.
+
+**Step 3: Inspect the diff and commit**
+
+Run: `git diff --check && git status --short`
+
+Commit message: `fix(chat): keep mobile composer above keyboard`

--- a/frontend/src/components/Chat/ChatView.test.tsx
+++ b/frontend/src/components/Chat/ChatView.test.tsx
@@ -175,6 +175,44 @@ describe('ChatView', () => {
     (api.sendTaskChat as ReturnType<typeof vi.fn>).mockResolvedValue({});
   });
 
+  it('fits full-screen chat to the iOS visual viewport but leaves inline chat alone', () => {
+    const originalViewport = Object.getOwnPropertyDescriptor(window, 'visualViewport');
+    const viewport = Object.assign(new EventTarget(), {
+      height: 486,
+      offsetTop: 47,
+    });
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: viewport,
+    });
+
+    try {
+      const fullScreen = render(
+        <ChatView task={makeTask()} projects={projects} onBack={onBack} />,
+      );
+      expect(fullScreen.container.firstElementChild).toHaveStyle({
+        height: '486px',
+        top: '47px',
+        bottom: 'auto',
+      });
+      fullScreen.unmount();
+
+      const inline = render(
+        <ChatView task={makeTask()} projects={projects} onBack={onBack} inline />,
+      );
+      expect((inline.container.firstElementChild as HTMLElement).style.height).toBe('');
+      expect((inline.container.firstElementChild as HTMLElement).style.top).toBe('');
+      expect((inline.container.firstElementChild as HTMLElement).style.bottom).toBe('');
+      inline.unmount();
+    } finally {
+      if (originalViewport) {
+        Object.defineProperty(window, 'visualViewport', originalViewport);
+      } else {
+        Reflect.deleteProperty(window, 'visualViewport');
+      }
+    }
+  });
+
   describe('chat conflict state', () => {
     it('does not show Interrupt for a non-busy 409 rejection', async () => {
       const rejection = Object.assign(

--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -13,6 +13,7 @@ import { FastModeBadge, TaskConfigBadge } from '../Tasks/TaskBadges';
 import { ExpandableText } from '../ExpandableText';
 import { formatMessageTime } from '../../config/timezone';
 import { useFileDrop } from '../../hooks/useFileDrop';
+import { useVisualViewportBounds } from '../../hooks/useVisualViewportBounds';
 import {
   dedupeUploadResults,
   isUploadResult,
@@ -265,11 +266,14 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
   const [titleDraft, setTitleDraft] = useState(task.title || '');
   const titleInputRef = useRef<HTMLInputElement>(null);
   const [titleExpanded, setTitleExpanded] = useState(false);
+  const chatRootRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [starred, setStarred] = useState(task.starred);
+
+  useVisualViewportBounds(chatRootRef, !inline);
 
   // Temp model override (one-shot per message, not persisted to the task)
   const [modelOverride, setModelOverride] = useState<string | null>(null);
@@ -1595,7 +1599,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
   };
 
   return (
-    <div className={inline ? "flex flex-col h-full bg-gray-950" : "fixed inset-0 bg-gray-950 flex flex-col z-50"}>
+    <div ref={chatRootRef} className={inline ? "flex flex-col h-full bg-gray-950" : "fixed inset-0 bg-gray-950 flex flex-col z-50"}>
       {/* Header — two rows */}
       <div className="px-3 sm:px-4 py-1.5 pt-[max(0.375rem,env(safe-area-inset-top))] border-b border-gray-800 bg-gray-900">
         {/* Row 1: back + task info + action buttons */}

--- a/frontend/src/hooks/useVisualViewportBounds.test.tsx
+++ b/frontend/src/hooks/useVisualViewportBounds.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { useRef } from 'react';
+import { useVisualViewportBounds } from './useVisualViewportBounds';
+
+class MockVisualViewport extends EventTarget {
+  height = 844;
+  offsetTop = 0;
+}
+
+function Harness({ enabled = true }: { enabled?: boolean }) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  useVisualViewportBounds(rootRef, enabled);
+  return <div ref={rootRef} data-testid="viewport-root" />;
+}
+
+const originalVisualViewport = Object.getOwnPropertyDescriptor(
+  window,
+  'visualViewport',
+);
+
+function installVisualViewport(viewport: MockVisualViewport | undefined) {
+  Object.defineProperty(window, 'visualViewport', {
+    configurable: true,
+    value: viewport,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalVisualViewport) {
+    Object.defineProperty(window, 'visualViewport', originalVisualViewport);
+  } else {
+    Reflect.deleteProperty(window, 'visualViewport');
+  }
+});
+
+describe('useVisualViewportBounds', () => {
+  it('keeps the root inside the visual viewport as the keyboard opens and scrolls', () => {
+    const viewport = new MockVisualViewport();
+    installVisualViewport(viewport);
+
+    render(<Harness />);
+    const root = screen.getByTestId('viewport-root');
+
+    expect(root).toHaveStyle({ height: '844px', top: '0px', bottom: 'auto' });
+
+    act(() => {
+      viewport.height = 486;
+      viewport.dispatchEvent(new Event('resize'));
+    });
+    expect(root).toHaveStyle({ height: '486px', top: '0px', bottom: 'auto' });
+
+    act(() => {
+      viewport.offsetTop = 47;
+      viewport.dispatchEvent(new Event('scroll'));
+    });
+    expect(root).toHaveStyle({ height: '486px', top: '47px', bottom: 'auto' });
+  });
+
+  it('resynchronizes after an orientation change and removes overrides on cleanup', () => {
+    const viewport = new MockVisualViewport();
+    installVisualViewport(viewport);
+    const removeViewportListener = vi.spyOn(viewport, 'removeEventListener');
+    const removeWindowListener = vi.spyOn(window, 'removeEventListener');
+
+    const { unmount } = render(<Harness />);
+    const root = screen.getByTestId('viewport-root');
+
+    act(() => {
+      viewport.height = 390;
+      viewport.offsetTop = 12;
+      window.dispatchEvent(new Event('orientationchange'));
+    });
+    expect(root).toHaveStyle({ height: '390px', top: '12px' });
+
+    unmount();
+
+    expect(root.style.height).toBe('');
+    expect(root.style.top).toBe('');
+    expect(root.style.bottom).toBe('');
+    expect(removeViewportListener).toHaveBeenCalledWith('resize', expect.any(Function));
+    expect(removeViewportListener).toHaveBeenCalledWith('scroll', expect.any(Function));
+    expect(removeWindowListener).toHaveBeenCalledWith(
+      'orientationchange',
+      expect.any(Function),
+    );
+  });
+
+  it('leaves layout untouched when disabled', () => {
+    installVisualViewport(new MockVisualViewport());
+
+    render(<Harness enabled={false} />);
+
+    expect(screen.getByTestId('viewport-root').getAttribute('style')).toBeNull();
+  });
+
+  it('keeps the CSS fallback when visualViewport is unavailable', () => {
+    installVisualViewport(undefined);
+
+    render(<Harness />);
+
+    expect(screen.getByTestId('viewport-root').getAttribute('style')).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useVisualViewportBounds.ts
+++ b/frontend/src/hooks/useVisualViewportBounds.ts
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+import type { RefObject } from 'react';
+
+/**
+ * Keep a fixed overlay inside the part of the page that is actually visible.
+ *
+ * iOS in-app browsers keep the layout viewport at its pre-keyboard height while
+ * shrinking `visualViewport`, so a bottom composer can otherwise sit behind the
+ * software keyboard. Direct style writes avoid rerendering the full chat during
+ * WebKit's keyboard animation.
+ */
+export function useVisualViewportBounds(
+  rootRef: RefObject<HTMLElement | null>,
+  enabled: boolean,
+) {
+  useEffect(() => {
+    const root = rootRef.current;
+    const viewport = window.visualViewport;
+    if (!enabled || !root || !viewport) return;
+
+    const syncBounds = () => {
+      const height = Number.isFinite(viewport.height)
+        ? Math.max(0, viewport.height)
+        : 0;
+      const offsetTop = Number.isFinite(viewport.offsetTop)
+        ? Math.max(0, viewport.offsetTop)
+        : 0;
+
+      if (height > 0) root.style.height = `${height}px`;
+      root.style.top = `${offsetTop}px`;
+      root.style.bottom = 'auto';
+    };
+
+    syncBounds();
+    viewport.addEventListener('resize', syncBounds);
+    viewport.addEventListener('scroll', syncBounds);
+    window.addEventListener('orientationchange', syncBounds);
+
+    return () => {
+      viewport.removeEventListener('resize', syncBounds);
+      viewport.removeEventListener('scroll', syncBounds);
+      window.removeEventListener('orientationchange', syncBounds);
+      root.style.height = '';
+      root.style.top = '';
+      root.style.bottom = '';
+    };
+  }, [enabled, rootRef]);
+}


### PR DESCRIPTION
## Summary

- synchronize the full-screen task chat with `window.visualViewport`
- keep the composer above the software keyboard in iOS in-app browsers such as Feishu WKWebView
- preserve the existing body scroll lock and leave desktop inline chat unchanged
- fall back to the current fixed layout when `visualViewport` is unavailable

## Root cause

The full-screen ChatView is fixed to the layout viewport while the iOS software keyboard only shrinks the visual viewport. Because the page body is also fixed to prevent scroll bleed, WebKit cannot reliably scroll the composer into view, leaving it behind the keyboard.

## Testing

- 120 focused chat and viewport tests pass
- `npm run build` passes (TypeScript + production Vite build)
- regression coverage includes resize, visual viewport scroll, orientation change, cleanup, fallback, and desktop inline mode