### PR TITLE
fix(codex): accept verified SSE without MIME

### DIFF
--- a/backend/services/codex_tier_proxy.py
+++ b/backend/services/codex_tier_proxy.py
@@ -402,7 +402,11 @@ def _connection_tokens(headers: dict[str, str]) -> set[str]:
     }
 
 
-def _filter_request_headers(headers: dict[str, str]) -> dict[str, str]:
+def _filter_request_headers(
+    headers: dict[str, str],
+    *,
+    expect_sse: bool = False,
+) -> dict[str, str]:
     blocked = _HOP_BY_HOP | _connection_tokens(headers) | {
         "host",
         "content-length",
@@ -419,6 +423,8 @@ def _filter_request_headers(headers: dict[str, str]) -> dict[str, str]:
     # response is still required, but this prevents normal upstreams from
     # selecting one.
     filtered["accept-encoding"] = "identity"
+    if expect_sse:
+        filtered["accept"] = "text/event-stream"
     return filtered
 
 
@@ -434,6 +440,26 @@ def _filter_response_headers(headers: httpx.Headers) -> list[tuple[str, str]]:
         if name.lower() not in blocked
         and name.lower() not in _SENSITIVE_HEADERS
     ]
+
+
+def _verified_sse_response_headers(
+    headers: httpx.Headers,
+) -> list[tuple[str, str]]:
+    """Normalize a byte-verified Responses stream for the Codex client.
+
+    The ChatGPT Codex backend can omit the SSE MIME header even though the
+    response body is a valid Responses event stream.  The proxy proves the
+    framing and service tier from the buffered body before calling this
+    helper, so the downstream header can safely be canonicalized here.
+    """
+
+    filtered = [
+        (name, value)
+        for name, value in _filter_response_headers(headers)
+        if name.lower() != "content-type"
+    ]
+    filtered.append(("Content-Type", "text/event-stream"))
+    return filtered
 
 
 def _split_sse_events(buffer: bytearray) -> tuple[list[bytes], bytearray]:
@@ -1258,7 +1284,10 @@ class CodexActualTierProxy:
             request = client.build_request(
                 method,
                 upstream_url,
-                headers=_filter_request_headers(headers),
+                headers=_filter_request_headers(
+                    headers,
+                    expect_sse=identity is not None,
+                ),
                 content=body,
             )
             upstream = await client.send(request, stream=True)
@@ -1416,11 +1445,6 @@ class CodexActualTierProxy:
             raise CodexTierProofError(
                 "Compressed Responses stream cannot be audited"
             )
-        content_type = upstream.headers.get("content-type", "").lower()
-        if "text/event-stream" not in content_type:
-            raise CodexTierProofError(
-                "Upstream did not return a Responses SSE stream"
-            )
 
         iterator = _iter_response_raw(upstream)
         untouched = bytearray()
@@ -1470,8 +1494,9 @@ class CodexActualTierProxy:
                 ):
                     raise CodexTierProofError(
                         "Upstream actual service tier mismatch: "
-                        "expected priority, "
-                        f"got {reported_tier!r}"
+                        "requested=priority, "
+                        f"upstream_actual={reported_tier!r}; "
+                        "Fast was not honored"
                     )
                 actual = (
                     reported_tier
@@ -1517,7 +1542,7 @@ class CodexActualTierProxy:
         await self._send_stream_headers(
             writer,
             upstream.status_code,
-            list(_filter_response_headers(upstream.headers)),
+            _verified_sse_response_headers(upstream.headers),
         )
         writer.write(untouched)
         await writer.drain()

--- a/backend/tests/test_codex_tier_proxy.py
+++ b/backend/tests/test_codex_tier_proxy.py
@@ -1,4 +1,5 @@
 import asyncio
+import gzip
 import json
 import os
 from pathlib import Path
@@ -83,7 +84,6 @@ async def test_fast_proxy_requires_request_and_actual_priority():
         return httpx.Response(
             200,
             headers={
-                "content-type": "text/event-stream",
                 "connection": "keep-alive",
             },
             content=_sse(tier="priority"),
@@ -116,7 +116,9 @@ async def test_fast_proxy_requires_request_and_actual_priority():
         assert seen["body"]["service_tier"] == "priority"
         assert seen["request"].headers["authorization"] == "Bearer do-not-log"
         assert "x-hop" not in seen["request"].headers
+        assert seen["request"].headers["accept"] == "text/event-stream"
         assert seen["request"].headers["accept-encoding"] == "identity"
+        assert response.headers["content-type"] == "text/event-stream"
         assert response.headers["connection"] == "close"
     finally:
         await proxy.close()
@@ -201,12 +203,14 @@ async def test_standard_proxy_does_not_depend_on_responses_sse_prelude():
 
 
 @pytest.mark.asyncio
-async def test_actual_tier_mismatch_releases_no_sse_bytes_and_fails_waiter():
+@pytest.mark.parametrize("reported_tier", ["default", "auto", None])
+async def test_actual_tier_mismatch_releases_no_sse_bytes_and_fails_waiter(
+    reported_tier: str | None,
+):
     async def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             200,
-            headers={"content-type": "text/event-stream"},
-            content=_sse(tier="default"),
+            content=_sse(tier=reported_tier),
         )
 
     proxy = await _running_proxy(handler)
@@ -220,7 +224,81 @@ async def test_actual_tier_mismatch_releases_no_sse_bytes_and_fails_waiter():
             )
         assert response.status_code == 502
         assert b"response.created" not in response.content
