### PR TITLE
fix(claude): allow long-running PTY tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,7 @@ CODEX_MAIN_MCP_ENABLED=true     # 默认启用；紧急回退可显式设为 fal
 AUTO_START_DISPATCHER=true
 MERGE_PUSH_RETRIES=3
 AUTO_PUSH_TO_ORIGIN=true
+CLAUDE_PTY_RESPONSE_IDLE_TIMEOUT_SECONDS=7200  # PTY 无活动超时；工具/子 Agent 有进展时自动续期
 PORT=8000                       # 主服务端口（默认 8000）
 CLOUDROUTER_ACCOUNTS_DIR=~/.ccm/api-accounts  # CloudRouter API 账号独立目录（每把 Key 一个 0700 子目录）
 SSH_KEY_STORAGE_DIR=~/.ccm/ssh-keys           # SSH 页面上传私钥的 0700/0600 后端托管目录

--- a/backend/config.py
+++ b/backend/config.py
@@ -51,11 +51,11 @@ class Settings(BaseSettings):
     merge_push_retries: int = 3
     auto_push_to_origin: bool = True
     task_timeout_seconds: int = 7200  # 2 hours
-    # A live Claude PTY can lose the native tool executor while leaving the
-    # parent CLI and its JSONL tailer alive.  Bound foreground JSONL silence
-    # below the task-wide timeout so the exact turn fails and can be retried
-    # instead of remaining in a false "running" state for two hours.
-    claude_pty_response_idle_timeout_seconds: float = 900.0
+    # This is an inactivity timeout, refreshed whenever the main JSONL or a
+    # tracked sub-agent transcript advances.  A legitimate foreground tool
+    # can stay silent for more than 15 minutes, so keep the default aligned
+    # with the task-wide timeout instead of aborting a healthy tool call.
+    claude_pty_response_idle_timeout_seconds: float = 7200.0
     # 会话上下文利用率达到该比例即自动摘要+换新 session。超大 context 的请求
     # 在服务端易挂起（2026-07-08 task 22/27 连环 stall 均发生在 ~90% 区间），
     # 故不要设回 0.9 让 session 在重灾区长时间工作。

--- a/backend/tests/test_service_instance_manager.py
+++ b/backend/tests/test_service_instance_manager.py
@@ -4691,6 +4691,7 @@ async def test_claude_pty_scrubs_ambient_credentials_and_restores_exact_git_env(
     assert observed["response_timeout"] == (
         settings.claude_pty_response_idle_timeout_seconds
     )
+    assert observed["response_timeout"] == 7200.0
     assert env["SAFE_VALUE"] == ""
     assert env["AUTH_TOKEN"] == ""
     assert env["CCM_INTERNAL_SERVICE_TOKEN"] == ""


### PR DESCRIPTION
## Summary

- raise the CCM-owned Claude PTY inactivity timeout from 900 seconds to 7200 seconds
- keep activity-based renewal intact for main JSONL and tracked sub-agent progress
- document the deployment override and assert the effective timeout at the PTY launch boundary

## Responsibility domain

- Primary: `provider-runtime`
- Supporting configuration: `backend-platform`
- No cross-domain dependency, persistent-state ownership, schema, or documentation-authority changes

## Validation

- `CLAUDE_BINARY=claude pytest backend/tests/test_service_instance_manager.py::test_claude_pty_scrubs_ambient_credentials_and_restores_exact_git_env -q` — passed
- Earlier pre-rebase PTY/runtime integration suite: 359 passed
- `git diff --check` — passed

## Validation limitations

The complete provider test files were also attempted against the existing workspace virtualenv. They reached 100%, but 9 tests failed because that environment is older than current `main` (for example, its pinned `claude-pty` lacks the `Session.active_turn_process` API expected by current tests). The focused launch-boundary integration test covering this change passes; required CI should run with the branch's synchronized dependency environment.
