### PR TITLE
fix(ui): hide local Codex Monitor enabled status

### DIFF
--- a/frontend/src/components/Tasks/TaskForm.test.tsx
+++ b/frontend/src/components/Tasks/TaskForm.test.tsx
@@ -460,14 +460,12 @@ describe('Codex provider UI gating', () => {
     expect(screen.getByText('Thinking')).toBeInTheDocument();
   });
 
-  it('shows Monitor with ordinary/User Skills for local Codex', async () => {
+  it('keeps the local Monitor status quiet while exposing Monitor in Plugins', async () => {
     const cliSelect = await renderAndOpenConfig();
     expect(screen.queryByText(/本地 Codex Monitor 已启用/)).not.toBeInTheDocument();
 
     await userEvent.selectOptions(cliSelect, 'codex');
-    expect(
-      screen.getByText('本地 Codex Monitor 已启用'),
-    ).toBeInTheDocument();
+    expect(screen.queryByText(/本地 Codex Monitor 已启用/)).not.toBeInTheDocument();
     await waitFor(() => expect(screen.getByText(/Plugins/)).toBeInTheDocument());
     expect(screen.getByText('Skills')).toBeInTheDocument();
     await userEvent.click(screen.getByText(/Plugins/));

--- a/frontend/src/components/Tasks/TaskForm.tsx
+++ b/frontend/src/components/Tasks/TaskForm.tsx
@@ -1373,24 +1373,21 @@ export function TaskForm({ onCreated }: TaskFormProps) {
             )}
           </div>
         )}
-        {mode !== 'delivery_loop' && provider === 'codex' && (
+        {mode !== 'delivery_loop' && provider === 'codex' &&
+          (!codexTaskSkillsEnabled || remoteTaskScope || !codexMonitorEnabled) && (
           <span
             className="text-xs text-gray-500 px-1 py-1.5 whitespace-nowrap"
             title={!codexTaskSkillsEnabled
               ? 'Codex 主任务 MCP 已关闭；仅 Sub-Agent 可用'
               : remoteTaskScope
                 ? 'Codex Monitor 当前仅支持本地、非共享任务'
-                : codexMonitorEnabled
-                  ? 'Codex Monitor 已对本地任务开放'
-                  : '当前后端尚未声明 Codex Monitor capability'}
+                : '当前后端尚未声明 Codex Monitor capability'}
           >
             {!codexTaskSkillsEnabled
               ? '主任务 MCP 已关闭 · 仅 Sub-Agent 可用'
               : remoteTaskScope
                 ? 'Monitor 仅支持本地 Codex'
-                : codexMonitorEnabled
-                  ? '本地 Codex Monitor 已启用'
-                  : 'Codex Monitor capability 未知'}
+                : 'Codex Monitor capability 未知'}
           </span>
         )}
         {/* Plugins dropdown */}


### PR DESCRIPTION
## Summary

- hide the redundant “本地 Codex Monitor 已启用” label for local Codex tasks
- retain actionable warning labels when Monitor is unavailable or restricted
- keep the Monitor entry available in Plugins

## Testing

- `npx vitest run src/components/Tasks/TaskForm.test.tsx` (45 passed, 7 skipped)
- `npx tsc --noEmit`
- `git diff --check`