### PR TITLE
feat(delivery): default auto-merge to trusted mode

### DIFF
--- a/backend/api/delivery_runs.py
+++ b/backend/api/delivery_runs.py
@@ -285,6 +285,7 @@ async def create_run(
                 timeout_hours=body.timeout_hours,
                 max_cycles=body.max_cycles,
                 max_no_progress=body.max_no_progress,
+                strict_branch_protection=body.strict_branch_protection,
             ),
             admission_disabled_reason=admission_disabled_reason,
         )

--- a/backend/schemas/delivery.py
+++ b/backend/schemas/delivery.py
@@ -23,6 +23,8 @@ class DeliveryRunCreate(BaseModel):
     timeout_hours: float | None = Field(default=None, ge=0, le=168)
     max_cycles: int = Field(default=10, ge=1, le=100)
     max_no_progress: int = Field(default=3, ge=1, le=20)
+    # Trusted mode is the default for new Runs; historical Runs remain strict.
+    strict_branch_protection: bool = False
 
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/services/delivery_pr_policy.py
+++ b/backend/services/delivery_pr_policy.py
@@ -40,6 +40,7 @@ class FrozenDeliveryPRPolicy:
     terminal: str
     wait_for_ci: bool
     required_checks: list[dict]
+    strict_branch_protection: bool
 
 
 def has_reserved_delivery_marker(review: PRReview | None) -> bool:
