### PR TITLE
feat: improve Markdown math rendering

### DIFF
--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -153,6 +153,32 @@ _DOC_SYNC_NOTE = (
     "若两者是 symlink 关系则改一处即可，无需额外操作）。"
 )
 
+_MATH_FORMAT_HINT = (
+    "数学排版提示：公式请使用有效 LaTeX（行内 `\\(...\\)`，独立 "
+    "`\\[...\\]`），不要放进代码块或写成 `sum_i`、`sqrt(...)` 等 ASCII 伪公式。"
+)
+_MATH_INTENT_PATTERN = re.compile(
+    r"(?:"
+    r"数学|公式|方程|不等式|定理|证明|推导|求导|积分|极限|矩阵|"
+    r"概率|期望|方差|梯度|收敛|上界|下界|理论保证|遗憾界|"
+    r"\b(?:latex|math(?:ematics)?|equation|theorem|"
+    r"deriv(?:e|ation|ative)|integral|probabilit(?:y|ies)|expectation|"
+    r"variance|convergence|regret|adagrad|eigenvalue|eigenvector)\b|"
+    r"\bgradient\s+(?:descent|method|vector)\b|"
+    r"\bmatrix\s+(?:algebra|calculus|equation|multiplication|inverse|transpose)\b|"
+    r"\b(?:prove|proof)\s+(?:that|this|the|an?\s+(?:identity|inequality|theorem))\b|"
+    r"\\(?:frac|sum|sqrt|int|lim|prod|mathbb|mathbf|begin)\b|"
+    r"\\\(|\\\[|\$\$|[∑√≤≥∞]"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _conditional_math_format_hint(prompt: str) -> str:
+    """Return a short rendering hint only for clearly mathematical turns."""
+
+    return _MATH_FORMAT_HINT if _MATH_INTENT_PATTERN.search(prompt) else ""
+
 
 def _task_artifact_policy(task: Task) -> str:
     """Build the provider-neutral, project-scoped artifact contract."""
@@ -215,10 +241,13 @@ def _task_artifact_policy(task: Task) -> str:
 
 
 def _prepend_task_artifact_policy(task: Task, prompt: str) -> str:
-    """Attach the artifact contract to one Task turn prompt."""
+    """Attach mandatory artifacts plus any turn-specific formatting hint."""
 
-    policy = _task_artifact_policy(task)
-    return f"{policy}\n\n{prompt}" if policy else prompt
+    prefixes = [_task_artifact_policy(task)]
+    if not is_pr_sandbox_task(task):
+        prefixes.append(_conditional_math_format_hint(prompt))
+    active_prefixes = [prefix for prefix in prefixes if prefix]
+    return "\n\n".join([*active_prefixes, prompt])
 
 
 def _agent_doc_preamble(task: Task) -> str:
@@ -4985,6 +5014,10 @@ class GlobalDispatcher:
             if command_args:
                 task_description = command_args
             parts.append(command.prompt_template)
+        if not is_pr_sandbox_task(task):
+            math_hint = _conditional_math_format_hint(task_description)
+            if math_hint:
+                parts.append(math_hint)
         parts.append(f"任务:\n{task_description}")
         return "\n\n".join(parts)
 
@@ -7922,6 +7955,11 @@ class GlobalDispatcher:
                 f"用户提供了以下参考图片，请先用 Read 工具查看：\n{image_list}"
             )
 
