### PR TITLE
Place Task search beside Filter

### DIFF
--- a/frontend/src/pages/TasksPage.test.tsx
+++ b/frontend/src/pages/TasksPage.test.tsx
@@ -124,7 +124,7 @@ vi.mock('../components/Chat/LoopChatView', () => ({
   LoopChatView: () => null,
 }));
 vi.mock('../components/ProjectSelect', () => ({
-  ProjectSelect: () => null,
+  ProjectSelect: () => <button type="button">Projects</button>,
 }));
 vi.mock('../components/Tasks/TaskBadges', () => ({
   PluginsBadge: ({ task }: { task: { id: number } }) => (
@@ -300,6 +300,22 @@ describe('TasksPage realtime reconciliation', () => {
     await userEvent.click(screen.getByRole('button', { name: /Filter/ }));
     expect(screen.queryByText('Standalone Plans')).not.toBeInTheDocument();
     expect(screen.queryByText('Related Plans')).not.toBeInTheDocument();
+  });
+
+  it('places search directly after Filter and before Projects', async () => {
+    render(
+      <TasksPage
+        chatTaskId={null}
+        onChatTaskChange={vi.fn()}
+      />,
+    );
+
+    const filterButton = await screen.findByRole('button', { name: /Filter/ });
+    const searchButton = screen.getByTitle('Search task titles (regex)');
+    const projectButton = screen.getByRole('button', { name: 'Projects' });
+
+    expect(filterButton.compareDocumentPosition(searchButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(searchButton.compareDocumentPosition(projectButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('shows the attention tag in the split-mode task sidebar', async () => {

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -535,14 +535,6 @@ export function TasksPage({ chatTaskId, onChatTaskChange }: TasksPageProps) {
           )}
         </div>
 
-        <ProjectSelect
-          projects={tagFilteredProjects}
-          value={projectFilter}
-          onChange={(v) => setProjectFilter(v ? Number(v) : undefined)}
-          placeholder="Projects"
-          tagColorMap={tagColorMap}
-        />
-
         <button
           onClick={() => {
             setShowSearch((s) => {
@@ -583,6 +575,14 @@ export function TasksPage({ chatTaskId, onChatTaskChange }: TasksPageProps) {
         {filteredSearchResults !== null && (
           <span className="text-xs text-gray-500 whitespace-nowrap">{filteredSearchResults.length} match{filteredSearchResults.length === 1 ? '' : 'es'}</span>
         )}
+
+        <ProjectSelect
+          projects={tagFilteredProjects}
+          value={projectFilter}
+          onChange={(v) => setProjectFilter(v ? Number(v) : undefined)}
+          placeholder="Projects"
+          tagColorMap={tagColorMap}
+        />
       </div>
   );
 


### PR DESCRIPTION
## Summary

- Move the Task search control directly after Filter.
- Keep Projects immediately after the search control.
- Add a regression test for toolbar ordering.

## Validation

- `./node_modules/.bin/vitest run src/pages/TasksPage.test.tsx` — 8 passed.
- `./node_modules/.bin/tsc -b && ./node_modules/.bin/vite build` — passed.
- `git diff --check` — passed.

## Existing lint debt

Targeted ESLint still reports the three pre-existing `react-hooks/refs` errors in `TasksPage.tsx` at the render-time ref assignments. This change does not touch those lines.
