### PR TITLE
Preserve Codex timeout terminal state

### DIFF
--- a/backend/services/codex_app_server.py
+++ b/backend/services/codex_app_server.py
@@ -525,7 +525,11 @@ class CodexTurnProcess:
         if self.returncode is not None:
             return
         self.returncode = returncode
-        self.termination_kind = termination_kind
+        # Dispatcher timeout is stamped before interrupting the native turn.
+        # Do not let the subsequent app-server ``interrupted`` notification
+        # relabel that forced abort as a successful user interrupt.
+        if self.termination_kind != "timeout":
+            self.termination_kind = termination_kind
         if stderr:
             self.stderr.feed_data(stderr.encode("utf-8", errors="replace"))
         self.stdout.feed_eof()

--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -2307,6 +2307,14 @@ class GlobalDispatcher:
                     task.id,
                     timeout,
                 )
+                # A provider may report the forced interrupt as the same
+                # SIGINT/130 terminal used for a user-requested stop.  Stamp
+                # the process before signalling it so the output consumer
+                # cannot publish a timed-out, partial reply as completed.
+                try:
+                    process.termination_kind = "timeout"
+                except (AttributeError, TypeError):
+                    pass
                 killed = await self.instance_manager.kill_process_generation(
                     instance_id,
                     process,

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -10506,7 +10506,7 @@ class InstanceManager:
             return False
         return (
             getattr(process, "termination_kind", None)
-            != "internal_abort"
+            not in {"internal_abort", "timeout"}
         )
 
     def get_config_dir(self, instance_id: int) -> str | None:

--- a/backend/tests/test_codex_app_server.py
+++ b/backend/tests/test_codex_app_server.py
@@ -5147,6 +5147,19 @@ async def test_turn_process_interrupt_is_nonblocking_and_completes():
 
 
 @pytest.mark.asyncio
+async def test_turn_process_timeout_cannot_be_relabelled_user_interrupt():
+    async def interrupt():
+        return None
+
+    process = CodexTurnProcess(1, interrupt)
+    process.termination_kind = "timeout"
+    process.finish(130, termination_kind="user_interrupt")
+
+    assert await process.wait() == 130
+    assert process.termination_kind == "timeout"
+
+
+@pytest.mark.asyncio
 async def test_turn_process_failed_interrupt_preserves_active_evidence():
     interrupt_attempted = asyncio.Event()
 

--- a/backend/tests/test_service_dispatcher.py
+++ b/backend/tests/test_service_dispatcher.py
@@ -3875,6 +3875,7 @@ class TestResolveTimeout:
         )
         await d._wait_process(p, t, "test", instance_id=1)
         assert p.killed is True
+        assert p.termination_kind == "timeout"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_service_instance_manager.py
+++ b/backend/tests/test_service_instance_manager.py
@@ -7600,6 +7600,8 @@ def test_internal_codex_abort_is_not_a_successful_chat_terminal():
     assert not InstanceManager._chat_terminal_succeeded(process, 130)
     process.termination_kind = "user_interrupt"
     assert InstanceManager._chat_terminal_succeeded(process, 130)
+    process.termination_kind = "timeout"
+    assert not InstanceManager._chat_terminal_succeeded(process, 130)
     assert InstanceManager._chat_terminal_succeeded(process, 0)
 
 


### PR DESCRIPTION
## What changed

- Stamp forced dispatcher timeouts before interrupting a Codex turn.
- Prevent the app-server interrupted event from relabeling a timeout as a user interruption.
- Treat timeout terminals as unsuccessful chat completion.
- Add regression coverage across dispatcher, app-server, and instance-manager behavior.

## Impact

Timed-out partial Codex responses can no longer be published as successful user-interrupted completions.

## Validation

- `uv run pytest -q backend/tests/test_codex_app_server.py backend/tests/test_service_dispatcher.py backend/tests/test_service_instance_manager.py`
- 689 passed.