@@ -271,6 +272,8 @@ async def frozen_delivery_pr_policy(
         raise DeliveryPRPolicyError("Delivery policy snapshot hash is invalid")
     auto_merge = policy.get("auto_merge")
     terminal = policy.get("terminal")
+    # Runs admitted before trusted mode existed keep the strict contract.
+    strict_branch_protection = policy.get("strict_branch_protection", True)
     monitor_policy = policy.get("pr_monitor")
     wait_for_ci = (
         monitor_policy.get("wait_for_ci")
@@ -290,6 +293,7 @@ async def frozen_delivery_pr_policy(
         or monitor_policy.get("repo_id") != review.repo_id
         or monitor_policy.get("review_mode") != "panel"
         or wait_for_ci is not True
+        or type(strict_branch_protection) is not bool
         or not isinstance(required_checks, list)
         or not required_checks
         or any(not isinstance(item, dict) for item in required_checks)
@@ -304,6 +308,7 @@ async def frozen_delivery_pr_policy(
         terminal=terminal,
         wait_for_ci=wait_for_ci,
         required_checks=required_checks,
+        strict_branch_protection=strict_branch_protection,
     )
 
 

--- a/backend/services/delivery_service.py
+++ b/backend/services/delivery_service.py
@@ -166,6 +166,7 @@ class DeliveryCreateSpec:
     timeout_hours: float | None = None
     max_cycles: int = 10
     max_no_progress: int = 3
+    strict_branch_protection: bool = False
 
 
 def _admission_scope(created_by: int | None) -> str:
@@ -218,6 +219,7 @@ def _admission_request(
         "timeout_hours": spec.timeout_hours,
         "max_cycles": spec.max_cycles,
         "max_no_progress": spec.max_no_progress,
+        "strict_branch_protection": spec.strict_branch_protection,
     }
 
 
@@ -531,6 +533,10 @@ async def create_delivery_run(
         raise DeliveryValidationError(
             "max_no_progress must be between 1 and 20"
         )
+    if type(spec.strict_branch_protection) is not bool:
+        raise DeliveryValidationError(
+            "strict_branch_protection must be a boolean"
+        )
 
     # Admission serializes with Project/PR Monitor identity mutations.  The
     # API mutation paths take the same rows before checking for an active Run,
@@ -637,6 +643,7 @@ async def create_delivery_run(
         "schema_version": 1,
         "terminal": "merged" if auto_merge else "ready_to_merge",
         "auto_merge": auto_merge,
+        "strict_branch_protection": spec.strict_branch_protection,
         "max_cycles": spec.max_cycles,
         "max_no_progress": spec.max_no_progress,
         "provider": resolved_provider,

--- a/backend/services/pr_review_service.py
+++ b/backend/services/pr_review_service.py
@@ -1499,6 +1499,36 @@ def _direct_merge_policy_error(detail: str) -> GhError:
     return GhError(f"Direct auto-merge protection policy is unsafe: {detail}")
 
 
+def _validate_direct_merge_permission(
+    permission: object,
+    *,
+    actor: str,
+) -> None:
+    if not isinstance(permission, dict):
+        raise _direct_merge_policy_error(
+            "publisher repository permission response is malformed"
+        )
+    role = permission.get("role_name")
+    user = permission.get("user")
+    permissions = user.get("permissions") if isinstance(user, dict) else None
+    if (
+        role not in _STANDARD_GITHUB_ROLES
+        or permission.get("permission") != _STANDARD_GITHUB_ROLES.get(role)
+        or not isinstance(user, dict)
+        or not isinstance(user.get("login"), str)
+        or user["login"].lower() != actor.lower()
+        or user.get("type") != "User"
+        or user.get("role_name") != role
+        or not isinstance(permissions, dict)
+        or permissions.get("push") is not True
+        or (role == "admin" and permissions.get("admin") is not True)
+        or (role == "maintain" and permissions.get("maintain") is not True)
+    ):
+        raise _direct_merge_policy_error(
+            "publisher must have a standard write, maintain, or admin role"
+        )
+
+
 def _validate_direct_merge_protection(
     protection: object,
     permission: object,
@@ -1509,6 +1539,7 @@ def _validate_direct_merge_protection(
     frozen_required_checks: object = None,
     exact_ci: object = None,
     head_sha: str | None = None,
+    strict_branch_protection: bool = True,
 ) -> None:
     """Validate the classic protection contract for a frozen-ref update."""
 
@@ -1757,35 +1788,7 @@ def _validate_direct_merge_protection(
             "merge commits conflict with required linear history"
         )
 
-    if not isinstance(permission, dict):
-        raise _direct_merge_policy_error(
-            "publisher repository permission response is malformed"
-        )
-    role = permission.get("role_name")
-    user = permission.get("user")
-    permissions = user.get("permissions") if isinstance(user, dict) else None
-    if (
-        role not in _STANDARD_GITHUB_ROLES
-        or permission.get("permission") != _STANDARD_GITHUB_ROLES.get(role)
-        or not isinstance(user, dict)
-        or not isinstance(user.get("login"), str)
-        or user["login"].lower() != actor.lower()
-        or user.get("type") != "User"
-        or user.get("role_name") != role
-        or not isinstance(permissions, dict)
-        or permissions.get("push") is not True
-        or (
-            role == "admin"
-            and permissions.get("admin") is not True
-        )
-        or (
-            role == "maintain"
-            and permissions.get("maintain") is not True
-        )
-    ):
-        raise _direct_merge_policy_error(
-            "publisher must have a standard write, maintain, or admin role"
-        )
+    _validate_direct_merge_permission(permission, actor=actor)
 
 
 def _github_not_found(exc: GhError) -> bool:
@@ -1817,18 +1820,12 @@ async def _require_direct_merge_protection(
         or "\r" in base_ref
     ):
         raise _direct_merge_policy_error("configured base branch is invalid")
+    if type(strict_branch_protection) is not bool:
+        raise _direct_merge_policy_error(
+            "strict branch-protection mode is malformed"
+        )
     branch = quote(base_ref, safe="")
     username = quote(actor, safe="")
-    try:
-        protection = await _gh_api_json(
-            f"repos/{repo_name}/branches/{branch}/protection"
-        )
-    except GhError as exc:
-        if _github_not_found(exc):
-            raise _direct_merge_policy_error(
-                "the base branch has no classic protection"
-            ) from exc
-        raise
     try:
         permission = await _gh_api_json(
             f"repos/{repo_name}/collaborators/{username}/permission"
@@ -1837,6 +1834,19 @@ async def _require_direct_merge_protection(
         if _github_not_found(exc):
             raise _direct_merge_policy_error(
                 "the publisher is not a standard repository collaborator"
+            ) from exc
+        raise
+    if not strict_branch_protection:
+        _validate_direct_merge_permission(permission, actor=actor)
+        return
+    try:
+        protection = await _gh_api_json(
+            f"repos/{repo_name}/branches/{branch}/protection"
+        )
+    except GhError as exc:
+        if _github_not_found(exc):
+            raise _direct_merge_policy_error(
+                "the base branch has no classic protection"
             ) from exc
         raise
     try:
@@ -2740,6 +2750,7 @@ async def _publish_review_action(
     wait_for_ci: bool = False,
     required_checks: list[dict] | None = None,
     ensure_zero_threads: Callable[[], Awaitable[bool]] | None = None,
+    strict_branch_protection: bool = True,
 ) -> tuple[str, str]:
     """Reconcile or perform one durable, head-pinned GitHub publication."""
 
@@ -2796,6 +2807,7 @@ async def _publish_review_action(
                 base_ref=base_ref,
                 actor=actor,
                 merge_method=merge_method,
+                strict_branch_protection=strict_branch_protection,
             )
 
         if result == "review_comments":
@@ -3017,6 +3029,7 @@ async def _publish_review_action(
             frozen_required_checks=(required_checks if wait_for_ci else None),
             exact_ci=exact_ci,
             head_sha=(head_sha if wait_for_ci else None),
+            strict_branch_protection=strict_branch_protection,
         )
         # CI and thread reconciliation may take long enough for the base ref
         # to move. Re-read the complete subject at the last possible boundary;
@@ -4936,6 +4949,11 @@ async def _resume_publishing_review_under_lease(
     except DeliveryPRPolicyError as exc:
         delivery_policy = None
         delivery_policy_error = str(exc)
+    strict_branch_protection = (
+        delivery_policy.strict_branch_protection
+        if delivery_policy is not None
+        else True
+    )
     valid = (
         delivery_policy_error is None
         and repo is not None
@@ -5090,6 +5108,7 @@ async def _resume_publishing_review_under_lease(
             wait_for_ci=frozen_wait_for_ci,
             required_checks=frozen_required_checks,
             ensure_zero_threads=(ensure_zero_threads if panel_task else None),
+            strict_branch_protection=strict_branch_protection,
         )
     except GhError as exc:
         logger.error(

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1520,6 +1520,7 @@ export interface DeliveryRunCreate {
   timeout_hours?: number | null;
   max_cycles?: number;
   max_no_progress?: number;
+  strict_branch_protection?: boolean;
 }
 
 export interface RequiredCheckPolicy {

--- a/frontend/src/components/Delivery/DeliveryCreateForm.tsx
+++ b/frontend/src/components/Delivery/DeliveryCreateForm.tsx
@@ -20,6 +20,7 @@ export function DeliveryCreateForm({ projects, repos, config, onCreated, onNavig
   const [title, setTitle] = useState('');
   const [requirements, setRequirements] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [strictBranchProtection, setStrictBranchProtection] = useState(false);
   const [error, setError] = useState('');
   const project = projects.find((item) => item.id === projectId);
   const providerOptions = useMemo(() => config?.provider_options || [], [config?.provider_options]);
@@ -51,6 +52,7 @@ export function DeliveryCreateForm({ projects, repos, config, onCreated, onNavig
       model: provider === 'codex' ? config.default_codex_model : config.default_model,
       codex_service_tier: provider === 'codex' ? (config.default_codex_service_tier || 'default') : 'default',
       effort_level: config.default_effort,
+      strict_branch_protection: strictBranchProtection,
     } as const;
     const request = prepareDeliveryAdmission(`delivery-page:${project.id}`, draft);
     setSubmitting(true);
@@ -96,6 +98,12 @@ export function DeliveryCreateForm({ projects, repos, config, onCreated, onNavig
         <input aria-label="Delivery title" value={title} onChange={(event) => setTitle(event.target.value)} maxLength={200} required placeholder="What should this Delivery accomplish?" className="rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 outline-none focus:border-indigo-500" />
       </div>
       <textarea aria-label="Delivery requirements" value={requirements} onChange={(event) => setRequirements(event.target.value)} required rows={4} placeholder="Describe requirements and acceptance criteria…" className="mt-3 w-full resize-y rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 outline-none focus:border-indigo-500" />
+      {repo?.auto_merge && (
+        <label className="mt-3 flex cursor-pointer items-start gap-3 rounded-lg border border-gray-800 bg-gray-950/50 px-3 py-2.5">
+          <input aria-label="Require strict GitHub branch protection" type="checkbox" checked={strictBranchProtection} onChange={(event) => setStrictBranchProtection(event.target.checked)} className="mt-0.5 h-4 w-4 rounded border-gray-600 bg-gray-800 text-indigo-600" />
+          <span><span className="block text-xs font-medium text-gray-200">Strict branch-protection mode</span><span className="mt-0.5 block text-[11px] leading-4 text-gray-500">Off by default. Trusted mode still requires exact CI, Panel findings and GitHub write permission; enable this only when GitHub Branch Protection must also be proved.</span></span>
+        </label>
+      )}
       {project && repo && <div className="mt-3 flex flex-wrap gap-x-5 gap-y-1 rounded-lg border border-gray-800 bg-gray-950/50 px-3 py-2 text-[11px] text-gray-500"><span>Repository <b className="text-gray-300">{repo.repo_full_name}</b></span><span>Branch <b className="text-gray-300">{project.default_branch}</b></span><span>Provider <b className="text-gray-300">{repo.provider}</b></span><span>Completion <b className="text-gray-300">{repo.auto_merge ? 'merged' : 'ready to merge'}</b></span></div>}
       {disabledReason && <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-xs leading-5 text-amber-300"><AlertCircle size={14} className="mt-0.5 shrink-0" /><div>{disabledReason}<div className="mt-1 flex gap-3"><button type="button" onClick={onNavigateProjects} className="underline underline-offset-2">Open Projects</button><button type="button" onClick={onNavigatePRMonitor} className="underline underline-offset-2">Open PR Monitor</button></div></div></div>}
       {error && <div className="mt-3 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-300">{error}</div>}


### PR DESCRIPTION
## Summary
- make trusted mode the default for new Delivery Runs
- add an opt-in strict branch-protection switch in the Delivery form
- freeze the selected mode into each Delivery policy snapshot
- keep historical Runs and ordinary PR Monitor publication strict
- in trusted mode, retain exact-head CI, Panel finding, PR identity, ancestry, and GitHub write-permission gates

## Compatibility
- existing Delivery policies without the new field default to strict mode
- no database migration is required because the setting is frozen in the existing JSON policy snapshot

## Validation
- Python syntax validation passed for all modified backend files
- full CI requested on this PR