-        with pytest.raises(CodexTierProofError, match="actual service tier"):
+        with pytest.raises(
+            CodexTierProofError,
+            match="actual service tier",
+        ) as exc_info:
+            await proxy.wait_for_actual_tier(
+                "thread-1",
+                "turn-1",
+                "priority",
+                timeout=0.2,
+            )
+        message = str(exc_info.value)
+        assert "requested=priority" in message
+        assert f"upstream_actual={reported_tier!r}" in message
+        assert "Fast was not honored" in message
+    finally:
+        await proxy.close()
+
+
+@pytest.mark.asyncio
+async def test_fast_proxy_rejects_non_sse_success_without_releasing_body():
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=b'{"secret_upstream_error":"not an SSE stream"}',
+        )
+
+    proxy = await _running_proxy(handler)
+    proxy.set_thread_tier("thread-1", "priority")
+    try:
+        async with httpx.AsyncClient(trust_env=False) as client:
+            response = await client.post(
+                f"{proxy.local_base_url}/responses",
+                headers={"x-client-request-id": "thread-1"},
+                json=_request_body(),
+            )
+        assert response.status_code == 502
+        assert b"secret_upstream_error" not in response.content
+        with pytest.raises(
+            CodexTierProofError,
+            match="ended before response.created",
+        ):
+            await proxy.wait_for_actual_tier(
+                "thread-1",
+                "turn-1",
+                "priority",
+                timeout=0.2,
+            )
+    finally:
+        await proxy.close()
+
+
+@pytest.mark.asyncio
+async def test_fast_proxy_rejects_compressed_sse_before_releasing_body():
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-encoding": "gzip"},
+            content=gzip.compress(_sse(tier="priority")),
+        )
+
+    proxy = await _running_proxy(handler)
+    proxy.set_thread_tier("thread-1", "priority")
+    try:
+        async with httpx.AsyncClient(trust_env=False) as client:
+            response = await client.post(
+                f"{proxy.local_base_url}/responses",
+                headers={"x-client-request-id": "thread-1"},
+                json=_request_body(),
+            )
+        assert response.status_code == 502
+        assert b"response.created" not in response.content
+        with pytest.raises(
+            CodexTierProofError,
+            match="Compressed Responses stream cannot be audited",
+        ):
             await proxy.wait_for_actual_tier(
                 "thread-1",
                 "turn-1",


### PR DESCRIPTION
## Summary

- accept valid Responses SSE when the ChatGPT Codex backend omits `Content-Type`
- force `Accept: text/event-stream` and keep `Accept-Encoding: identity` for auditable Responses requests
- normalize the verified downstream stream MIME while preserving zero-byte release before Fast tier proof
- report `requested=priority` and the actual upstream tier when Fast is not honored

## Root cause

The Fast proof proxy rejected HTTP 200 responses before reading the body whenever the upstream omitted `Content-Type: text/event-stream`. The ChatGPT Codex backend can omit that header while still returning a valid SSE stream, and Codex's native transport parses the stream by framing rather than MIME. Standard turns bypassed this Fast-only check.

The proxy now validates the bounded SSE body and requires `response.created.response.service_tier == "priority"` before releasing any bytes. `default`, `auto`, missing tiers, non-SSE bodies, and compressed streams still fail closed.

## Validation

- `.venv/bin/pytest backend/tests/test_codex_tier_proxy.py -q` — 33 passed
- `git diff --check`
