### PR TITLE
fix: size chat project badge to content

### DIFF
--- a/frontend/src/components/Chat/ChatView.test.tsx
+++ b/frontend/src/components/Chat/ChatView.test.tsx
@@ -467,6 +467,11 @@ describe('ChatView', () => {
     expect(badges.className).toContain('flex-nowrap');
     expect(badges.className).toContain('overflow-hidden');
 
+    const projectBadge = screen.getByTestId('chat-project-badge');
+    expect(projectBadge).toHaveAttribute('title', 'A long mobile project name');
+    expect(projectBadge).toHaveClass('w-fit', 'max-w-full', 'shrink', 'truncate');
+    expect(projectBadge).not.toHaveClass('flex-1', 'grow', 'w-full');
+
     const actions = screen.getByTestId('chat-header-actions');
     expect(actions.className).toContain('shrink-0');
     expect(screen.getByText('Plans').className).toContain('hidden');

--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -2717,7 +2717,13 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
                 </span>
               )}
               {projectName && (
-                <span className="min-w-0 flex-1 truncate whitespace-nowrap rounded bg-emerald-600/30 px-1.5 text-xs font-medium text-emerald-300">{projectName}</span>
+                <span
+                  data-testid="chat-project-badge"
+                  className="min-w-0 w-fit max-w-full shrink truncate whitespace-nowrap rounded bg-emerald-600/30 px-1.5 text-xs font-medium text-emerald-300"
+                  title={projectName}
+                >
+                  {projectName}
+                </span>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary

- size the chat header project badge to its project name instead of filling all remaining space
- allow the badge to shrink and truncate only when the responsive header runs out of room
- expose the full project name through the title attribute and cover the layout contract in the existing mobile header test

## Responsibility

- Primary area: frontend chat shell
- Cross-domain dependencies: none
- Persistent state or documentation authority changes: none

## Validation

- `npx vitest run src/components/Chat/ChatView.test.tsx` — 132 passed
- `npx vitest run src/components/Chat/ChatView.test.tsx -t "keeps mobile header badges"` — passed after final rebase
- `npx tsc --noEmit` — passed
- `npx eslint src/components/Chat/ChatView.tsx src/components/Chat/ChatView.test.tsx` — 0 errors; one pre-existing Hook dependency warning at ChatView.tsx:527
- `npm run build` — passed after final rebase

## Rebase evidence

- fetched and rebased onto latest `origin/main` (`fa6635df655df9c7952b3d1944e885c959734924`) immediately before final validation and push
