### PR TITLE
fix: route Apex accounts through apexin API

### DIFF
--- a/backend/services/cloudrouter_accounts.py
+++ b/backend/services/cloudrouter_accounts.py
@@ -35,9 +35,16 @@ CLAUDE_BASE_URL = "https://console.cloudrouter.online"
 CODEX_BASE_URL = "https://console.cloudrouter.online/v1"
 MODELS_URL = f"{CODEX_BASE_URL}/models"
 USAGE_URL = f"{CODEX_BASE_URL}/usage"
-APEX_CODEX_BASE_URL = "https://35-75-22-186.sslip.io/v1"
+APEX_CODEX_BASE_URL = "https://api.apexin.ai/v1"
 APEX_MODELS_URL = f"{APEX_CODEX_BASE_URL}/models"
 APEX_USAGE_URL = f"{APEX_CODEX_BASE_URL}/usage"
+LEGACY_APEX_CODEX_BASE_URL = "https://35-75-22-186.sslip.io/v1"
+LEGACY_APEX_ENDPOINTS = {
+    "claude_base_url": None,
+    "codex_base_url": LEGACY_APEX_CODEX_BASE_URL,
+    "models_url": f"{LEGACY_APEX_CODEX_BASE_URL}/models",
+    "usage_url": f"{LEGACY_APEX_CODEX_BASE_URL}/usage",
+}
 # Keep this aligned with the Codex CLI version pinned by scripts/setup.sh and
 # WorkerProvisioner.  Apex exposes the native Codex model catalog endpoint,
 # which requires the caller version in order to filter compatible models.
@@ -1580,7 +1587,14 @@ class CloudRouterAccountStore:
             raise CloudRouterUnsafePathError(
                 f"Mismatched API provider metadata: {account_id}"
             )
-        if data.get("endpoints") != spec.endpoints:
+        migrate_legacy_apex_endpoints = (
+            api_provider == API_PROVIDER_APEX
+            and data.get("endpoints") == LEGACY_APEX_ENDPOINTS
+        )
+        if (
+            data.get("endpoints") != spec.endpoints
+            and not migrate_legacy_apex_endpoints
+        ):
             raise CloudRouterUnsafePathError(f"Modified fixed endpoints: {account_id}")
         name = data.get("name")
         models = data.get("models")
@@ -1656,6 +1670,20 @@ class CloudRouterAccountStore:
                 )
             _require_owned_regular(path / "codex" / "config.toml", 0o600)
             self._validate_runtime_configuration(account)
+        if migrate_legacy_apex_endpoints:
+            data["endpoints"] = dict(spec.endpoints)
+            try:
+                _atomic_private_json(
+                    metadata_path,
+                    data,
+                    maximum=MAX_METADATA_BYTES,
+                )
+            except CloudRouterAccountError:
+                raise
+            except OSError as exc:
+                raise CloudRouterUnsafePathError(
+                    f"Could not migrate fixed endpoints: {account_id}",
+                ) from exc
         return account
 
     @staticmethod
@@ -1784,12 +1812,36 @@ class CloudRouterAccountStore:
             "model_providers": expected_providers,
         }
         legacy_apex_codex = None
+        legacy_apex_endpoint_codex = None
+        legacy_apex_endpoint_legacy_codex = None
         if account.api_provider == API_PROVIDER_APEX:
             legacy_apex_codex = {
                 "model_provider": LEGACY_APEX_CODEX_PROVIDER,
                 "model_providers": {
                     LEGACY_APEX_CODEX_PROVIDER: {
                         **expected_provider,
+                        "name": LEGACY_APEX_LABEL,
+                    },
+                },
+            }
+            legacy_endpoint_provider = {
+                **expected_provider,
+                "base_url": LEGACY_APEX_CODEX_BASE_URL,
+            }
+            legacy_apex_endpoint_codex = {
+                "model_provider": spec.codex_provider,
+                "model_providers": {
+                    spec.codex_provider: legacy_endpoint_provider,
+                    LEGACY_APEX_CODEX_PROVIDER: {
+                        **legacy_endpoint_provider,
+                    },
+                },
+            }
+            legacy_apex_endpoint_legacy_codex = {
+                "model_provider": LEGACY_APEX_CODEX_PROVIDER,
+                "model_providers": {
+                    LEGACY_APEX_CODEX_PROVIDER: {
+                        **legacy_endpoint_provider,
                         "name": LEGACY_APEX_LABEL,
                     },
                 },
@@ -1821,11 +1873,29 @@ class CloudRouterAccountStore:
             legacy_apex_codex is not None
             and codex == legacy_apex_codex
         )
