### PR TITLE
Fix Codex tier proxy WebSocket fallback

### DIFF
--- a/backend/services/codex_tier_proxy.py
+++ b/backend/services/codex_tier_proxy.py
@@ -664,7 +664,20 @@ class CodexActualTierProxy:
     def codex_override_args(self) -> tuple[str, ...]:
         local = json.dumps(self.local_base_url)
         if self.route.built_in_openai:
-            overrides = [f"openai_base_url={local}"]
+            # ``openai_base_url`` keeps the built-in provider's WebSocket
+            # capability enabled.  Recent Codex versions treat a 426 from
+            # that transport as fatal instead of reliably falling back to
+            # HTTP, so describe the loopback proof proxy as a separate
+            # provider whose transport capability is explicit.
+            provider_id = "ccm_actual_tier"
+            overrides = [
+                f"model_provider={json.dumps(provider_id)}",
+                f"model_providers.{provider_id}.name={json.dumps('OpenAI via CCM tier proof')}",
+                f"model_providers.{provider_id}.base_url={local}",
+                f"model_providers.{provider_id}.wire_api={json.dumps('responses')}",
+                f"model_providers.{provider_id}.requires_openai_auth=true",
+                f"model_providers.{provider_id}.supports_websockets=false",
+            ]
         else:
             overrides = [
                 f"model_providers.{provider_id}.base_url={local}"

--- a/backend/tests/test_codex_tier_proxy.py
+++ b/backend/tests/test_codex_tier_proxy.py
@@ -844,3 +844,27 @@ def test_override_args_are_non_persistent_and_disable_compression():
         ),
     )
     assert args[2:] == ("--disable", "enable_request_compression")
+
+
+def test_native_override_uses_http_only_authenticated_provider():
+    proxy = CodexActualTierProxy(
+        CodexTierProxyRoute(
+            "https://chatgpt.com/backend-api/codex",
+            provider_id="openai",
+            built_in_openai=True,
+        ),
+    )
+    proxy._server = object()  # type: ignore[assignment]
+    proxy._port = 4321
+
+    args = proxy.codex_override_args()
+
+    assert "model_provider=\"ccm_actual_tier\"" in args
+    assert (
+        "model_providers.ccm_actual_tier.base_url="
+        + json.dumps(proxy.local_base_url)
+    ) in args
+    assert "model_providers.ccm_actual_tier.wire_api=\"responses\"" in args
+    assert "model_providers.ccm_actual_tier.requires_openai_auth=true" in args
+    assert "model_providers.ccm_actual_tier.supports_websockets=false" in args
+    assert args[-2:] == ("--disable", "enable_request_compression")


### PR DESCRIPTION
## What changed

- Route native OpenAI traffic through a CCM-owned authenticated provider definition.
- Explicitly advertise `supports_websockets = false` so Codex uses HTTP Responses transport.
- Add regression coverage for the generated non-persistent provider overrides.

## Root cause and impact

The actual-tier loopback proxy returned HTTP 426 to WebSocket upgrade attempts and assumed Codex would fall back to HTTP SSE. Codex 0.144.6 repeatedly retried the WebSocket and then exited, causing production tasks such as task 300 to fail even though the app-server wrapper reported exit code 0. The explicit provider capability prevents the unsupported WebSocket attempt while retaining OpenAI authentication and tier-proof inspection.

## Validation

- `uv run pytest -q backend/tests/test_codex_tier_proxy.py` (29 passed)
- `git diff --cached --check`
- Codex 0.144.6 accepts the generated provider configuration.