+        math_hint = _conditional_math_format_hint(
+            f"{task.description}\n{task.goal_condition or ''}"
+        )
+        if math_hint:
+            parts.append(math_hint)
         parts.append(f"任务:\n{task.description}")
         parts.append(
             f"\n目标完成条件:\n{task.goal_condition}\n\n"

--- a/backend/tests/test_service_dispatcher.py
+++ b/backend/tests/test_service_dispatcher.py
@@ -9354,6 +9354,45 @@ async def test_build_task_prompt_carries_doc_sync_note(db_factory):
 
 
 @pytest.mark.asyncio
+async def test_build_task_prompt_adds_short_math_hint_only_for_math_intent(
+    db_factory,
+):
+    """Task #114-like theory questions get LaTeX guidance; ordinary work does not."""
+    dispatcher = _make_dispatcher(db_factory)
+
+    for provider in ("claude", "codex"):
+        math_prompt = await dispatcher._build_task_prompt(
+            Task(
+                title="t",
+                description="什么是 Diagonal AdaGrad 的核心理论保证？",
+                provider=provider,
+            )
+        )
+        ordinary_prompt = await dispatcher._build_task_prompt(
+            Task(title="t", description="整理部署文档", provider=provider)
+        )
+
+        assert "数学排版提示" in math_prompt
+        assert "不要放进代码块" in math_prompt
+        assert "数学排版提示" not in ordinary_prompt
+
+        for non_math_description in (
+            "Fix the CSS linear-gradient and its color stops",
+            "Update this Excel formula and spreadsheet formatting",
+            "Debug Matrix protocol message delivery",
+            "Write a proof of concept for the deployment hook",
+        ):
+            non_math_prompt = await dispatcher._build_task_prompt(
+                Task(
+                    title="t",
+                    description=non_math_description,
+                    provider=provider,
+                )
+            )
+            assert "数学排版提示" not in non_math_prompt
+
+
+@pytest.mark.asyncio
 async def test_build_task_prompt_requires_downloadable_artifact_links(
     db_factory,
     tmp_path,
@@ -9451,6 +9490,23 @@ def test_user_prompt_cannot_suppress_followup_artifact_policy(tmp_path):
     assert ".claude-manager/artifacts/task-45" in wrapped
     assert wrapped.startswith(TASK_ARTIFACT_POLICY_TAG)
     assert wrapped.count(TASK_ARTIFACT_POLICY_TAG) == 2
+
+
+@pytest.mark.parametrize("provider", ["claude", "codex"])
+def test_followup_math_hint_is_turn_scoped(provider, tmp_path):
+    task = Task(
+        id=47,
+        title="t",
+        provider=provider,
+        target_repo=str(tmp_path),
+    )
+
+    math_turn = _prepend_task_artifact_policy(task, "请推导这个公式的上界")
+    ordinary_turn = _prepend_task_artifact_policy(task, "继续整理 README")
+
+    assert "数学排版提示" in math_turn
+    assert math_turn.endswith("请推导这个公式的上界")
+    assert "数学排版提示" not in ordinary_turn
 
 
 @pytest.mark.parametrize("provider", ["claude", "codex"])

--- a/frontend/src/components/Markdown/MarkdownRenderer.test.tsx
+++ b/frontend/src/components/Markdown/MarkdownRenderer.test.tsx
@@ -32,6 +32,56 @@ describe('MarkdownRenderer math support', () => {
     expect(container.querySelector('.katex-html')).not.toBeNull();
   });
 
+  it('renders display math split into Markdown nodes by a standalone equals line', () => {
+    const markdown = String.raw`Diagonal AdaGrad gives
+
+\[
+R_T
+=
+\sum_{t=1}^T f_t(x_t)-\sum_{t=1}^T f_t(x^\*)
+\le
+O\left(\sum_{i=1}^d D_i \sqrt{G_{T,i}}\right)
+\]`;
+    const { container } = render(<MarkdownRenderer content={markdown} />);
+
+    expect(container.querySelectorAll('.katex-display')).toHaveLength(1);
+    expect(container.querySelector('.katex-error')).toBeNull();
+    expect(container.querySelector('h1, h2')).toBeNull();
+    expect(container.querySelector('.katex-html')?.textContent).toContain('≤');
+  });
+
+  it('renders compact display math nested in a list item', () => {
+    const markdown = String.raw`- Gaussian lower bound
+
+  \[ \Omega\!\left(\min\left\{\frac{\sigma^2 A^2 d^2}{\eta^4},\frac{\sigma^2 H R^2 d^2}{\eta^3}\right\}\right) \]`;
+    const { container } = render(<MarkdownRenderer content={markdown} />);
+
+    expect(container.querySelector('li .katex-display')).not.toBeNull();
+    expect(container.querySelector('li .katex-html')?.textContent).toContain('Ω');
+  });
+
+  it('repairs an escaped superscript star only inside confirmed math nodes', () => {
+    const markdown = [
+      String.raw`Inline \(x^\*\).`,
+      '',
+      '```tex',
+      String.raw`x^\*`,
+      '```',
+      '',
+      '$$',
+      String.raw`y^{\*}`,
+      '$$',
+    ].join('\n');
+    const { container } = render(<MarkdownRenderer content={markdown} />);
+
+    expect(container.querySelectorAll('.katex')).toHaveLength(2);
+    expect(container.querySelector('[style*="color:#cc0000"]')).toBeNull();
+    expect(
+      Array.from(container.querySelectorAll('annotation')).map((node) => node.textContent),
+    ).toEqual(['x^*', 'y^{*}']);
+    expect(container.querySelector('pre code')?.textContent).toContain(String.raw`x^\*`);
+  });
+
   it('keeps Markdown-like tokens inside whole-paragraph display math', () => {
     const markdown = String.raw`\[
 \text{**not Markdown strong**}

--- a/frontend/src/components/Markdown/MarkdownRenderer.test.tsx
+++ b/frontend/src/components/Markdown/MarkdownRenderer.test.tsx
@@ -1,11 +1,16 @@
 import { render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { MarkdownRenderer } from './MarkdownRenderer';
+import { remarkBackslashMath } from './markdownMath';
 
 interface CapturedNode {
   type?: string;
   value?: string;
   children?: CapturedNode[];
+  position?: {
+    start?: { offset?: number };
+    end?: { offset?: number };
+  };
 }
 
 function nodesOfType(root: CapturedNode | null, type: string): CapturedNode[] {
@@ -58,6 +63,86 @@ O\left(\sum_{i=1}^d D_i \sqrt{G_{T,i}}\right)
 
     expect(container.querySelector('li .katex-display')).not.toBeNull();
     expect(container.querySelector('li .katex-html')?.textContent).toContain('Ω');
+  });
+
+  it('scans a large unclosed display formula without repeatedly copying prefixes', () => {
+    const chunks = [String.raw`\[`, ...Array.from({ length: 20_000 }, () => 'x')];
+    const source = chunks.join('\n\n');
+    let offset = 0;
+    const children = chunks.map((chunk) => {
+      const start = offset;
+      const end = start + chunk.length;
+      offset = end + 2;
+      return {
+        type: 'paragraph',
+        position: { start: { offset: start }, end: { offset: end } },
+        children: [{
+          type: 'text',
+          value: chunk,
+          position: { start: { offset: start }, end: { offset: end } },
+        }],
+      };
+    });
+    const tree = {
+      type: 'root',
+      position: { start: { offset: 0 }, end: { offset: source.length } },
+      children,
+    };
+
+    const originalSlice = String.prototype.slice;
+    let copiedCharacters = 0;
+    const sliceSpy = vi.spyOn(String.prototype, 'slice').mockImplementation(function (
+      this: string,
+      start?: number,
+      end?: number,
+    ) {
+      const result = originalSlice.call(this, start, end);
+      copiedCharacters += result.length;
+      return result;
+    });
+
+    let elapsedMs = 0;
+    try {
+      const startedAt = performance.now();
+      remarkBackslashMath()(tree, { value: source });
+      elapsedMs = performance.now() - startedAt;
+    } finally {
+      sliceSpy.mockRestore();
+    }
+
+    expect(source.length).toBeGreaterThan(60_000);
+    expect(copiedCharacters).toBeLessThan(source.length * 2);
+    expect(elapsedMs).toBeLessThan(1_000);
+  });
+
+  it('preserves fenced code nested between display delimiters', () => {
+    const markdown = [
+      String.raw`\[`,
+      '',
+      '> ```tex',
+      '> protected_code',
+      '> ```',
+      '',
+      String.raw`\]`,
+    ].join('\n');
+    const { container } = render(<MarkdownRenderer content={markdown} />);
+
+    expect(container.querySelector('.katex')).toBeNull();
+    expect(container.querySelector('blockquote pre code')?.textContent).toContain('protected_code');
+  });
+
+  it('preserves a link nested between display delimiters', () => {
+    const markdown = String.raw`\[
+
+> [protected link](https://example.test/protected)
+
+\]`;
+    const { container } = render(<MarkdownRenderer content={markdown} />);
+
+    expect(container.querySelector('.katex')).toBeNull();
+    expect(container.querySelector('blockquote a')?.getAttribute('href')).toBe(
+      'https://example.test/protected',
+    );
   });
 
   it('repairs an escaped superscript star only inside confirmed math nodes', () => {

--- a/frontend/src/components/Markdown/markdownMath.ts
+++ b/frontend/src/components/Markdown/markdownMath.ts
@@ -30,6 +30,45 @@ const SKIP_DESCENDANTS = new Set([
   'inlineMath',
 ]);
 
+const MAX_DISPLAY_MATH_SOURCE_LENGTH = 100_000;
+
+function normalizeMathValue(value: string): string {
+  // Models occasionally escape a superscript star as `x^\*`. KaTeX treats
+  // `\*` as an unknown command and paints it red; a bare `*` is the intended
+  // TeX token. Restrict this repair to confirmed math nodes and leave `\\*`
+  // (a line break followed by a star) untouched.
+  return value.replace(/(^|[^\\])\\\*/g, '$1*');
+}
+
+function replaceFirstHastTextValue(node: unknown, value: string): boolean {
+  if (!node || typeof node !== 'object') return false;
+  const candidate = node as {
+    type?: unknown;
+    value?: unknown;
+    children?: unknown;
+  };
+  if (candidate.type === 'text') {
+    candidate.value = value;
+    return true;
+  }
+  if (!Array.isArray(candidate.children)) return false;
+  return candidate.children.some((child) => replaceFirstHastTextValue(child, value));
+}
+
+function normalizeExistingMathNode(node: MarkdownNode): void {
+  if (typeof node.value !== 'string') return;
+  const normalizedValue = normalizeMathValue(node.value);
+  if (normalizedValue === node.value) return;
+  node.value = normalizedValue;
+
+  // mdast-util-math stores a second copy for mdast-to-hast. Keep that copy in
+  // sync so `$$...$$` nodes receive the same repair as backslash-delimited math.
+  const hChildren = node.data?.hChildren;
+  if (Array.isArray(hChildren)) {
+    hChildren.some((child) => replaceFirstHastTextValue(child, normalizedValue));
+  }
+}
+
 function isMarkdownNode(value: unknown): value is MarkdownNode {
   return Boolean(
     value
@@ -79,28 +118,30 @@ function findDelimiter(
 }
 
 function inlineMathNode(value: string): MarkdownNode {
+  const normalizedValue = normalizeMathValue(value);
   return {
     type: 'inlineMath',
-    value,
+    value: normalizedValue,
     data: {
       hName: 'code',
       hProperties: { className: ['language-math', 'math-inline'] },
-      hChildren: [{ type: 'text', value }],
+      hChildren: [{ type: 'text', value: normalizedValue }],
     },
   };
 }
 
 function displayMathNode(value: string): MarkdownNode {
+  const normalizedValue = normalizeMathValue(value);
   return {
     type: 'math',
-    value,
+    value: normalizedValue,
     data: {
       hName: 'pre',
       hChildren: [{
         type: 'element',
         tagName: 'code',
         properties: { className: ['language-math', 'math-display'] },
-        children: [{ type: 'text', value }],
+        children: [{ type: 'text', value: normalizedValue }],
       }],
     },
   };
@@ -111,10 +152,7 @@ function stripOneLineEnding(value: string, fromStart: boolean): string {
   return value.replace(/(?:\r\n|\r|\n)$/, '');
 }
 
-function parseDisplayMath(paragraph: MarkdownNode, source: string): MarkdownNode | null {
-  const raw = sourceForNode(paragraph, source);
-  if (raw === null) return null;
-
+function parseDisplayMathSource(raw: string): MarkdownNode | null {
   const leadingWhitespace = raw.match(/^[ \t]*/)?.[0].length || 0;
   const opening = findDelimiter(raw, '[', leadingWhitespace);
   if (opening !== leadingWhitespace) return null;
@@ -126,6 +164,38 @@ function parseDisplayMath(paragraph: MarkdownNode, source: string): MarkdownNode
   value = stripOneLineEnding(value, true);
   value = stripOneLineEnding(value, false);
   return displayMathNode(value);
+}
+
+function parseDisplayMathRange(
+  children: MarkdownNode[],
+  startIndex: number,
+  source: string,
+): { node: MarkdownNode; endIndex: number } | null {
+  if (SKIP_DESCENDANTS.has(children[startIndex].type)) return null;
+  const start = children[startIndex].position?.start?.offset;
+  if (typeof start !== 'number') return null;
+
+  const openingSource = sourceForNode(children[startIndex], source);
+  if (openingSource === null) return null;
+  const leadingWhitespace = openingSource.match(/^[ \t]*/)?.[0].length || 0;
+  if (findDelimiter(openingSource, '[', leadingWhitespace) !== leadingWhitespace) {
+    return null;
+  }
+
+  for (let endIndex = startIndex; endIndex < children.length; endIndex += 1) {
+    if (SKIP_DESCENDANTS.has(children[endIndex].type)) return null;
+    const end = children[endIndex].position?.end?.offset;
+    if (typeof end !== 'number' || end < start) return null;
+    if (end - start > MAX_DISPLAY_MATH_SOURCE_LENGTH) return null;
+
+    const raw = source.slice(start, end);
+    const node = parseDisplayMathSource(raw);
+    if (node) return { node, endIndex };
+
+    const opening = findDelimiter(raw, '[', leadingWhitespace);
+    if (findDelimiter(raw, ']', opening + 2) >= 0) return null;
+  }
+  return null;
 }
 
 function splitInlineMath(node: MarkdownNode, source: string): MarkdownNode[] | null {
@@ -176,15 +246,21 @@ function transformChildren(parent: MarkdownNode, source: string): void {
   if (!parent.children || SKIP_DESCENDANTS.has(parent.type)) return;
 
   const transformed: MarkdownNode[] = [];
-  for (const child of parent.children) {
-    if (child.type === 'paragraph') {
-      const displayMath = parseDisplayMath(child, source);
-      if (displayMath) {
-        transformed.push(displayMath);
-        continue;
-      }
+  for (let index = 0; index < parent.children.length; index += 1) {
+    const displayMath = parseDisplayMathRange(parent.children, index, source);
+    if (displayMath) {
+      transformed.push(displayMath.node);
+      index = displayMath.endIndex;
+      continue;
     }
 
+    const child = parent.children[index];
+    if (
+      (child.type === 'math' || child.type === 'inlineMath')
+      && typeof child.value === 'string'
+    ) {
+      normalizeExistingMathNode(child);
+    }
     if (child.type === 'text') {
       transformed.push(...(splitInlineMath(child, source) || [child]));
       continue;
@@ -200,8 +276,11 @@ function transformChildren(parent: MarkdownNode, source: string): void {
  * Parse Codex's `\\(...\\)` and `\\[...\\]` notation after Markdown has
  * formed its AST. Source positions recover the escaped delimiters without
  * rewriting URLs, HTML, code, definitions, images, or link destinations.
- * Inline pairs are deliberately confined to one text node, and display math
- * must occupy a whole paragraph, so delimiters cannot capture unrelated AST.
+ * Inline pairs are deliberately confined to one text node. Display math may
+ * span sibling AST nodes because TeX lines such as a standalone `=` can be
+ * parsed as Markdown headings; the explicit delimiters still have to occupy
+ * the complete source range within one container. Narrow compatibility fixes
+ * are applied only after content has been identified as a math node.
  */
 export function remarkBackslashMath() {
   return (tree: unknown, file: MarkdownFile): void => {

--- a/frontend/src/components/Markdown/markdownMath.ts
+++ b/frontend/src/components/Markdown/markdownMath.ts
@@ -104,8 +104,10 @@ function findDelimiter(
   source: string,
   closingCharacter: '(' | ')' | '[' | ']',
   fromIndex: number,
+  toIndex: number = source.length,
 ): number {
-  for (let index = fromIndex; index < source.length - 1; index += 1) {
+  const boundedEnd = Math.min(toIndex, source.length);
+  for (let index = fromIndex; index + 1 < boundedEnd; index += 1) {
     if (
       source[index] === '\\'
       && source[index + 1] === closingCharacter
@@ -152,18 +154,42 @@ function stripOneLineEnding(value: string, fromStart: boolean): string {
   return value.replace(/(?:\r\n|\r|\n)$/, '');
 }
 
-function parseDisplayMathSource(raw: string): MarkdownNode | null {
-  const leadingWhitespace = raw.match(/^[ \t]*/)?.[0].length || 0;
-  const opening = findDelimiter(raw, '[', leadingWhitespace);
-  if (opening !== leadingWhitespace) return null;
+function containsProtectedNode(node: MarkdownNode): boolean {
+  return SKIP_DESCENDANTS.has(node.type)
+    || Boolean(node.children?.some((child) => containsProtectedNode(child)));
+}
 
-  const closing = findDelimiter(raw, ']', opening + 2);
-  if (closing < 0 || !/^[ \t]*$/.test(raw.slice(closing + 2))) return null;
+function findDisplayMathOpening(node: MarkdownNode, source: string): {
+  start: number;
+  opening: number;
+} | null {
+  const start = node.position?.start?.offset;
+  const end = node.position?.end?.offset;
+  if (
+    typeof start !== 'number'
+    || typeof end !== 'number'
+    || start < 0
+    || end < start
+    || end > source.length
+  ) {
+    return null;
+  }
 
-  let value = raw.slice(opening + 2, closing);
-  value = stripOneLineEnding(value, true);
-  value = stripOneLineEnding(value, false);
-  return displayMathNode(value);
+  let opening = start;
+  while (opening < end && (source[opening] === ' ' || source[opening] === '\t')) {
+    opening += 1;
+  }
+  if (opening + 1 >= end || source[opening] !== '\\' || source[opening + 1] !== '[') {
+    return null;
+  }
+  return { start, opening };
+}
+
+function containsOnlyHorizontalWhitespace(source: string, start: number, end: number): boolean {
+  for (let index = start; index < end; index += 1) {
+    if (source[index] !== ' ' && source[index] !== '\t') return false;
+  }
+  return true;
 }
 
 function parseDisplayMathRange(
@@ -171,29 +197,39 @@ function parseDisplayMathRange(
   startIndex: number,
   source: string,
 ): { node: MarkdownNode; endIndex: number } | null {
-  if (SKIP_DESCENDANTS.has(children[startIndex].type)) return null;
-  const start = children[startIndex].position?.start?.offset;
-  if (typeof start !== 'number') return null;
+  const openingRange = findDisplayMathOpening(children[startIndex], source);
+  if (!openingRange) return null;
 
-  const openingSource = sourceForNode(children[startIndex], source);
-  if (openingSource === null) return null;
-  const leadingWhitespace = openingSource.match(/^[ \t]*/)?.[0].length || 0;
-  if (findDelimiter(openingSource, '[', leadingWhitespace) !== leadingWhitespace) {
-    return null;
-  }
+  const { start, opening } = openingRange;
+  let searchFrom = opening + 2;
+  let previousEnd = start;
 
   for (let endIndex = startIndex; endIndex < children.length; endIndex += 1) {
-    if (SKIP_DESCENDANTS.has(children[endIndex].type)) return null;
+    if (containsProtectedNode(children[endIndex])) return null;
     const end = children[endIndex].position?.end?.offset;
-    if (typeof end !== 'number' || end < start) return null;
+    if (
+      typeof end !== 'number'
+      || end < previousEnd
+      || end > source.length
+    ) {
+      return null;
+    }
     if (end - start > MAX_DISPLAY_MATH_SOURCE_LENGTH) return null;
 
-    const raw = source.slice(start, end);
-    const node = parseDisplayMathSource(raw);
-    if (node) return { node, endIndex };
+    const closing = findDelimiter(source, ']', searchFrom, end);
+    if (closing >= 0) {
+      if (!containsOnlyHorizontalWhitespace(source, closing + 2, end)) return null;
 
-    const opening = findDelimiter(raw, '[', leadingWhitespace);
-    if (findDelimiter(raw, ']', opening + 2) >= 0) return null;
+      let value = source.slice(opening + 2, closing);
+      value = stripOneLineEnding(value, true);
+      value = stripOneLineEnding(value, false);
+      return { node: displayMathNode(value), endIndex };
+    }
+
+    // Keep one character of overlap so a delimiter split at an AST boundary
+    // is still found, while every other source character is scanned once.
+    searchFrom = Math.max(searchFrom, end - 1);
+    previousEnd = end;
   }
   return null;
 }


### PR DESCRIPTION
## Summary

- reconstruct explicit `\[...\]` display math when Markdown splits it across sibling AST nodes (for example a standalone `=` line)
- normalize the model's invalid `\*` escape only inside confirmed math nodes, while preserving code blocks and other protected Markdown nodes
- add a short LaTeX formatting hint only for clearly mathematical turns; ordinary coding/docs prompts and ambiguous CSS/Excel/Matrix/PoC prompts do not receive it
- keep KaTeX security boundaries unchanged (`trust: false`, no global source rewriting)

## Governance / scope

- primary responsibility domains: `frontend-chat-shell`, `task-lifecycle`
- no persistent state ownership, schema, document authority, or new direct module import boundary
- only four implementation/test files are included; the separate local documentation-reorganization work is not part of this PR

## Verification

- `python -m pytest backend/tests/test_task*.py backend/tests/test_service_dispatcher.py backend/tests/test_api_tasks.py backend/tests/test_api_chat_plan.py -q` — **630 passed**
- `python -m pytest backend/tests/test_service_dispatcher.py -q` — **257 passed**
- `npx vitest run src/components/Markdown/MarkdownRenderer.test.tsx` — **13 passed**
- `npx eslint src/components/Markdown/markdownMath.ts src/components/Markdown/MarkdownRenderer.test.tsx` — passed
- `npx tsc --noEmit` — passed
- `npm run build` — passed
- full `npx vitest run` — **644 passed, 1 pre-existing unrelated failure**: `ChatView.test.tsx` expects `Awaiting review`, while current `main` renders `Needs approval`

Local governance-WIP checks still report pre-existing repository drift (Ruff format debt 238 vs baseline 225 and documentation-reorganization violations); this PR does not modify those baselines or governance files.
