### PR TITLE
fix(tasks): expose retry for retryable statuses

### DIFF
--- a/frontend/src/components/Tasks/TaskList.test.tsx
+++ b/frontend/src/components/Tasks/TaskList.test.tsx
@@ -377,24 +377,46 @@ describe('TaskList', () => {
       await waitFor(() => expect(onRefresh).toHaveBeenCalled());
     });
 
-    it('shows Retry in overflow menu for failed tasks', async () => {
-      const tasks = [makeTask({
-        status: 'failed',
-        provider: 'codex',
-        model: 'gpt-5.6-sol',
-        codex_service_tier: 'priority',
-      })];
-      render(<TaskList tasks={tasks} projects={projects} onRefresh={onRefresh} onOpenChat={onOpenChat} />);
+    it.each(['failed', 'cancelled', 'conflict', 'completed'])(
+      'shows Retry in overflow menu for %s tasks',
+      async (status) => {
+        const tasks = [makeTask({
+          status,
+          provider: 'codex',
+          model: 'gpt-5.6-sol',
+          codex_service_tier: 'priority',
+        })];
+        render(<TaskList tasks={tasks} projects={projects} onRefresh={onRefresh} onOpenChat={onOpenChat} />);
+
+        await userEvent.click(screen.getByTitle('More actions'));
+        await userEvent.click(screen.getByText('Retry'));
+
+        expect(api.retryTask).toHaveBeenCalledWith(1, {
+          provider: 'codex',
+          model: 'gpt-5.6-sol',
+          codex_service_tier: 'priority',
+        });
+        await waitFor(() => expect(onRefresh).toHaveBeenCalled());
+      },
+    );
+
+    it.each([
+      { mode: 'plan', status: 'failed' },
+      { mode: 'auto', status: 'pending' },
+      { mode: 'auto', status: 'completed', background_active: true },
+      { mode: 'auto', status: 'failed', delivery_run_id: 17 },
+    ])('hides Retry when the Task lifecycle does not allow it: %o', async (overrides) => {
+      render(
+        <TaskList
+          tasks={[makeTask(overrides)]}
+          projects={projects}
+          onRefresh={onRefresh}
+          onOpenChat={onOpenChat}
+        />,
+      );
 
       await userEvent.click(screen.getByTitle('More actions'));
-      await userEvent.click(screen.getByText('Retry'));
-
-      expect(api.retryTask).toHaveBeenCalledWith(1, {
-        provider: 'codex',
-        model: 'gpt-5.6-sol',
-        codex_service_tier: 'priority',
-      });
-      await waitFor(() => expect(onRefresh).toHaveBeenCalled());
+      expect(screen.queryByText('Retry')).not.toBeInTheDocument();
     });
 
     it('closes overflow menu on outside click', async () => {

--- a/frontend/src/components/Tasks/TaskList.tsx
+++ b/frontend/src/components/Tasks/TaskList.tsx
@@ -38,6 +38,19 @@ const statusColors: Record<string, string> = {
   cancelled: 'bg-gray-500',
 };
 
+// Keep this aligned with backend/api/tasks.py::_MANUAL_RETRYABLE_STATUSES.
+// Active background output and controller-owned task modes have separate
+// lifecycle controls and cannot be retried through the public Task action.
+const manualRetryableStatuses = new Set(['failed', 'cancelled', 'conflict', 'completed']);
+
+function canRetryTask(task: Task): boolean {
+  return !task.background_active
+    && task.mode !== 'plan'
+    && task.mode !== 'delivery_loop'
+    && task.delivery_run_id == null
+    && manualRetryableStatuses.has(task.status);
+}
+
 export function TaskList({ tasks, projects, onRefresh, onTaskUpdated, onOpenChat, activeTaskId, autoSortOnAccess, onBeforeArchive, onReorder }: TaskListProps) {
   const projectMap = useMemo(() => {
     const map: Record<number, { name: string; color: string | null }> = {};
@@ -358,7 +371,7 @@ export function TaskList({ tasks, projects, onRefresh, onTaskUpdated, onOpenChat
                         <XCircle size={14} /> Cancel
                       </button>
                     )}
-                    {t.status === 'failed' && (
+                    {canRetryTask(t) && (
                       <button
                         onClick={() => { handleRetry(t); setMenuOpenId(null); }}
                         className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-blue-400 hover:bg-gray-800 text-left"


### PR DESCRIPTION
## Summary
- show Retry for failed, cancelled, conflict, and completed Tasks, matching the backend retry contract
- hide Retry for Plan Tasks, Delivery-owned Tasks, and Tasks with active background output
- cover allowed and blocked lifecycle states in TaskList tests

## Testing
- TaskList Vitest suite: 41 passed
- ESLint on changed files
- TypeScript and Vite production build