### PR TITLE
fix: support unlimited Apex quota windows

### DIFF
--- a/backend/services/cloudrouter_accounts.py
+++ b/backend/services/cloudrouter_accounts.py
@@ -1143,16 +1143,47 @@ def _normalise_apex_usage(
     exhausted = False
     for window_id, label, unit in definitions:
         key_used = _decimal(raw_used.get(window_id))
-        remaining = _decimal(raw_remaining.get(window_id))
-        limit = _decimal(raw_limits.get(window_id))
+        has_remaining = window_id in raw_remaining
+        has_limit = window_id in raw_limits
+        raw_window_remaining = raw_remaining.get(window_id)
+        raw_window_limit = raw_limits.get(window_id)
+        unlimited = (
+            has_remaining
+            and has_limit
+            and raw_window_remaining is None
+            and raw_window_limit is None
+        )
         # Availability is governed by the shared group, so a partial response
         # must never become a known-healthy snapshot based only on this Key's
-        # own usage. Apex documents all three values for every fixed window.
+        # own usage. Apex documents every fixed window, using explicit null
+        # limit/remaining pairs for windows without a quota.
         if (
             key_used is None
-            or remaining is None
-            or limit is None
             or key_used < 0
+            or not has_remaining
+            or not has_limit
+        ):
+            raise CloudRouterUpstreamError("invalid_usage_response")
+        if unlimited:
+            parsed_key_used = _json_number(key_used)
+            item = {
+                "id": window_id,
+                "label": label,
+                "currency": unit,
+                "scope": "group",
+                "unlimited": True,
+                "key_used": parsed_key_used,
+            }
+            windows.append(item)
+            if parsed_key_used is not None:
+                key_usage[window_id] = parsed_key_used
+            continue
+
+        remaining = _decimal(raw_window_remaining)
+        limit = _decimal(raw_window_limit)
+        if (
+            remaining is None
+            or limit is None
             or remaining < 0
             or limit < 0
             or remaining > limit

--- a/backend/tests/test_cloudrouter_accounts.py
+++ b/backend/tests/test_cloudrouter_accounts.py
@@ -336,6 +336,146 @@ async def test_apex_usage_separates_key_usage_from_shared_group_quota(
 
 
 @pytest.mark.asyncio
+async def test_apex_null_quota_windows_are_known_unlimited(
+    tmp_path, monkeypatch,
+):
+    store = CloudRouterAccountStore(tmp_path / "accounts")
+    monkeypatch.setattr(
+        store,
+        "probe_models",
+        AsyncMock(return_value={"claude": [], "codex": ["gpt-5.4"]}),
+    )
+    account = await store.add_account(
+        "Apex", "lck-test-secret", api_provider="apex",
+    )
+    monkeypatch.setattr(
+        store,
+        "_request_json",
+        AsyncMock(return_value={
+            "key_name": "unlimited-key",
+            "group_name": "unlimited-group",
+            "used": {
+                "requests_5h": 3,
+                "requests_day": 7,
+                "tokens_day": 1_000,
+                "tokens_month": 2_000,
+            },
+            "remaining": {
+                "requests_5h": None,
+                "requests_day": None,
+                "tokens_day": None,
+                "tokens_month": None,
+            },
+            "limits": {
+                "requests_5h": None,
+                "requests_day": None,
+                "tokens_day": None,
+                "tokens_month": None,
+                "concurrency": 20,
+            },
+        }),
+    )
+
+    snapshot = await store.fetch_usage(account.id, force=True)
+
+    assert snapshot["state"] == "active"
+    assert snapshot["known"] is True
+    assert snapshot["available"] is True
+    assert snapshot["concurrency"] == 20
+    assert snapshot["key_usage"] == {
+        "requests_5h": 3,
+        "requests_day": 7,
+        "tokens_day": 1_000,
+        "tokens_month": 2_000,
+    }
+    assert len(snapshot["windows"]) == 4
+    assert all(window["unlimited"] is True for window in snapshot["windows"])
+    assert all("limit" not in window for window in snapshot["windows"])
+    assert all("remaining" not in window for window in snapshot["windows"])
+    assert all("utilization" not in window for window in snapshot["windows"])
+    assert store.cached_quota_decision(account.id) == {
+        "available": True,
+        "known": True,
+        "reason": "active",
+    }
+
+
+def test_apex_usage_supports_mixed_limited_and_unlimited_windows():
+    snapshot = cloudrouter_module._normalise_apex_usage("apex-1", {
+        "used": {
+            "requests_5h": 3,
+            "requests_day": 7,
+            "tokens_day": 1_000,
+            "tokens_month": 2_000,
+        },
+        "remaining": {
+            "requests_5h": None,
+            "requests_day": 93,
+            "tokens_day": None,
+            "tokens_month": 8_000,
+        },
+        "limits": {
+            "requests_5h": None,
+            "requests_day": 100,
+            "tokens_day": None,
+            "tokens_month": 10_000,
+            "concurrency": 5,
+        },
+    })
+
+    windows = {window["id"]: window for window in snapshot["windows"]}
+    assert windows["requests_5h"]["unlimited"] is True
+    assert windows["requests_5h"]["key_used"] == 3
+    assert windows["tokens_day"]["unlimited"] is True
+    assert windows["requests_day"]["limit"] == 100
+    assert windows["requests_day"]["remaining"] == 93
+    assert windows["tokens_month"]["used"] == 2_000
+    assert snapshot["state"] == "active"
+    assert snapshot["available"] is True
+
+
+@pytest.mark.parametrize(
+    ("remaining", "limit"),
+    [
+        (None, 100),
+        (100, None),
+        ("invalid", 100),
+        (100, "invalid"),
+    ],
+)
+def test_apex_usage_rejects_asymmetric_or_invalid_window_values(
+    remaining, limit,
+):
+    payload = {
+        "used": {
+            "requests_5h": 3,
+            "requests_day": 7,
+            "tokens_day": 1_000,
+            "tokens_month": 2_000,
+        },
+        "remaining": {
+            "requests_5h": remaining,
+            "requests_day": 93,
+            "tokens_day": 9_000,
+            "tokens_month": 8_000,
+        },
+        "limits": {
+            "requests_5h": limit,
+            "requests_day": 100,
+            "tokens_day": 10_000,
+            "tokens_month": 10_000,
+            "concurrency": 5,
+        },
+    }
+
+    with pytest.raises(
+        CloudRouterUpstreamError,
+        match="invalid_usage_response",
+    ):
+        cloudrouter_module._normalise_apex_usage("apex-1", payload)
+
+
+@pytest.mark.asyncio
 async def test_partial_apex_group_usage_cannot_replace_known_exhaustion(
     tmp_path, monkeypatch,
 ):

--- a/backend/tests/test_codex_pool.py
+++ b/backend/tests/test_codex_pool.py
@@ -1023,6 +1023,16 @@ class TestQuotaAwareSelection:
             "secondary_used_percent": 40,
         })
 
+    def test_api_unlimited_window_does_not_trigger_threshold(self):
+        assert not codex_pool_module.api_quota_at_or_above({
+            "known": True,
+            "available": True,
+            "windows": [{
+                "unlimited": True,
+                "key_used": 1_000_000,
+            }],
+        })
+
     def test_cooldown_uses_later_reset_of_all_high_windows(self):
         now = 1_700_000_000
         assert quota_cooldown_seconds({

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -541,6 +541,8 @@ export interface CloudRouterQuotaWindow {
   resets_at?: string | number | null;
   currency?: string | null;
   scope?: string | null;
+  /** This quota window has no configured limit. */
+  unlimited?: boolean;
   /** Usage attributed to this individual API key for a shared window. */
   key_used?: number | null;
 }

--- a/frontend/src/components/Layout/PoolDrawer.test.tsx
+++ b/frontend/src/components/Layout/PoolDrawer.test.tsx
@@ -851,6 +851,7 @@ describe('PoolDrawer', () => {
       expect(card).toHaveTextContent('分组共享剩余 88 requests');
       expect(card).toHaveTextContent('分组并发上限 3');
       expect(card).toHaveTextContent('5h 请求（分组共享）');
+      expect(card).not.toHaveTextContent('总额度：无法确认');
       expect(card).toHaveTextContent('到期时间：无法确认');
       expect(card).toHaveTextContent('剩余天数：无法确认');
 
@@ -858,6 +859,65 @@ describe('PoolDrawer', () => {
       await waitFor(() => {
         expect(api.refreshCloudRouterAccount).toHaveBeenCalledWith('apex-1');
       });
+    });
+
+    it('renders Apex null quota windows as unlimited instead of unavailable', async () => {
+      enableCodexPool({
+        enabled: true,
+        total: 1,
+        available: 1,
+        cooldown: 0,
+        disabled: 0,
+        preferred: null,
+        accounts: [{
+          id: 'apex:apex-1:codex',
+          codex_home: '/tmp/apex-1/codex',
+          email: '',
+          enabled: true,
+          available: true,
+          cooldown_until: null,
+          cooldown_remaining: 0,
+          auth_kind: 'apex_api',
+          api_provider: 'apex',
+          display_name: 'Apex Unlimited',
+          api_account_id: 'apex-1',
+          supported_models: ['gpt-5.4'],
+          api_quota: {
+            state: 'active',
+            mode: 'shared_group',
+            known: true,
+            key_name: 'apex-unlimited-key',
+            group_name: 'apex-unlimited-group',
+            key_usage: { requests_5h: 3 },
+            concurrency: 3,
+            windows: [{
+              id: 'requests_5h',
+              label: '5h 请求（分组共享）',
+              scope: 'group',
+              unlimited: true,
+              key_used: 3,
+              currency: 'requests',
+            }],
+          },
+        }],
+      });
+      const user = userEvent.setup();
+
+      await renderAndWaitForPro();
+      await openDrawer(user);
+      await user.click(screen.getByRole('button', { name: 'Codex' }));
+
+      const card = (await screen.findByText('Apex Unlimited')).closest('.rounded-lg') as HTMLElement;
+      await user.click(within(card).getByRole('button', { name: '查看额度与有效期' }));
+
+      expect(card).toHaveTextContent('状态 active');
+      expect(card).toHaveTextContent('分组不限额');
+      expect(card).toHaveTextContent('本 Key 已用 3 requests');
+      expect(card).not.toHaveTextContent('总额度：无法确认');
+      expect(card).not.toHaveTextContent('分组共享上限');
+      expect(card).not.toHaveTextContent('分组共享剩余');
+      expect(card).not.toHaveTextContent('重置时间无法确认');
+      expect(card).toHaveTextContent('到期时间：无法确认');
     });
 
     it('renders unrestricted CloudRouter usage without presenting informational zeroes as the Key balance', async () => {

--- a/frontend/src/components/Layout/PoolDrawer.tsx
+++ b/frontend/src/components/Layout/PoolDrawer.tsx
@@ -266,6 +266,7 @@ function ApiQuotaPanel({ quota, onRefresh }: {
     && quota.days_until_expiry == null;
   const total = quota.quota;
   const hasSharedGroup = Boolean(quota.group_name);
+  const hasWindows = Boolean(quota.windows?.length);
   const totalUtilization = total?.used != null && total.limit != null && total.limit > 0
     ? Math.min(100, Math.max(0, (total.used / total.limit) * 100))
     : null;
@@ -354,9 +355,9 @@ function ApiQuotaPanel({ quota, onRefresh }: {
             <span className="text-gray-400">余额 <span className="font-medium text-foreground">{formatApiAmount(quota.balance, currency)}</span></span>
           )}
         </div>
-      ) : (
+      ) : !hasWindows ? (
         <div className="text-xs text-gray-500">总额度：无法确认</div>
-      )}
+      ) : null}
       <ApiUsageDetails quota={quota} currency={currency} />
       <div className="grid grid-cols-1 gap-1 text-[10px] text-gray-500">
         <span>到期时间：<span className="text-gray-300">
@@ -379,17 +380,22 @@ function ApiQuotaPanel({ quota, onRefresh }: {
         )}
       </div>
       {quota.windows?.map((window, index) => {
-        const utilization = window.utilization != null
-          ? window.utilization
-          : window.used != null && window.limit != null && window.limit > 0
-            ? (window.used / window.limit) * 100
-            : null;
+        const windowUnlimited = window.unlimited === true;
+        const utilization = windowUnlimited
+          ? null
+          : window.utilization != null
+            ? window.utilization
+            : window.used != null && window.limit != null && window.limit > 0
+              ? (window.used / window.limit) * 100
+              : null;
         const pct = utilization == null ? null : Math.min(100, Math.max(0, utilization));
         const resetAt = window.reset_at ?? window.resets_at ?? null;
         const windowId = window.id || `${window.label || 'window'}-${index}`;
         const isSharedWindow = window.scope === 'group' || hasSharedGroup;
         const keyUsed = window.key_used ?? quota.key_usage?.[window.id || ''];
         const windowLabel = window.label || window.id || `额度窗口 ${index + 1}`;
+        const hasFiniteAmounts = !windowUnlimited
+          && (window.used != null || window.limit != null || window.remaining != null);
         return (
           <div key={windowId} className="space-y-1">
             <div className="flex items-center justify-between gap-2 text-[10px]">
@@ -397,8 +403,10 @@ function ApiQuotaPanel({ quota, onRefresh }: {
                 {windowLabel}
                 {isSharedWindow && !windowLabel.includes('分组共享') ? '（分组共享）' : ''}
               </span>
-              <span className="text-gray-500">
-                {resetAt == null ? '重置时间无法确认' : formatApiTimestamp(resetAt)}
+              <span className={windowUnlimited ? 'font-medium text-emerald-300' : 'text-gray-500'}>
+                {windowUnlimited
+                  ? isSharedWindow ? '分组不限额' : '不限额'
+                  : resetAt == null ? '重置时间无法确认' : formatApiTimestamp(resetAt)}
               </span>
             </div>
             {pct != null && (
@@ -409,11 +417,11 @@ function ApiQuotaPanel({ quota, onRefresh }: {
                 <span className={`w-10 shrink-0 text-right text-xs font-medium ${textColor(pct)}`}>{pct.toFixed(0)}%</span>
               </div>
             )}
-            {(window.used != null || window.limit != null || window.remaining != null || keyUsed != null) && (
+            {(hasFiniteAmounts || keyUsed != null) && (
               <div className="flex flex-wrap gap-x-3 text-[10px] text-gray-500">
-                {window.used != null && <span>{isSharedWindow ? '分组共享已用' : '已用'} {formatApiAmount(window.used, window.currency || quota.currency)}</span>}
-                {window.limit != null && <span>{isSharedWindow ? '分组共享上限' : '上限'} {formatApiAmount(window.limit, window.currency || quota.currency)}</span>}
-                {window.remaining != null && <span>{isSharedWindow ? '分组共享剩余' : '剩余'} {formatApiAmount(window.remaining, window.currency || quota.currency)}</span>}
+                {!windowUnlimited && window.used != null && <span>{isSharedWindow ? '分组共享已用' : '已用'} {formatApiAmount(window.used, window.currency || quota.currency)}</span>}
+                {!windowUnlimited && window.limit != null && <span>{isSharedWindow ? '分组共享上限' : '上限'} {formatApiAmount(window.limit, window.currency || quota.currency)}</span>}
+                {!windowUnlimited && window.remaining != null && <span>{isSharedWindow ? '分组共享剩余' : '剩余'} {formatApiAmount(window.remaining, window.currency || quota.currency)}</span>}
                 {keyUsed != null && <span>本 Key 已用 {formatApiAmount(keyUsed, window.currency || quota.currency)}</span>}
               </div>
             )}


### PR DESCRIPTION
## Summary
- treat explicit Apex `limit: null` + `remaining: null` window pairs as unlimited while retaining per-Key usage
- keep missing, asymmetric, non-finite, and otherwise invalid quota fields fail-closed
- exclude unlimited windows from quota-switch thresholds and render them without misleading unavailable totals or progress bars

## Validation
- `pytest -q backend/tests/test_cloudrouter_accounts.py backend/tests/test_codex_pool.py` — 155 passed
- `npx vitest run src/components/Layout/PoolDrawer.test.tsx` — 47 passed
- `npm run build`
- `npx eslint src/components/Layout/PoolDrawer.tsx src/components/Layout/PoolDrawer.test.tsx`
- live Apex `/v1/usage` verification: account active/known/available, unlimited windows parsed correctly, and Codex Pool reports no quota error