-        if codex != expected_codex and not migrate_legacy_apex:
+        migrate_legacy_apex_endpoint = (
+            (
+                legacy_apex_endpoint_codex is not None
+                and codex == legacy_apex_endpoint_codex
+            )
+            or (
+                legacy_apex_endpoint_legacy_codex is not None
+                and codex == legacy_apex_endpoint_legacy_codex
+            )
+        )
+        if (
+            codex != expected_codex
+            and not migrate_legacy_apex
+            and not migrate_legacy_apex_endpoint
+        ):
             raise CloudRouterUnsafePathError(
                 f"Modified Codex API routing: {account.id}",
             )
-        if projects is not None or migrate_legacy_apex:
+        if (
+            projects is not None
+            or migrate_legacy_apex
+            or migrate_legacy_apex_endpoint
+        ):
             try:
                 _atomic_private_write(
                     account.root / "codex" / "config.toml",

--- a/backend/tests/test_cloudrouter_accounts.py
+++ b/backend/tests/test_cloudrouter_accounts.py
@@ -39,6 +39,12 @@ MODELS = {
 }
 
 
+def test_apex_gateway_uses_apexin_endpoint():
+    assert APEX_CODEX_BASE_URL == "https://api.apexin.ai/v1"
+    assert APEX_MODELS_URL == "https://api.apexin.ai/v1/models"
+    assert APEX_USAGE_URL == "https://api.apexin.ai/v1/usage"
+
+
 def test_api_auth_kind_is_limited_to_registered_gateways():
     assert cloudrouter_module.is_api_auth_kind("cloudrouter_api")
     assert cloudrouter_module.is_api_auth_kind("apex_api")
@@ -163,6 +169,44 @@ async def test_add_apex_builds_private_codex_only_home_without_leaking_key(
     assert str(root / "key-helper") in codex_config
     assert "lck-test-secret" not in codex_config
     assert os.popen(str(root / "key-helper")).read() == "lck-test-secret"
+
+
+@pytest.mark.asyncio
+async def test_legacy_apex_endpoint_is_migrated_to_apexin(
+    tmp_path, monkeypatch,
+):
+    store = CloudRouterAccountStore(tmp_path / "accounts")
+    monkeypatch.setattr(
+        store,
+        "probe_models",
+        AsyncMock(return_value={"claude": [], "codex": ["gpt-5.4"]}),
+    )
+    account = await store.add_account(
+        "Apex", "lck-test-secret", api_provider="apex",
+    )
+    legacy_base_url = "https://35-75-22-186.sslip.io/v1"
+    metadata_path = account.root / "account.json"
+    metadata = json.loads(metadata_path.read_text())
+    metadata["endpoints"] = {
+        "claude_base_url": None,
+        "codex_base_url": legacy_base_url,
+        "models_url": f"{legacy_base_url}/models",
+        "usage_url": f"{legacy_base_url}/usage",
+    }
+    metadata_path.write_text(json.dumps(metadata))
+    config_path = account.root / "codex" / "config.toml"
+    config_path.write_text(
+        config_path.read_text().replace(APEX_CODEX_BASE_URL, legacy_base_url)
+    )
+
+    assert [item.id for item in store.reload()] == [account.id]
+    migrated_metadata = json.loads(metadata_path.read_text())
+    assert migrated_metadata["endpoints"]["codex_base_url"] == APEX_CODEX_BASE_URL
+    migrated_config = tomllib.loads(config_path.read_text())
+    assert {
+        provider["base_url"]
+        for provider in migrated_config["model_providers"].values()
+    } == {APEX_CODEX_BASE_URL}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- switch the managed ApexRouter base URL to `https://api.apexin.ai/v1`
- migrate exact legacy endpoint metadata and Codex configs to the new route
- keep fail-closed validation for any unrecognized routing changes

## Tests
- `.venv/bin/pytest -q backend/tests/test_cloudrouter_accounts.py` (`84 passed`)
