### PR TITLE
fix(codex): reconcile retained background lifecycle

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -3440,7 +3440,7 @@ async def get_chat_history(
         task.last_accessed_at = _dt.utcnow()
         await db.commit()
 
-    allowed = ["user_message", "message", "result", "tool_use", "tool_result", "system_init", "system_event", "thinking", "process_exit"]
+    allowed = ["user_message", "message", "result", "tool_use", "tool_result", "system_init", "system_event", "thinking", "process_exit", "background_lifecycle"]
     # Noisy telemetry must be excluded in SQL, before LIMIT applies. Filtering
     # after the query made pages come back short (< limit), which the client
     # reads as "history exhausted" — older messages became unreachable.
@@ -3570,6 +3570,7 @@ async def get_chat_history(
         turn_id = row.native_turn_id
         native_item_type = None
         native_item_status = None
+        background_lifecycle = None
         if row.raw_json:
             try:
                 raw = json.loads(row.raw_json)
@@ -3612,6 +3613,15 @@ async def get_chat_history(
                         raw_content = raw["raw_content"]
                     if isinstance(raw.get("applied_plans"), list):
                         applied_plans = raw["applied_plans"]
+                    if raw.get("type") == "background.lifecycle":
+                        background_lifecycle = {
+                            "state": raw.get("state"),
+                            "reason": raw.get("reason"),
+                            "active_count": raw.get("active_count"),
+                            "active_thread_ids": raw.get("active_thread_ids"),
+                            "started_at": raw.get("started_at"),
+                            "last_activity_at": raw.get("last_activity_at"),
+                        }
             except (json.JSONDecodeError, TypeError):
                 pass
         if applied_plans is None:
@@ -3654,6 +3664,7 @@ async def get_chat_history(
             "turn_id": turn_id,
             "native_item_type": native_item_type,
             "native_item_status": native_item_status,
+            "background_lifecycle": background_lifecycle,
         })
 
     # Trim back to requested limit (we over-fetched to compensate for

--- a/backend/services/codex_app_server.py
+++ b/backend/services/codex_app_server.py
@@ -217,6 +217,7 @@ _DESCENDANT_RECONCILE_INTERVAL = 5.0
 _DESCENDANT_RECONCILE_REQUEST_TIMEOUT = 5.0
 _DESCENDANT_INTERRUPT_CONFIRM_TIMEOUT = 10.0
 _DESCENDANT_INTERRUPT_POLL_INTERVAL = 0.1
+_BACKGROUND_LIFECYCLE_ACTIVITY_INTERVAL = 60.0
 # A transient local app-server RPC failure is not evidence that a Goal ended.
 # Retry while retaining the exact CCM process generation; turn/Goal
 # notifications remain the fast path and invalidate the stale guard.
@@ -2188,6 +2189,10 @@ class _TurnContext:
     descendant_interrupt_lock: asyncio.Lock | None = None
     descendant_guard_task: asyncio.Task | None = None
     deferred_terminal_notification: dict[str, Any] | None = None
+    background_lifecycle_started_at: datetime | None = None
+    background_lifecycle_last_activity_at: datetime | None = None
+    background_lifecycle_last_published_monotonic: float | None = None
+    background_lifecycle_reason: str | None = None
     following_native_goal: bool = False
     pending_goal_terminal_notification: dict[str, Any] | None = None
     goal_terminal_generation: int = 0
@@ -3033,7 +3038,10 @@ class CodexAppServer:
     ) -> None:
         if not self._context_is_current(context):
             return
+        changed = thread_id not in context.active_descendant_thread_ids
         context.active_descendant_thread_ids.add(thread_id)
+        if changed:
+            self._publish_background_lifecycle_activity(context)
         self._signal_descendant_state_change(context)
 
     def _mark_descendant_terminal(
@@ -3041,8 +3049,69 @@ class CodexAppServer:
         context: _TurnContext,
         thread_id: str,
     ) -> None:
+        changed = thread_id in context.active_descendant_thread_ids
         context.active_descendant_thread_ids.discard(thread_id)
+        if changed:
+            self._publish_background_lifecycle_activity(context)
         self._signal_descendant_state_change(context)
+
+    def _publish_background_lifecycle(
+        self,
+        context: _TurnContext,
+        *,
+        state: str,
+        reason: str | None = None,
+        activity: bool = False,
+        force: bool = False,
+    ) -> None:
+        """Expose a retained native lifecycle without changing ownership."""
+
+        if not self._context_is_current(context):
+            return
+        now = datetime.utcnow()
+        if context.background_lifecycle_started_at is None:
+            context.background_lifecycle_started_at = now
+        if activity or state == "completed":
+            context.background_lifecycle_last_activity_at = now
+        if reason is not None:
+            context.background_lifecycle_reason = reason
+        monotonic_now = time.monotonic()
+        last_published = context.background_lifecycle_last_published_monotonic
+        if (
+            not force
+            and last_published is not None
+            and monotonic_now - last_published
+            < _BACKGROUND_LIFECYCLE_ACTIVITY_INTERVAL
+        ):
+            return
+        context.background_lifecycle_last_published_monotonic = monotonic_now
+        context.process.feed({
+            "type": "background.lifecycle",
+            "state": state,
+            "reason": context.background_lifecycle_reason,
+            "active_count": len(context.active_descendant_thread_ids),
+            "active_thread_ids": sorted(
+                context.active_descendant_thread_ids
+            ),
+            "started_at": context.background_lifecycle_started_at.isoformat(),
+            "last_activity_at": (
+                context.background_lifecycle_last_activity_at.isoformat()
+                if context.background_lifecycle_last_activity_at
+                else None
+            ),
+        })
+
+    def _publish_background_lifecycle_activity(
+        self,
+        context: _TurnContext,
+    ) -> None:
+        if context.background_lifecycle_started_at is None:
+            return
+        self._publish_background_lifecycle(
+            context,
+            state="running",
+            activity=True,
+        )
 
     def _contexts_tracking_descendant(
         self,
@@ -3630,6 +3699,13 @@ class CodexAppServer:
                 context.turn_id,
             )
             return
+        self._publish_background_lifecycle(
+            context,
+            state="running",
+            reason="waiting_for_descendants",
+            activity=True,
+            force=True,
+        )
         turn = params.get("turn") or {}
         runtime = self._thread_runtime.get(context.thread_id)
         goal_may_continue = bool(
@@ -3806,6 +3882,13 @@ class CodexAppServer:
         context.goal_terminal_generation += 1
         generation = context.goal_terminal_generation
         context.pending_goal_terminal_notification = dict(params)
+        self._publish_background_lifecycle(
+            context,
+            state="running",
+            reason="waiting_for_native_goal",
+            activity=True,
+            force=True,
+        )
         self._reset_goal_turn_identity(context)
         guard = asyncio.create_task(
             self._guard_native_goal_terminal(
@@ -3854,6 +3937,12 @@ class CodexAppServer:
 
         if not self._context_is_current(context):
             return
+        if context.background_lifecycle_started_at is not None:
+            self._publish_background_lifecycle(
+                context,
+                state="completed",
+                force=True,
+            )
         turn = params.get("turn") or {}
         terminal_turn_id = turn.get("id") or context.turn_id
         status = turn.get("status") or "completed"
@@ -7827,6 +7916,12 @@ class CodexAppServer:
             return
         thread_id = params.get("threadId")
         thread_id_str = str(thread_id) if thread_id else None
+        if thread_id_str is not None:
+            lifecycle_context = self._lineage_context_for_thread(thread_id_str)
+            if lifecycle_context is not None:
+                self._publish_background_lifecycle_activity(
+                    lifecycle_context,
+                )
         if method == "thread/goal/updated" and thread_id_str is not None:
             goal = params.get("goal")
             goal_status = (

--- a/backend/services/codex_app_server.py
+++ b/backend/services/codex_app_server.py
@@ -27,7 +27,7 @@ import uuid
 from collections import deque
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Sequence
 
@@ -3068,7 +3068,7 @@ class CodexAppServer:
 
         if not self._context_is_current(context):
             return
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         if context.background_lifecycle_started_at is None:
             context.background_lifecycle_started_at = now
         if activity or state == "completed":

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -13152,6 +13152,21 @@ class InstanceManager:
                 "content": "turn.completed",
                 "context_usage": self._codex_context_usage(usage) if usage else None,
             })
+        elif codex_type == "background.lifecycle":
+            event.update({
+                "event_type": "background_lifecycle",
+                "content": None,
+                "background_state": data.get("state"),
+                "background_reason": data.get("reason"),
+                "background_active_count": data.get("active_count"),
+                "background_active_thread_ids": data.get(
+                    "active_thread_ids"
+                ),
+                "background_started_at": data.get("started_at"),
+                "background_last_activity_at": data.get(
+                    "last_activity_at"
+                ),
+            })
         elif "error" in codex_type.lower() or data.get("error"):
             # turn.failed 形如 {"type":"turn.failed","error":{"message":...}}（实测）
             message = data.get("message")

--- a/backend/tests/test_codex_app_server.py
+++ b/backend/tests/test_codex_app_server.py
@@ -8267,6 +8267,12 @@ async def test_active_native_goal_keeps_process_across_continuation_turns():
     rows = []
     while line := await process.stdout.readline():
         rows.append(json.loads(line))
+    lifecycle_rows = [
+        row for row in rows if row.get("type") == "background.lifecycle"
+    ]
+    assert lifecycle_rows[0]["state"] == "running"
+    assert lifecycle_rows[-1]["state"] == "completed"
+    assert lifecycle_rows[0]["reason"] == "waiting_for_native_goal"
     assert any(
         row.get("delta") == "continuation output is visible"
         for row in rows
@@ -9076,6 +9082,8 @@ async def test_collab_agent_notifications_are_tool_items_not_terminal_noise():
     assert [line["type"] for line in lines] == [
         "item.started",
         "item.completed",
+        "background.lifecycle",
+        "background.lifecycle",
         "turn.completed",
     ]
     assert lines[0]["item"] == {
@@ -9091,7 +9099,10 @@ async def test_collab_agent_notifications_are_tool_items_not_terminal_noise():
     }
     assert lines[1]["item"]["type"] == "collab_agent_tool_call"
     assert lines[1]["item"]["status"] == "completed"
-    assert lines[2]["type"] == "turn.completed"
+    assert lines[2]["state"] == "running"
+    assert lines[2]["active_thread_ids"] == ["child-1"]
+    assert lines[3]["state"] == "completed"
+    assert lines[4]["type"] == "turn.completed"
     assert "child-1" not in server._contexts_by_descendant
 
 
@@ -9143,6 +9154,17 @@ async def test_parent_completed_waits_for_active_child_and_preserves_late_output
     assert process.returncode is None
     assert server.has_active_thread("thread-parent") is True
 
+    lifecycle = json.loads(await process.stdout.readline())
+    assert lifecycle == {
+        "type": "background.lifecycle",
+        "state": "running",
+        "reason": "waiting_for_descendants",
+        "active_count": 1,
+        "active_thread_ids": ["thread-child"],
+        "started_at": lifecycle["started_at"],
+        "last_activity_at": lifecycle["last_activity_at"],
+    }
+
     # The context remains attached after native parent completion, so a
     # notification already in the transport queue is delivered before EOF.
     server._handle_notification("item/agentMessage/delta", {
@@ -9162,9 +9184,11 @@ async def test_parent_completed_waits_for_active_child_and_preserves_late_output
         lines.append(json.loads(line))
     assert [line["type"] for line in lines] == [
         "item.agent_message.delta",
+        "background.lifecycle",
         "turn.completed",
     ]
     assert lines[0]["delta"] == "late but valid"
+    assert lines[1]["state"] == "completed"
     assert server._contexts_by_descendant == {}
 
 
@@ -9618,9 +9642,15 @@ async def test_descendant_terminal_deadline_holds_adapter_until_proven(
     lines = []
     while line := await process.stdout.readline():
         lines.append(json.loads(line))
-    assert [line["type"] for line in lines] == ["turn.failed"]
+    assert [line["type"] for line in lines] == [
+        "background.lifecycle",
+        "background.lifecycle",
+        "turn.failed",
+    ]
+    assert lines[0]["state"] == "running"
+    assert lines[1]["state"] == "completed"
     assert "could not prove all native sub-agents terminal" in (
-        lines[0]["error"]["message"]
+        lines[2]["error"]["message"]
     )
 
 

--- a/backend/tests/test_codex_app_server.py
+++ b/backend/tests/test_codex_app_server.py
@@ -9164,6 +9164,8 @@ async def test_parent_completed_waits_for_active_child_and_preserves_late_output
         "started_at": lifecycle["started_at"],
         "last_activity_at": lifecycle["last_activity_at"],
     }
+    assert lifecycle["started_at"].endswith("+00:00")
+    assert lifecycle["last_activity_at"].endswith("+00:00")
 
     # The context remains attached after native parent completion, so a
     # notification already in the transport queue is delivered before EOF.

--- a/backend/tests/test_message_pipeline.py
+++ b/backend/tests/test_message_pipeline.py
@@ -262,6 +262,29 @@ class TestStreamParserSystemEvents:
 # ========== InstanceManager._consume_output tests ==========
 
 
+def test_parse_codex_background_lifecycle_event():
+    im = InstanceManager(MagicMock(), MagicMock())
+
+    event = im._parse_codex_line(json.dumps({
+        "type": "background.lifecycle",
+        "state": "running",
+        "reason": "waiting_for_descendants",
+        "active_count": 2,
+        "active_thread_ids": ["child-a", "child-b"],
+        "started_at": "2026-08-13T12:00:00",
+        "last_activity_at": "2026-08-13T12:01:00",
+    }))
+
+    assert event is not None
+    assert event["event_type"] == "background_lifecycle"
+    assert event["background_state"] == "running"
+    assert event["background_reason"] == "waiting_for_descendants"
+    assert event["background_active_count"] == 2
+    assert event["background_active_thread_ids"] == ["child-a", "child-b"]
+    assert event["background_started_at"] == "2026-08-13T12:00:00"
+    assert event["background_last_activity_at"] == "2026-08-13T12:01:00"
+
+
 def _make_mock_process_with_output(lines: list[str], exit_code: int = 0):
     """Create a mock process that yields NDJSON lines from stdout."""
     proc = MagicMock()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -946,6 +946,7 @@ export interface ChatMessage {
   /** Native item metadata used for narrowly-scoped compatibility filtering. */
   native_item_type?: string | null;
   native_item_status?: string | null;
+  background_lifecycle?: BackgroundLifecycle | null;
   /** True when this row came from persisted chat history, not live optimism. */
   persisted?: boolean;
   // 权限透传卡片（event_type === 'permission_request' 时存在）
@@ -954,6 +955,15 @@ export interface ChatMessage {
   // ask_user 卡片（event_type === 'ask_user_question' 时存在）
   ask_questions?: AskUserQuestion[] | null;
   ask_status?: 'pending' | 'answered' | 'timed_out' | 'expired' | null;
+}
+
+export interface BackgroundLifecycle {
+  state: 'running' | 'completed';
+  reason: 'waiting_for_descendants' | 'waiting_for_native_goal' | string;
+  active_count: number;
+  active_thread_ids: string[];
+  started_at: string;
+  last_activity_at: string | null;
 }
 
 export interface CodexForkAnchor {

--- a/frontend/src/components/Chat/ChatView.test.tsx
+++ b/frontend/src/components/Chat/ChatView.test.tsx
@@ -3523,6 +3523,120 @@ describe('Codex app-server 增量消息', () => {
     expect(screen.getByText('Codex is thinking...')).toBeInTheDocument();
   });
 
+  it('replaces the thinking spinner with a retained Codex background lifecycle', async () => {
+    const task = makeTask({
+      id: 203,
+      provider: 'codex',
+      status: 'executing',
+      retry_count: 1,
+      turn_generation: 7,
+    });
+    render(<ChatView task={task} projects={projects} onBack={onBack} />);
+    await waitFor(() => expect(api.getTaskChatHistory).toHaveBeenCalled());
+
+    act(() => {
+      capturedOnMessage!({
+        channel: 'task:203',
+        data: {
+          id: 9001,
+          event_type: 'background_lifecycle',
+          background_state: 'running',
+          background_reason: 'waiting_for_descendants',
+          background_active_count: 2,
+          background_active_thread_ids: ['child-a', 'child-b'],
+          background_started_at: new Date().toISOString(),
+          background_last_activity_at: new Date().toISOString(),
+          task_retry_count: 1,
+          task_turn_generation: 7,
+        },
+      });
+    });
+
+    expect(screen.getByText('主回复已完成，后台仍在运行')).toBeInTheDocument();
+    expect(screen.getByText(/正在等待2 个子 Agent/)).toBeInTheDocument();
+    expect(screen.queryByText('Codex is thinking...')).not.toBeInTheDocument();
+  });
+
+  it('labels a retained background lifecycle stalled after 30 silent minutes', async () => {
+    const task = makeTask({
+      id: 204,
+      provider: 'codex',
+      status: 'executing',
+      retry_count: 0,
+      turn_generation: 3,
+    });
+    const oldActivity = new Date(Date.now() - 31 * 60_000).toISOString();
+    (api.getTaskChatHistory as ReturnType<typeof vi.fn>).mockResolvedValueOnce([{
+      id: 9002,
+      role: 'system',
+      event_type: 'background_lifecycle',
+      content: null,
+      tool_name: null,
+      tool_input: null,
+      tool_output: null,
+      is_error: false,
+      loop_iteration: null,
+      timestamp: oldActivity,
+      image_urls: null,
+      attachments: null,
+      task_retry_count: 0,
+      task_turn_generation: 3,
+      background_lifecycle: {
+        state: 'running',
+        reason: 'waiting_for_native_goal',
+        active_count: 0,
+        active_thread_ids: [],
+        started_at: oldActivity,
+        last_activity_at: oldActivity,
+      },
+    }]);
+
+    render(<ChatView task={task} projects={projects} onBack={onBack} />);
+
+    expect(await screen.findByText('后台任务可能停滞')).toBeInTheDocument();
+    expect(screen.getByText(/正在等待原生 Goal/)).toBeInTheDocument();
+  });
+
+  it('ignores a retained background lifecycle from an older task turn', async () => {
+    const task = makeTask({
+      id: 205,
+      provider: 'codex',
+      status: 'executing',
+      retry_count: 2,
+      turn_generation: 9,
+    });
+    const now = new Date().toISOString();
+    (api.getTaskChatHistory as ReturnType<typeof vi.fn>).mockResolvedValueOnce([{
+      id: 9003,
+      role: 'system',
+      event_type: 'background_lifecycle',
+      content: null,
+      tool_name: null,
+      tool_input: null,
+      tool_output: null,
+      is_error: false,
+      loop_iteration: null,
+      timestamp: now,
+      image_urls: null,
+      attachments: null,
+      task_retry_count: 1,
+      task_turn_generation: 8,
+      background_lifecycle: {
+        state: 'running',
+        reason: 'waiting_for_descendants',
+        active_count: 1,
+        active_thread_ids: ['old-child'],
+        started_at: now,
+        last_activity_at: now,
+      },
+    }]);
+
+    render(<ChatView task={task} projects={projects} onBack={onBack} />);
+
+    expect(await screen.findByText('Codex is thinking...')).toBeInTheDocument();
+    expect(screen.queryByText('主回复已完成，后台仍在运行')).not.toBeInTheDocument();
+  });
+
   it('drops old exact status, background, and context events after observing a newer turn', async () => {
     const task = makeTask({
       id: 202,

--- a/frontend/src/components/Chat/ChatView.test.tsx
+++ b/frontend/src/components/Chat/ChatView.test.tsx
@@ -12,6 +12,7 @@ vi.mock('../../api/client', () => ({
   ),
   api: {
     getTaskChatHistory: vi.fn().mockResolvedValue([]),
+    getTask: vi.fn(),
     sendTaskChat: vi.fn().mockResolvedValue({}),
     startFrontendReviewGoal: vi.fn().mockResolvedValue({
       status: 'pending',
@@ -328,6 +329,13 @@ describe('ChatView', () => {
     localStorage.clear();
     vi.clearAllMocks();
     (api.getTaskChatHistory as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (api.getTask as ReturnType<typeof vi.fn>).mockReset();
+    (api.getTask as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: 'executing',
+      background_active: false,
+      retry_count: 0,
+      turn_generation: 0,
+    } as Task);
     (api.getAskUserPending as ReturnType<typeof vi.fn>).mockResolvedValue({ pending: [] });
     (api.listForkAnchors as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     (api.listPlans as ReturnType<typeof vi.fn>).mockResolvedValue([]);
@@ -1583,6 +1591,100 @@ describe('ChatView', () => {
       });
       expect(screen.queryByText(/Goal Agent 第/)).not.toBeInTheDocument();
       expect(screen.queryByText(/is thinking/)).not.toBeInTheDocument();
+    });
+
+    it('reconciles a terminal task when process_exit arrives without status_change', async () => {
+      const task = makeTask({
+        id: 413,
+        status: 'executing',
+        retry_count: 2,
+        turn_generation: 11,
+      });
+      vi.mocked(api.getTask).mockImplementation(async (taskId) => (
+        taskId === 413
+          ? { ...task, status: 'completed', background_active: false }
+          : { ...task, id: taskId, status: 'executing' }
+      ));
+      render(
+        <ChatView
+          task={task}
+          projects={projects}
+          onBack={onBack}
+          onTaskUpdated={onTaskUpdated}
+        />,
+      );
+
+      expect(screen.getByText('Claude is thinking...')).toBeInTheDocument();
+      act(() => {
+        capturedOnMessage?.({
+          channel: 'task:413',
+          data: {
+            event_type: 'process_exit',
+            exit_code: 0,
+            task_retry_count: 2,
+            task_turn_generation: 11,
+          },
+        });
+      });
+
+      await waitFor(() => expect(api.getTask).toHaveBeenCalledWith(413), {
+        timeout: 1500,
+      });
+      await waitFor(() => {
+        expect(screen.queryByText('Claude is thinking...')).not.toBeInTheDocument();
+      });
+      expect(onTaskUpdated).toHaveBeenCalledWith(expect.objectContaining({
+        id: 413,
+        status: 'completed',
+      }));
+    });
+
+    it('does not apply process_exit reconciliation from an older generation', async () => {
+      const task = makeTask({
+        id: 414,
+        status: 'executing',
+        retry_count: 2,
+        turn_generation: 11,
+      });
+      vi.mocked(api.getTask).mockImplementation(async (taskId) => (
+        taskId === 414
+          ? {
+              ...task,
+              status: 'completed',
+              turn_generation: 12,
+              background_active: false,
+            }
+          : { ...task, id: taskId, status: 'executing' }
+      ));
+      render(
+        <ChatView
+          task={task}
+          projects={projects}
+          onBack={onBack}
+          onTaskUpdated={onTaskUpdated}
+        />,
+      );
+
+      act(() => {
+        capturedOnMessage?.({
+          channel: 'task:414',
+          data: {
+            event_type: 'process_exit',
+            exit_code: 0,
+            task_retry_count: 2,
+            task_turn_generation: 11,
+          },
+        });
+      });
+
+      await waitFor(() => expect(api.getTask).toHaveBeenCalledWith(414), {
+        timeout: 1500,
+      });
+      await waitFor(() => {
+        expect(screen.queryByText('正在确认任务状态...')).not.toBeInTheDocument();
+      });
+      expect(screen.getByText('Claude is thinking...')).toBeInTheDocument();
+      expect(onTaskUpdated).not.toHaveBeenCalled();
     });
 
     it('Task 运行时显示但禁用循环审查按钮', () => {

--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -495,6 +495,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
   const lastWsBackgroundAt = useRef(0);
   const [historyLoading, setHistoryLoading] = useState(true);
   const [interrupting, setInterrupting] = useState(false);
+  const [terminalReconciliationPending, setTerminalReconciliationPending] = useState(false);
   const [stillRunning, setStillRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [dropError, setDropError] = useState<string | null>(null);
@@ -536,6 +537,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
     if (incoming.taskId !== current.taskId) {
       clearLiveStreamCache(current.taskId, current);
       activeTaskTurnRef.current = incoming;
+      setTerminalReconciliationPending(false);
       setMessages(restoreLiveStreamCache(task));
       return;
     }
@@ -545,6 +547,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
 
     clearLiveStreamCache(task.id, current);
     activeTaskTurnRef.current = incoming;
+    setTerminalReconciliationPending(false);
     setMessages((previous) => {
       const next = removeOtherTurnProvisionals(previous, incoming);
       syncLiveStreamCache(incoming, next);
@@ -1320,6 +1323,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
     if (comparison > 0) {
       clearLiveStreamCache(current.taskId, current);
       activeTaskTurnRef.current = incoming;
+      setTerminalReconciliationPending(false);
     }
     return comparison;
   }, []);
@@ -1690,6 +1694,36 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
           refreshHistoryRef.current();
           return;
         }
+        // A process exit can arrive without its preceding terminal status
+        // event (for example during a WebSocket gap). Re-read the authoritative
+        // Task before clearing the exact generation, rather than leaving a
+        // stale executing prop rendering the generic thinking indicator.
+        setTerminalReconciliationPending(true);
+        void api.getTask(task.id).then((updated) => {
+          if (!sameTaskTurn(exitIdentity, activeTaskTurnRef.current)) return;
+          const updatedIdentity = taskTurnIdentity(updated);
+          if (!sameTaskTurn(exitIdentity, updatedIdentity)) {
+            observeTaskTurn(updatedIdentity);
+            return;
+          }
+          const terminal = ['completed', 'failed', 'cancelled', 'conflict']
+            .includes(updated.status);
+          if (terminal) {
+            setLocalStatus(updated.status);
+            setLocalBackgroundActive(updated.background_active === true);
+            setSending(false);
+            setStillRunning(false);
+            setAutoDequeueFlag(f => f + 1);
+            onTaskUpdated?.(updated);
+          }
+        }).catch(() => {
+          // Keep the existing status until the next poll; the UI uses a
+          // distinct reconciliation message while this request is unresolved.
+        }).finally(() => {
+          if (sameTaskTurn(exitIdentity, activeTaskTurnRef.current)) {
+            setTerminalReconciliationPending(false);
+          }
+        });
         setSending(false);
         setStillRunning(false);
         // Keep an already observed terminal status sticky. A late process_exit
@@ -1951,7 +1985,7 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
       syncLiveStreamCache(activeTaskTurnRef.current, next);
       return next;
     });
-  }, [markAskUserResolved, observeTaskTurn, refreshVersionedPlans, task.goal_max_turns, task.id, task.worker_id]);
+  }, [markAskUserResolved, observeTaskTurn, onTaskUpdated, refreshVersionedPlans, task.goal_max_turns, task.id, task.worker_id]);
 
   const fetchHistory = useCallback(() => {
     setHistoryLoading(true);
@@ -3468,6 +3502,8 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
               </div>
             ) : isWaitingCapability ? (
               <span>Waiting for requested capability...</span>
+            ) : terminalReconciliationPending ? (
+              <span>正在确认任务状态...</span>
             ) : (
               <span>{providerLabel} is thinking...</span>
             )}

--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -17,6 +17,7 @@ import type {
   TestHarnessRun,
   UploadResult,
   WorkspaceReviewCapabilities,
+  BackgroundLifecycle,
 } from '../../api/client';
 import { DEFAULT_BROWSER_CHANNEL } from '../../config/browserReview';
 import { useWebSocket } from '../../hooks/useWebSocket';
@@ -79,6 +80,31 @@ const WORKSPACE_REVIEW_START_TOOLS = new Set([
   'ccm_workspace_review.test_current_changes',
   'ccm_workspace_review.test_git_target',
 ]);
+
+const BACKGROUND_STALLED_AFTER_MS = 30 * 60 * 1000;
+const BACKGROUND_LONG_STALLED_AFTER_MS = 2 * 60 * 60 * 1000;
+
+function latestBackgroundLifecycle(
+  messages: ChatMessage[],
+  identity: TaskTurnIdentity,
+): BackgroundLifecycle | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!messageMatchesTaskTurn(message, identity)) continue;
+    const lifecycle = message.background_lifecycle;
+    if (lifecycle) return lifecycle;
+  }
+  return null;
+}
+
+function formatBackgroundSilence(milliseconds: number): string {
+  const minutes = Math.max(0, Math.floor(milliseconds / 60_000));
+  if (minutes < 1) return '刚刚';
+  if (minutes < 60) return `${minutes} 分钟前`;
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  return remainder ? `${hours} 小时 ${remainder} 分钟前` : `${hours} 小时前`;
+}
 
 function workspaceReviewGoalFromToolInput(rawInput: unknown): string | null {
   if (typeof rawInput !== 'string' || !rawInput.trim()) return null;
@@ -884,6 +910,19 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
   // A native agent/monitor tail can remain active while the owning foreground
   // turn is still `executing`; keep the marker independently visible.
   const isProcessing = sending || backgroundActive || ['in_progress', 'executing', 'waiting_capability'].includes(effectiveStatus);
+  const backgroundLifecycle = useMemo(
+    () => latestBackgroundLifecycle(messages, activeTaskTurnRef.current),
+    [messages, task.retry_count, task.turn_generation],
+  );
+  const [, refreshBackgroundAge] = useState(0);
+  useEffect(() => {
+    if (!backgroundLifecycle) return;
+    const timer = window.setInterval(
+      () => refreshBackgroundAge((generation) => generation + 1),
+      60_000,
+    );
+    return () => window.clearInterval(timer);
+  }, [backgroundLifecycle]);
   const workspaceReviewCanBeConfigured = (
     workspaceReviewCapability?.available === true
     || workspaceReviewCapability?.suggested_config != null
@@ -1388,6 +1427,41 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
     if (msg.channel !== `task:${task.id}` || !msg.data) return;
 
     const eventType = msg.data.event_type as string || (msg.data.event as string);
+    if (eventType === 'background_lifecycle') {
+      const identity = eventTaskTurnIdentity(msg.data, task.id);
+      if (!identity || observeTaskTurn(identity) < 0) return;
+      const lifecycle: BackgroundLifecycle = {
+        state: msg.data.background_state === 'completed' ? 'completed' : 'running',
+        reason: String(msg.data.background_reason || 'waiting_for_descendants'),
+        active_count: Math.max(0, Number(msg.data.background_active_count) || 0),
+        active_thread_ids: Array.isArray(msg.data.background_active_thread_ids)
+          ? msg.data.background_active_thread_ids.map(String)
+          : [],
+        started_at: String(msg.data.background_started_at || new Date().toISOString()),
+        last_activity_at: typeof msg.data.background_last_activity_at === 'string'
+          ? msg.data.background_last_activity_at
+          : null,
+      };
+      const persistedId = Number(msg.data.id);
+      const entry: ChatMessage = {
+        id: Number.isFinite(persistedId) && persistedId > 0
+          ? persistedId
+          : Date.now() + Math.random(),
+        role: 'system', event_type: 'background_lifecycle', content: null,
+        tool_name: null, tool_input: null, tool_output: null, is_error: false,
+        loop_iteration: null,
+        task_retry_count: identity.retryCount,
+        task_turn_generation: identity.turnGeneration,
+        timestamp: typeof msg.data.timestamp === 'string'
+          ? msg.data.timestamp
+          : new Date().toISOString(),
+        image_urls: null, attachments: null,
+        background_lifecycle: lifecycle,
+        persisted: Number.isFinite(persistedId) && persistedId > 0,
+      };
+      setMessages((previous) => mergeChatHistory([entry], previous));
+      return;
+    }
     if (eventType === 'goal_evaluation') {
       setFrontendReviewGoalProgress({
         turn: Number(msg.data.turn) || 0,
@@ -3342,7 +3416,47 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
             />
           )
         )}
-        {isProcessing && (
+        {isProcessing && backgroundLifecycle && (() => {
+          if (backgroundLifecycle.state === 'completed') {
+            return (
+              <div className="mx-3 flex items-center gap-2 rounded-lg border border-emerald-500/25 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-300">
+                <Check size={14} />
+                <span>后台任务已完成，正在收尾…</span>
+              </div>
+            );
+          }
+          const lastActivity = Date.parse(
+            backgroundLifecycle.last_activity_at || backgroundLifecycle.started_at,
+          );
+          const silenceMs = Number.isFinite(lastActivity)
+            ? Math.max(0, Date.now() - lastActivity)
+            : 0;
+          const longStalled = silenceMs >= BACKGROUND_LONG_STALLED_AFTER_MS;
+          const possiblyStalled = silenceMs >= BACKGROUND_STALLED_AFTER_MS;
+          const reason = backgroundLifecycle.reason === 'waiting_for_native_goal'
+            ? '原生 Goal'
+            : `${backgroundLifecycle.active_count} 个子 Agent`;
+          return (
+            <div className={`mx-3 rounded-lg border px-3 py-2 text-sm ${
+              longStalled
+                ? 'border-red-500/30 bg-red-500/10 text-red-300'
+                : possiblyStalled
+                  ? 'border-amber-500/30 bg-amber-500/10 text-amber-300'
+                  : 'border-sky-500/25 bg-sky-500/10 text-sky-300'
+            }`}>
+              <div className="flex items-center gap-2 font-medium">
+                {possiblyStalled
+                  ? <AlertCircle size={14} />
+                  : <Loader2 size={14} className="animate-spin" />}
+                <span>{possiblyStalled ? '后台任务可能停滞' : '主回复已完成，后台仍在运行'}</span>
+              </div>
+              <div className="mt-1 text-xs opacity-75">
+                正在等待{reason} · 最近活动 {formatBackgroundSilence(silenceMs)}
+              </div>
+            </div>
+          );
+        })()}
+        {isProcessing && !backgroundLifecycle && (
           <div className="flex gap-2 items-start text-gray-500 text-sm px-3">
             <Loader2 size={14} className="animate-spin" />
             {showFrontendReviewGoal ? (
@@ -4427,6 +4541,8 @@ const MessageBubble = memo(function MessageBubble({
   onAskUserResolved?: (requestId: string, status: 'answered' | 'expired') => void;
 }) {
   const isUser = message.role === 'user';
+
+  if (message.event_type === 'background_lifecycle') return null;
 
   if (message.event_type === 'permission_request') {
     return <PermissionCard message={message} taskId={taskId} />;


### PR DESCRIPTION
## Summary

- expose a generation-bound Codex background lifecycle when a parent turn finishes while native descendants or a Goal remain active
- replace the generic thinking indicator with running, inactive, and completed background states
- recover from a dropped terminal `status_change` by re-reading the authoritative Task after an exact-generation `process_exit`
- ignore stale lifecycle and exit reconciliation from older retry/turn generations

## Responsibility and state impact

- Primary responsibility: Codex runtime lifecycle and chat presentation
- Preserves Task as lifecycle/session authority and Instance as executor
- Does not shorten the existing four-hour fail-closed fence or release an Instance early
- No database schema change and no new cross-domain direct dependency
- Background activity persistence is throttled to at most once per minute

## Verification

- `pytest backend/tests/test_codex_app_server.py backend/tests/test_message_pipeline.py -q` — 355 passed, 3 skipped
- `npx vitest run src/components/Chat/ChatView.test.tsx` — 137 passed
- `npx tsc --noEmit` — passed
- `npm run build` — passed (existing large-chunk warning only)
- `git diff --check origin/main...HEAD` — passed
- isolated browser integration: real backend + built frontend + WebSocket `process_exit`, deliberately omitted `status_change`; UI re-read `/api/tasks/{id}` and removed `Codex is thinking...` after authoritative status became completed

## Notes

The isolated integration used a temporary SQLite database and port 18010, then removed both. Production and the shared 8010 test deployment were not modified by the integration run.