### PR TITLE
fix: verify instance process identity across restarts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ claude-manager/
 │       ├── plan_agent_runner.py # 严格只读 Planner/Reviewer pipeline + exact process cleanup
 │       ├── plan_tasks.py        # Plan 上下文快照、repo 指纹、stale/附件校验
 │       ├── plan_service.py      # Version 状态机、输入/审批、执行 Task 物化与 Worker outcome 导入
+│       ├── process_identity.py  # 跨平台 PID/start/boot 身份读取与重启存活校验
 │       ├── capability_service.py # 通用 Capability 持久状态、CAS 与取消协议
 │       ├── capability_coordinator.py # Capability executor 恢复/调度器
 │       ├── plan_capability.py   # Plan Pipeline 的通用 Capability adapter
@@ -227,6 +228,7 @@ claude-manager/
 - **优先级**: 数字越小优先级越高 (P0 > P1 > P2)，排序用 `.asc()`
 - **Session 绑定**: `session_id` 和 `last_cwd` 在 **Task** 上（不是 Instance），因为 instance 是轮换执行不同 task 的 worker
 - **Instance 并发容量**: `max_concurrent_instances` 约束所有仍有运行证据的实例：默认取环境变量，`GlobalSettings.max_concurrent_instances` 可由管理员 Settings/API 持久覆盖并热更新，NULL 恢复环境默认；调度、补槽和 Instance API 必须统一读取 Dispatcher effective capacity。正常 `idle/running` 会占槽，`error/stopped` 仅在 PID 与反向 owner 证据都已清除后才是免费历史。API 创建与 Dispatcher 补槽共用 `instance_capacity_lock`，idle 选择到 launch 之间用 owner reservation；运行时下调 cap 不强杀现有 turn，但在占用降到 cap 以下前禁止新领取，升高后立即补槽并 wake。Task retry 可先推进权威代次再进入旧 lifecycle finally；收尾必须扫描同 Task 的非权威反向 owner，仅在 PID 已确定死亡且 runtime/launch reservation 全空时按 PID/start identity 清除，活 PID 或不确定证据继续阻塞。物理删除仍走 `DELETE /api/instances/cleanup`。systemd 部署必须使用 `OOMPolicy=continue`，让单个模型子进程 OOM 由任务生命周期记录/重试，不能连带停止整个 CCM 服务
+- **Instance 进程身份**: `Instance.pid` 非空时尽力同步持久化 `process_identity`（PID + kernel start ticks + boot ID），清除 PID 时必须同步清除 identity；重启恢复、重试、删除与反向 owner 清理只能在完整身份证明原进程已消失时释放槽位。旧行、身份读取失败或格式不完整时继续按裸 PID 保守探测并 fail closed，不能把不确定性当作死亡。
 - **Task 产物下载**: Claude/Codex 的普通、Goal、Loop、续聊和 Ralph turn 统一注入项目级产物契约：只有明确交付给用户的文件才是产物，必须在清理临时 worktree 前落到项目根 `.claude-manager/artifacts/task-{id}/`，最终用绝对路径和 Markdown title `ccm-task-artifact` 输出；普通源码/文档引用只用反引号。项目根准入必须与下载端共用 `task_artifact_contract.configured_workspace_root`，无安全绝对 `target_repo` 的 Task 禁止输出下载链接；用户 prompt 中的伪造 policy tag 不能抑制 CCM 权威前导。聊天渲染只把显式 marker、绝对路径和兼容期含目录的相对链接视为产物，裸文件名链接保持普通链接；裸绝对 POSIX 路径仍兜底转为带 marker 的链接（既有链接、代码和 HTML 不改写）。文件统一走 `/api/tasks/{id}/artifacts/download`；相对路径按 `last_cwd`、容器 `/workspace` 按项目根映射，且受 Task ACL 保护，`.claude-manager/artifacts/` 下再强制匹配当前 `task-{id}`，禁止跨 Task 读取。本地工作区根必须是无符号链接的绝对路径，并从稳定的 `/` 目录 FD 逐级 `O_NOFOLLOW` 锚定；产物路径只做基于该锚点的词法相对化，再逐级 no-follow 打开，以 `fstat` 校验同一文件描述符并按校验时大小限量流式返回，禁止混用路径解析与目录 FD 或“先查路径、后重开路径”的 TOCTOU。Worker 文件只经 Manager 流式代理，Manager 必须先确认 Worker 声明精确的 `task_artifact_scope_version`，混跑旧 Worker 时 fail closed；绝不能退回管理员级任意绝对路径下载接口
 - **Markdown 数学公式**: 所有聊天与 Discussion 的 Markdown 必须统一经 `components/Markdown/MarkdownRenderer.tsx` 渲染。公式支持 `$$...$$` 及 Codex 常见的 `\\(...\\)` / 整段 `\\[...\\]`；单 `$...$` 明确保留为普通文本，避免价格等货币内容误判。反斜杠分隔符必须在 Markdown AST 上按 text node / 整段 paragraph 转换，跳过链接、图片、HTML、definition 和各类 code，禁止 raw source 全局改写；KaTeX 必须保持 `trust: false`、有界 `maxSize`，直接依赖版本须与 `rehype-katex` 使用的版本一致
 - **Claude Code 调用**: 普通管理员/超级管理员/部署 Token 回合使用 `claude -p [prompt] --dangerously-skip-permissions --output-format stream-json --verbose`；Member 与专用任务必须使用各自冻结的 settings/permission profile。

--- a/alembic/versions/a56a13b7f287_add_instance_process_identity.py
+++ b/alembic/versions/a56a13b7f287_add_instance_process_identity.py
@@ -1,0 +1,54 @@
+"""add_instance_process_identity
+
+Adds kernel process identity evidence beside ``instances.pid`` so a bare PID
+number is never treated as proof that a managed generation is still running.
+
+``process_identity`` holds an opaque ``v1:<pid>:<start_ticks>:<boot_id>``
+value: the kernel-reported start time plus the boot session the PID was
+observed in. Together they let recovery distinguish "this exact process is
+still alive" from "this PID number was reused by an unrelated process", which
+a bare ``kill(pid, 0)`` probe cannot do.
+
+The PID is embedded in the value so a writer that updates ``pid`` without
+refreshing this column yields a mismatch that reads as unusable evidence
+rather than as proof of death.
+
+The column is nullable: rows written by an older binary carry no identity
+evidence and must keep the previous conservative fail-closed behaviour.
+
+Revision ID: a56a13b7f287
+Revises: a7d4e9c2f610
+Create Date: 2026-08-15 11:59:57.462549
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a56a13b7f287'
+down_revision: Union[str, None] = 'f4c7a9d2e610'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("instances", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("process_identity", sa.String(length=128), nullable=True)
+        )
+        batch_op.create_check_constraint(
+            "ck_instances_process_identity_requires_pid",
+            "process_identity IS NULL OR pid IS NOT NULL",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("instances", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "ck_instances_process_identity_requires_pid",
+            type_="check",
+        )
+        batch_op.drop_column("process_identity")

--- a/backend/api/instances.py
+++ b/backend/api/instances.py
@@ -18,8 +18,10 @@ from backend.services.instance_capacity import (
     instance_capacity_lock,
     occupied_slot_predicate,
 )
-from backend.services.task_queue import persisted_pid_is_definitively_dead
 from backend.services.pr_review_runtime import is_pr_sandbox_task
+from backend.services.process_identity import (
+    persisted_process_is_definitively_dead,
+)
 
 router = APIRouter(
     prefix="/api/instances",
@@ -51,6 +53,11 @@ def _instance_generation_predicates(instance: Instance) -> list:
             Instance.pid.is_(None)
             if instance.pid is None
             else Instance.pid == instance.pid
+        ),
+        (
+            Instance.process_identity.is_(None)
+            if instance.process_identity is None
+            else Instance.process_identity == instance.process_identity
         ),
         (
             Instance.started_at.is_(None)
@@ -96,15 +103,26 @@ async def _reconcile_dead_terminal_pid(
     The caller must hold InstanceManager's lifecycle lock. The exact status,
     PID and task owner predicates keep a stale cleanup request from clearing a
     newer generation that changed while the OS probe was in progress.
+
+    Death is proven from the full recorded identity (PID, start ticks and boot
+    id) so a reused PID number cannot keep a dead generation pinned forever.
     """
 
     pid = instance.pid
-    if pid is None or not persisted_pid_is_definitively_dead(pid):
+    if pid is None or not persisted_process_is_definitively_dead(
+        pid,
+        instance.process_identity,
+    ):
         return False
     predicates = [
         Instance.id == instance.id,
         Instance.status == instance.status,
         Instance.pid == pid,
+        (
+            Instance.process_identity.is_(None)
+            if instance.process_identity is None
+            else Instance.process_identity == instance.process_identity
+        ),
     ]
     if instance.current_task_id is None:
         predicates.append(Instance.current_task_id.is_(None))
@@ -124,7 +142,12 @@ async def _reconcile_dead_terminal_pid(
     reconciled = await db.execute(
         update(Instance)
         .where(*predicates)
-        .values(pid=None, current_task_id=None, current_plan_run_id=None)
+        .values(
+            pid=None,
+            process_identity=None,
+            current_task_id=None,
+            current_plan_run_id=None,
+        )
     )
     await db.commit()
     return bool(reconciled.rowcount)

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -69,6 +69,9 @@ from backend.services.pr_review_runtime import (
     is_pr_review_task,
     is_pr_sandbox_task,
 )
+from backend.services.process_identity import (
+    persisted_process_liveness,
+)
 from backend.services.task_skill_overrides import (
     clear_temporary_skills_marker,
 )
@@ -5236,29 +5239,29 @@ async def _retry_local_task_under_harness_owner_fence(
                         "generation; stop it before retrying"
                     ),
                 )
-
             pid = instance.pid
             if pid is not None:
-                try:
-                    os.kill(pid, 0)
-                except ProcessLookupError:
-                    pass
-                except OSError:
-                    # Permission errors and platform-specific failures do not
-                    # prove death. Keep all ownership evidence fail-closed.
-                    raise HTTPException(
-                        status_code=409,
-                        detail=(
-                            f"Unmanaged process PID {pid} may still be alive; "
-                            "stop or reconcile it before retrying"
-                        ),
-                    )
-                else:
+                # Compare the whole recorded identity, not just the PID number:
+                # after PID reuse or a host restart an unrelated process can
+                # answer to it and pin this task as un-retryable forever.
+                liveness = persisted_process_liveness(
+                    pid,
+                    instance.process_identity,
+                )
+                if liveness == "alive":
                     raise HTTPException(
                         status_code=409,
                         detail=(
                             f"Unmanaged process PID {pid} is still alive; "
                             "stop it before retrying"
+                        ),
+                    )
+                if liveness != "dead":
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            f"Unmanaged process PID {pid} may still be alive; "
+                            "stop or reconcile it before retrying"
                         ),
                     )
             elif instance.status == "running":
@@ -5276,6 +5279,11 @@ async def _retry_local_task_under_harness_owner_fence(
                 Instance.status == instance.status,
                 (Instance.pid.is_(None) if pid is None else Instance.pid == pid),
                 (
+                    Instance.process_identity.is_(None)
+                    if instance.process_identity is None
+                    else Instance.process_identity == instance.process_identity
+                ),
+                (
                     Instance.started_at.is_(None)
                     if instance.started_at is None
                     else Instance.started_at == instance.started_at
@@ -5284,7 +5292,12 @@ async def _retry_local_task_under_harness_owner_fence(
             cleared = await db.execute(
                 sa_update(Instance)
                 .where(*instance_predicates)
-                .values(status="error", current_task_id=None, pid=None)
+                .values(
+                    status="error",
+                    current_task_id=None,
+                    pid=None,
+                    process_identity=None,
+                )
             )
             if not cleared.rowcount:
                 await db.rollback()

--- a/backend/models/instance.py
+++ b/backend/models/instance.py
@@ -13,11 +13,27 @@ class Instance(Base):
             "NOT (current_task_id IS NOT NULL AND current_plan_run_id IS NOT NULL)",
             name="ck_instances_task_xor_plan_run_owner",
         ),
+        CheckConstraint(
+            "process_identity IS NULL OR pid IS NOT NULL",
+            name="ck_instances_process_identity_requires_pid",
+        ),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     pid: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # Opaque kernel identity ("v1:<pid>:<start_ticks>:<boot_id>") for the
+    # process in `pid`. A PID number alone cannot distinguish "this exact
+    # process is still alive" from "an unrelated process reused this number",
+    # so recovery probes compare the start time and boot session too.
+    # The PID is embedded in the value, so a writer that sets `pid` without
+    # refreshing this column produces a mismatch that reads as "unusable"
+    # rather than as proof of death. NULL means the row predates identity
+    # capture or the platform could not supply it; both stay fail-closed.
+    # Always write and clear this together with `pid`.
+    process_identity: Mapped[str | None] = mapped_column(
+        String(128), nullable=True
+    )
     status: Mapped[str] = mapped_column(String(20), default="idle")
     current_task_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     current_plan_run_id: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -61,6 +61,9 @@ from backend.services.instance_manager import (
     InstanceAlreadyRunningError,
     InstanceManager,
 )
+from backend.services.process_identity import (
+    persisted_process_is_definitively_dead,
+)
 from backend.services.process_safety import require_safe_process_group_id
 from backend.services.pr_review_runtime import (
     is_pr_sandbox_task,
@@ -2990,6 +2993,13 @@ class GlobalDispatcher:
                     # sides of this exact Task/Instance evidence.
                     live_task_ids.add(inst.current_task_id)
                     continue
+                # A bare ``os.kill(pid, 0)`` cannot tell this generation from an
+                # unrelated process that inherited the number after PID reuse
+                # or a host restart, so compare the recorded start ticks and
+                # boot id too. Rows persisted before those columns existed have
+                # no identity to compare and stay conservatively fail closed.
+                # A NULL PID records no process at all, so there is nothing to
+                # probe and nothing that can still be alive.
                 pid_may_be_alive = False
                 if inst.pid is not None:
                     codex_transport_pids = getattr(
@@ -3003,15 +3013,10 @@ class GlobalDispatcher:
                         else set()
                     )
                     if inst.pid not in live_transport_pids:
-                        try:
-                            os.kill(inst.pid, 0)
-                            pid_may_be_alive = True
-                        except ProcessLookupError:
-                            pass
-                        except OSError:
-                            # Anything other than a definitive ESRCH is uncertain
-                            # and therefore fail-closed against duplicate writes.
-                            pid_may_be_alive = True
+                        pid_may_be_alive = not persisted_process_is_definitively_dead(
+                            inst.pid,
+                            inst.process_identity,
+                        )
                 logger.warning(
                     "Quarantining unowned instance %s (%s), persisted PID %s%s",
                     inst.id,
@@ -3368,7 +3373,11 @@ class GlobalDispatcher:
                     # A definitively dead/no-PID generation is safe to detach.
                     # For an uncertain live PID, retain both links as evidence
                     # so retry/cleanup can continue to block duplicate work.
-                    quarantine_values.update(current_task_id=None, pid=None)
+                    quarantine_values.update(
+                        current_task_id=None,
+                        pid=None,
+                        process_identity=None,
+                    )
                 quarantined = await db.execute(
                     update(Instance)
                     .where(
@@ -3381,6 +3390,12 @@ class GlobalDispatcher:
                         Instance.status == inst.status,
                         Instance.current_task_id == inst.current_task_id,
                         Instance.pid == inst.pid,
+                        (
+                            Instance.process_identity.is_(None)
+                            if inst.process_identity is None
+                            else Instance.process_identity
+                            == inst.process_identity
+                        ),
                         (
                             Instance.started_at.is_(None)
                             if inst.started_at is None
@@ -5257,6 +5272,7 @@ class GlobalDispatcher:
                 current_plan_run_id=run.id,
                 current_task_id=None,
                 pid=None,
+                process_identity=None,
                 started_at=now,
             )
         )
@@ -12674,6 +12690,7 @@ class GlobalDispatcher:
                             ),
                             current_task_id=None,
                             pid=None,
+                            process_identity=None,
                         )
                     )
                     if not instance_reset.rowcount:

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -38,6 +38,10 @@ from backend.services.cancellation import (
     finish_awaitable,
 )
 from backend.services.codex_models import clamp_codex_effort
+from backend.services.process_identity import (
+    capture_process_identity,
+    persisted_process_is_definitively_dead,
+)
 from backend.services.process_safety import require_safe_process_group_id
 from backend.services.stream_parser import StreamParser
 from backend.services.task_queue import task_retry_not_superseded_predicate
@@ -5419,6 +5423,7 @@ class InstanceManager:
                     .where(*instance_identity)
                     .values(
                         pid=process.pid,
+                        process_identity=capture_process_identity(process.pid),
                         status="running",
                         current_task_id=task_id,
                         provider=provider,
@@ -5556,6 +5561,7 @@ class InstanceManager:
                                 .values(
                                     status="idle",
                                     pid=None,
+                                    process_identity=None,
                                     current_task_id=None,
                                 )
                             )
@@ -5566,6 +5572,9 @@ class InstanceManager:
                                 .values(
                                     status="error",
                                     pid=getattr(process, "pid", None),
+                                    process_identity=capture_process_identity(
+                                        getattr(process, "pid", None)
+                                    ),
                                     current_task_id=task_id,
                                 )
                             )
@@ -6938,6 +6947,7 @@ class InstanceManager:
                     .where(*instance_identity)
                     .values(
                         pid=pid,
+                        process_identity=capture_process_identity(pid),
                         status="running",
                         current_task_id=task_id,
                         provider="claude",
@@ -7147,6 +7157,7 @@ class InstanceManager:
                                 .values(
                                     status="idle",
                                     pid=None,
+                                    process_identity=None,
                                     current_task_id=None,
                                 )
                             )
@@ -7157,6 +7168,9 @@ class InstanceManager:
                                 .values(
                                     status="error",
                                     pid=(getattr(process, "pid", None) or None),
+                                    process_identity=capture_process_identity(
+                                        getattr(process, "pid", None) or None
+                                    ),
                                     current_task_id=task_id,
                                 )
                             )
@@ -9924,6 +9938,9 @@ class InstanceManager:
                 .values(
                     status="running",
                     pid=(getattr(process, "pid", 0) or 0),
+                    process_identity=capture_process_identity(
+                        getattr(process, "pid", 0) or 0
+                    ),
                     current_task_id=task_id,
                     provider="claude",
                 )
@@ -10153,8 +10170,11 @@ class InstanceManager:
             task.completed_at = None
             task.error_message = None
             task.pty_background_generation = generation
+
+            pid = getattr(process, "pid", 0) or 0
             instance.status = "running"
-            instance.pid = getattr(process, "pid", 0) or 0
+            instance.pid = pid
+            instance.process_identity = capture_process_identity(pid)
             instance.current_task_id = task_id
             instance.provider = "claude"
             await db.flush()
@@ -10325,6 +10345,7 @@ class InstanceManager:
                             else "error"
                         ),
                         pid=None,
+                        process_identity=None,
                         current_task_id=None,
                     )
                 )
@@ -11010,6 +11031,7 @@ class InstanceManager:
                             .values(
                                 status=recovery_status,
                                 pid=None,
+                                process_identity=None,
                                 current_task_id=None,
                             )
                         )
@@ -11035,6 +11057,9 @@ class InstanceManager:
                             .values(
                                 status="error",
                                 pid=getattr(process, "pid", None),
+                                process_identity=capture_process_identity(
+                                    getattr(process, "pid", None)
+                                ),
                                 current_task_id=task_id,
                             )
                         )
@@ -12149,6 +12174,7 @@ class InstanceManager:
                 .values(
                     status=new_status,
                     pid=None,
+                    process_identity=None,
                     current_task_id=None,
                 )
             )
@@ -16286,6 +16312,9 @@ class InstanceManager:
                         .values(
                             status="error",
                             pid=getattr(process, "pid", None),
+                            process_identity=capture_process_identity(
+                                getattr(process, "pid", None)
+                            ),
                             current_task_id=task_id,
                         )
                     )
@@ -16677,18 +16706,16 @@ class InstanceManager:
         )
 
     @staticmethod
-    def _pid_is_definitely_gone(pid: int | None) -> bool:
-        """Return True only when the OS proves an exact PID no longer exists."""
+    def _pid_is_definitely_gone(
+        pid: int | None,
+        persisted_identity: str | None,
+    ) -> bool:
+        """Return True only when the exact persisted process is gone."""
 
-        if not isinstance(pid, int) or pid <= 0:
-            return False
-        try:
-            os.kill(pid, 0)
-        except ProcessLookupError:
-            return True
-        except (PermissionError, OSError):
-            return False
-        return False
+        return persisted_process_is_definitively_dead(
+            pid,
+            persisted_identity,
+        )
 
     async def reconcile_dead_reverse_task_owner(
         self,
@@ -16757,7 +16784,36 @@ class InstanceManager:
                 ) is not None
             ):
                 return False
-            if not self._pid_is_definitely_gone(expected_pid):
+            # Snapshot the identity from the same exact reverse-owner row. The
+            # later writer predicate repeats it, so a concurrent generation
+            # cannot lend its boot/start proof to this cleanup decision.
+            async with self.db_factory() as identity_db:
+                identity_row = (
+                    await identity_db.execute(
+                        select(Instance.process_identity).where(
+                            Instance.id == instance_id,
+                            Instance.current_task_id == expected_task_id,
+                            (
+                                Instance.pid.is_(None)
+                                if expected_pid is None
+                                else Instance.pid == expected_pid
+                            ),
+                            (
+                                Instance.started_at.is_(None)
+                                if expected_started_at is None
+                                else Instance.started_at == expected_started_at
+                            ),
+                        )
+                    )
+                ).one_or_none()
+                await identity_db.rollback()
+            if identity_row is None:
+                return False
+            expected_process_identity = identity_row.process_identity
+            if not self._pid_is_definitely_gone(
+                expected_pid,
+                expected_process_identity,
+            ):
                 return False
 
             async with self.db_factory() as db:
@@ -16776,6 +16832,12 @@ class InstanceManager:
                         Instance.started_at.is_(None)
                         if expected_started_at is None
                         else Instance.started_at == expected_started_at
+                    ),
+                    (
+                        Instance.process_identity.is_(None)
+                        if expected_process_identity is None
+                        else Instance.process_identity
+                        == expected_process_identity
                     ),
                 ]
                 lease_valid_at = (
@@ -16827,10 +16889,17 @@ class InstanceManager:
                             else Instance.started_at
                             == expected_started_at
                         ),
+                        (
+                            Instance.process_identity.is_(None)
+                            if expected_process_identity is None
+                            else Instance.process_identity
+                            == expected_process_identity
+                        ),
                     )
                     .values(
                         status="idle",
                         pid=None,
+                        process_identity=None,
                         current_task_id=None,
                     )
                 )
@@ -17153,7 +17222,8 @@ class InstanceManager:
                                     is not _EXPECTED_GENERATION_UNSET
                                     and owner.pid == expected_pid
                                     and self._pid_is_definitely_gone(
-                                        expected_pid
+                                        expected_pid,
+                                        owner.process_identity,
                                     )
                                 )
                                 or self._has_reapable_pty_background_state(
@@ -18265,6 +18335,7 @@ class InstanceManager:
                         "error" if task_status == "failed" else "idle"
                     ),
                     pid=None,
+                    process_identity=None,
                     current_task_id=None,
                 )
             )

--- a/backend/services/plan_runtime_receipt.py
+++ b/backend/services/plan_runtime_receipt.py
@@ -22,6 +22,7 @@ from backend.models.plan_agent import (
     PlanAgentRuntimeReceipt,
     PlanAgentStep,
 )
+from backend.services import process_identity
 from backend.services.process_safety import require_safe_process_group_id
 
 
@@ -75,53 +76,17 @@ def _darwin_libproc():
 
 @lru_cache(maxsize=1)
 def _darwin_boot_session_uuid() -> str:
-    library = ctypes.CDLL("/usr/lib/libSystem.B.dylib", use_errno=True)
-    library.sysctlbyname.argtypes = [
-        ctypes.c_char_p,
-        ctypes.c_void_p,
-        ctypes.POINTER(ctypes.c_size_t),
-        ctypes.c_void_p,
-        ctypes.c_size_t,
-    ]
-    library.sysctlbyname.restype = ctypes.c_int
-    name = b"kern.bootsessionuuid"
-    length = ctypes.c_size_t()
-    ctypes.set_errno(0)
-    if library.sysctlbyname(
-        name,
-        None,
-        ctypes.byref(length),
-        None,
-        0,
-    ) != 0:
-        error = ctypes.get_errno()
-        raise PlanRuntimeReceiptError(
-            f"Could not read Darwin boot identity: {os.strerror(error)}"
-        )
-    if not 1 <= length.value <= 128:
-        raise PlanRuntimeReceiptError("Darwin boot identity has an invalid size")
-    payload = ctypes.create_string_buffer(length.value)
-    ctypes.set_errno(0)
-    if library.sysctlbyname(
-        name,
-        payload,
-        ctypes.byref(length),
-        None,
-        0,
-    ) != 0:
-        error = ctypes.get_errno()
-        raise PlanRuntimeReceiptError(
-            f"Could not read Darwin boot identity: {os.strerror(error)}"
-        )
+    """Delegate to the shared boot-identity primitive.
+
+    ``process_identity`` owns the ``kern.bootsessionuuid`` read for every
+    caller. Only the error taxonomy is translated here so durable Plan
+    runtime callers keep failing closed on ``PlanRuntimeReceiptError``.
+    """
+
     try:
-        value = payload.raw[: length.value].rstrip(b"\0").decode("ascii").lower()
-    except UnicodeDecodeError as exc:
-        raise PlanRuntimeReceiptError(
-            "Darwin boot identity is not ASCII"
-        ) from exc
-    if not _is_canonical_boot_id(value):
-        raise PlanRuntimeReceiptError("Darwin boot identity has an invalid format")
-    return value
+        return process_identity.darwin_boot_session_uuid()
+    except process_identity.ProcessIdentityError as exc:
+        raise PlanRuntimeReceiptError(str(exc)) from exc
 
 
 class PlanRuntimeReceiptError(RuntimeError):
@@ -192,12 +157,7 @@ def _is_int_at_least(value: object, minimum: int) -> bool:
 
 
 def _is_canonical_boot_id(value: object) -> bool:
-    if not isinstance(value, str) or len(value) != 36:
-        return False
-    try:
-        return str(uuid.UUID(value)) == value
-    except (ValueError, AttributeError):
-        return False
+    return process_identity.is_canonical_boot_id(value)
 
 
 def _is_runtime_token(value: object) -> bool:

--- a/backend/services/process_identity.py
+++ b/backend/services/process_identity.py
@@ -1,0 +1,408 @@
+"""Shared process identity verification for Instance and Plan runtime probes.
+
+This module provides PID identity readers that prevent false-positive detection
+after PID reuse or host restart. It shares Darwin/Linux process-identity logic
+between Instance lifecycle (Dispatcher/InstanceManager/TaskQueue) and Plan
+runtime receipts without creating import cycles.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import os
+import sys
+import uuid
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+
+class ProcessIdentityError(RuntimeError):
+    """Exact process identity could not be read or verified."""
+
+
+@dataclass(frozen=True)
+class ProcessIdentity:
+    """Exact POSIX process identity for safe PID reuse detection."""
+
+    pid: int
+    start_ticks: int
+    boot_id: str
+    uid: int | None = None
+    process_group_id: int | None = None
+    state: str | None = None
+
+
+class _DarwinProcBsdInfo(ctypes.Structure):
+    """Stable PROC_PIDTBSDINFO prefix for Darwin PID identity."""
+
+    _fields_ = [
+        ("pbi_flags", ctypes.c_uint32),
+        ("pbi_status", ctypes.c_uint32),
+        ("pbi_xstatus", ctypes.c_uint32),
+        ("pbi_pid", ctypes.c_uint32),
+        ("pbi_ppid", ctypes.c_uint32),
+        ("pbi_uid", ctypes.c_uint32),
+        ("pbi_gid", ctypes.c_uint32),
+        ("pbi_ruid", ctypes.c_uint32),
+        ("pbi_rgid", ctypes.c_uint32),
+        ("pbi_svuid", ctypes.c_uint32),
+        ("pbi_svgid", ctypes.c_uint32),
+        ("rfu_1", ctypes.c_uint32),
+        ("pbi_comm", ctypes.c_char * 16),
+        ("pbi_name", ctypes.c_char * 32),
+        ("pbi_nfiles", ctypes.c_uint32),
+        ("pbi_pgid", ctypes.c_uint32),
+        ("pbi_pjobc", ctypes.c_uint32),
+        ("e_tdev", ctypes.c_uint32),
+        ("e_tpgid", ctypes.c_uint32),
+        ("pbi_nice", ctypes.c_int32),
+        ("pbi_start_tvsec", ctypes.c_uint64),
+        ("pbi_start_tvusec", ctypes.c_uint64),
+    ]
+
+
+@lru_cache(maxsize=1)
+def _darwin_libproc():
+    library = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+    library.proc_pidinfo.argtypes = [
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_uint64,
+        ctypes.c_void_p,
+        ctypes.c_int,
+    ]
+    library.proc_pidinfo.restype = ctypes.c_int
+    return library
+
+
+@lru_cache(maxsize=1)
+def _read_boot_id() -> str:
+    """Return current boot session UUID for this host."""
+
+    if sys.platform == "darwin":
+        return _darwin_boot_session_uuid()
+    try:
+        value = (
+            Path("/proc/sys/kernel/random/boot_id")
+            .read_text(encoding="utf-8")
+            .strip()
+            .lower()
+        )
+    except OSError as exc:
+        raise ProcessIdentityError(
+            f"Could not read Linux boot identity: {exc}"
+        ) from exc
+    if not _is_canonical_boot_id(value):
+        raise ProcessIdentityError("Linux boot identity has an invalid format")
+    return value
+
+
+@lru_cache(maxsize=1)
+def _darwin_boot_session_uuid() -> str:
+    library = ctypes.CDLL("/usr/lib/libSystem.B.dylib", use_errno=True)
+    library.sysctlbyname.argtypes = [
+        ctypes.c_char_p,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+    ]
+    library.sysctlbyname.restype = ctypes.c_int
+    name = b"kern.bootsessionuuid"
+    length = ctypes.c_size_t()
+    ctypes.set_errno(0)
+    if library.sysctlbyname(name, None, ctypes.byref(length), None, 0) != 0:
+        error = ctypes.get_errno()
+        raise ProcessIdentityError(
+            f"Could not read Darwin boot identity: {os.strerror(error)}"
+        )
+    if not 1 <= length.value <= 128:
+        raise ProcessIdentityError("Darwin boot identity has an invalid size")
+    payload = ctypes.create_string_buffer(length.value)
+    ctypes.set_errno(0)
+    if library.sysctlbyname(
+        name, payload, ctypes.byref(length), None, 0
+    ) != 0:
+        error = ctypes.get_errno()
+        raise ProcessIdentityError(
+            f"Could not read Darwin boot identity: {os.strerror(error)}"
+        )
+    try:
+        value = (
+            payload.raw[: length.value]
+            .rstrip(b"\0")
+            .decode("ascii")
+            .lower()
+        )
+    except UnicodeDecodeError as exc:
+        raise ProcessIdentityError(
+            "Darwin boot identity is not ASCII"
+        ) from exc
+    if not _is_canonical_boot_id(value):
+        raise ProcessIdentityError("Darwin boot identity has an invalid format")
+    return value
+
+
+def darwin_boot_session_uuid() -> str:
+    """Public accessor for the Darwin ``kern.bootsessionuuid`` read.
+
+    A boot session UUID cannot change without a reboot, which would end this
+    process, so the underlying read is cached for the process lifetime.
+    """
+
+    return _darwin_boot_session_uuid()
+
+
+def is_canonical_boot_id(value: object) -> bool:
+    """Return True when ``value`` is a canonical lowercase UUID boot id."""
+
+    return _is_canonical_boot_id(value)
+
+
+def _is_canonical_boot_id(value: object) -> bool:
+    if not isinstance(value, str) or len(value) != 36:
+        return False
+    try:
+        return str(uuid.UUID(value)) == value
+    except (ValueError, AttributeError):
+        return False
+
+
+def read_process_identity(pid: int) -> ProcessIdentity | None:
+    """Read exact POSIX PID identity without following filesystem links.
+
+    Returns None if the process does not exist. Raises ProcessIdentityError
+    for permission failures or platform-specific read failures that cannot
+    prove the process is gone.
+    """
+
+    if type(pid) is not int or pid <= 1:
+        raise ProcessIdentityError(f"Unsafe PID {pid!r}")
+
+    if sys.platform == "darwin":
+        return _read_darwin_process_identity(pid)
+
+    proc_dir = Path("/proc") / str(pid)
+    try:
+        metadata = proc_dir.stat()
+        raw = (proc_dir / "stat").read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise ProcessIdentityError(
+            f"Could not read process identity for PID {pid}: {exc}"
+        ) from exc
+
+    separator = raw.rfind(") ")
+    if separator < 0:
+        raise ProcessIdentityError(f"Could not parse PID {pid}")
+    fields = raw[separator + 2 :].split()
+    if len(fields) <= 19:
+        raise ProcessIdentityError(f"PID {pid} identity is incomplete")
+
+    try:
+        state = fields[0]
+        process_group_id = int(fields[2])
+        start_ticks = int(fields[19])
+    except (TypeError, ValueError) as exc:
+        raise ProcessIdentityError(
+            f"PID {pid} identity is invalid"
+        ) from exc
+
+    return ProcessIdentity(
+        pid=pid,
+        process_group_id=process_group_id,
+        start_ticks=start_ticks,
+        uid=metadata.st_uid,
+        boot_id=_read_boot_id(),
+        state=state,
+    )
+
+
+def _read_darwin_process_identity(pid: int) -> ProcessIdentity | None:
+    info = _DarwinProcBsdInfo()
+    expected_size = ctypes.sizeof(info)
+    ctypes.set_errno(0)
+    result = _darwin_libproc().proc_pidinfo(
+        pid,
+        3,  # PROC_PIDTBSDINFO
+        0,
+        ctypes.byref(info),
+        expected_size,
+    )
+    if result == 0:
+        error = ctypes.get_errno()
+        if error in {0, errno.ENOENT, errno.ESRCH}:
+            return None
+        raise ProcessIdentityError(
+            f"Could not read process identity for PID {pid}: "
+            f"{os.strerror(error)}"
+        )
+    if result != expected_size or info.pbi_pid != pid:
+        raise ProcessIdentityError(f"PID {pid} identity is incomplete")
+
+    start_ticks = (
+        int(info.pbi_start_tvsec) * 1_000_000 + int(info.pbi_start_tvusec)
+    )
+    if start_ticks <= 0:
+        raise ProcessIdentityError(f"PID {pid} start identity is invalid")
+
+    # Darwin's pbi_status uses SZOMB=5
+    state = "Z" if int(info.pbi_status) == 5 else "R"
+
+    return ProcessIdentity(
+        pid=pid,
+        process_group_id=int(info.pbi_pgid),
+        start_ticks=start_ticks,
+        uid=int(info.pbi_uid),
+        boot_id=_read_boot_id(),
+        state=state,
+    )
+
+
+_IDENTITY_PREFIX = "v1"
+
+
+def encode_process_identity(identity: ProcessIdentity) -> str:
+    """Serialize identity for persistence beside a PID column.
+
+    The PID is encoded *inside* the value on purpose. A caller that writes a
+    new PID without refreshing this column leaves an identity whose embedded
+    PID no longer matches, which ``persisted_process_is_definitively_dead``
+    treats as unusable rather than as proof of death. That makes a missed
+    write site degrade to the conservative legacy probe instead of silently
+    authorizing duplicate execution.
+    """
+
+    return (
+        f"{_IDENTITY_PREFIX}:{identity.pid}:"
+        f"{identity.start_ticks}:{identity.boot_id}"
+    )
+
+
+def capture_process_identity(pid: int | None) -> str | None:
+    """Return an encoded identity for ``pid``, or None when unavailable.
+
+    Never raises: identity is an optimization that lets recovery prove a PID
+    is dead. When it cannot be read, callers persist the PID alone and stay
+    fail-closed exactly as they did before identity capture existed.
+    """
+
+    if pid is None or type(pid) is not int or pid <= 1:
+        return None
+    try:
+        identity = read_process_identity(pid)
+    except Exception:
+        # This helper runs in the launch persistence path. Platform/ctypes
+        # surprises must disable the stronger recovery evidence, never turn a
+        # successful subprocess spawn into a failed Task launch.
+        return None
+    if identity is None:
+        return None
+    return encode_process_identity(identity)
+
+
+def decode_process_identity(
+    persisted_identity: str | None,
+    pid: int,
+) -> tuple[int, str] | None:
+    """Return ``(start_ticks, boot_id)`` when the identity is usable for ``pid``.
+
+    Returns None when the value is absent, malformed, or was recorded for a
+    different PID, meaning the caller must fall back to a conservative probe.
+    """
+
+    if not isinstance(persisted_identity, str):
+        return None
+    parts = persisted_identity.split(":")
+    if len(parts) != 4 or parts[0] != _IDENTITY_PREFIX:
+        return None
+    try:
+        persisted_pid = int(parts[1])
+        start_ticks = int(parts[2])
+    except ValueError:
+        return None
+    boot_id = parts[3]
+    if persisted_pid != pid or start_ticks <= 0:
+        return None
+    if not _is_canonical_boot_id(boot_id):
+        return None
+    return start_ticks, boot_id
+
+
+def persisted_process_liveness(
+    pid: int | None,
+    persisted_identity: str | None,
+) -> str:
+    """Classify a persisted PID as ``dead``, ``alive`` or ``unknown``.
+
+    ``dead``     the exact recorded process is provably gone.
+    ``alive``    a process answering this PID was positively observed.
+    ``unknown``  death could not be proven; treat as still owning its work.
+
+    Both ``alive`` and ``unknown`` are fail-closed for destructive cleanup.
+    They are distinguished only so operator-facing messages can say whether a
+    live process was actually seen, which changes what a human should do next.
+    """
+
+    if pid is None or type(pid) is not int or pid <= 0:
+        return "unknown"
+
+    decoded = decode_process_identity(persisted_identity, pid)
+    if decoded is None:
+        # No usable identity (legacy row, unreadable at launch, or recorded
+        # for a different PID). Fall back to the bare probe.
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return "dead"
+        except PermissionError:
+            # Someone else's process answers to this PID; it is alive.
+            return "alive"
+        except OSError as exc:
+            return "dead" if exc.errno == errno.ESRCH else "unknown"
+        return "alive"
+
+    persisted_start_ticks, persisted_boot_id = decoded
+
+    # A different boot session proves the recorded process cannot survive:
+    # every process from the previous boot died with it.
+    try:
+        current_boot_id = _read_boot_id()
+    except Exception:
+        return "unknown"
+    if current_boot_id != persisted_boot_id:
+        return "dead"
+
+    try:
+        current_identity = read_process_identity(pid)
+    except Exception:
+        return "unknown"
+    if current_identity is None:
+        return "dead"
+
+    # The PID answers, but a different start time proves it was reused by an
+    # unrelated process, so the recorded generation is gone.
+    if current_identity.start_ticks != persisted_start_ticks:
+        return "dead"
+    return "alive"
+
+
+def persisted_process_is_definitively_dead(
+    pid: int | None,
+    persisted_identity: str | None,
+) -> bool:
+    """Return True only when the exact recorded process is provably gone.
+
+    This replaces the bare ``os.kill(pid, 0)`` probe, which cannot tell "this
+    exact process is still alive" from "an unrelated process reused this PID
+    number" and therefore pins tasks as permanently un-retryable after a host
+    restart or PID wraparound.
+
+    False means the recorded process may still be alive, or that death cannot
+    be proven safely; destructive cleanup must preserve the owner evidence.
+    """
+
+    return persisted_process_liveness(pid, persisted_identity) == "dead"

--- a/backend/services/task_queue.py
+++ b/backend/services/task_queue.py
@@ -1,5 +1,3 @@
-import errno
-import os
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime
@@ -16,6 +14,9 @@ from backend.models.test_harness import TestHarnessChildBinding
 from backend.models.task_ssh_grant import TaskSSHGrant
 from backend.models.user import User
 from backend.models.worker_task_termination import WorkerTaskTerminationReceipt
+from backend.services.process_identity import (
+    persisted_process_is_definitively_dead,
+)
 from backend.services.task_creation import (
     purge_task_access_grants,
     stage_task_record,
@@ -333,25 +334,6 @@ def task_is_pr_review_superseded(task: Task | None) -> bool:
     )
 
 
-def persisted_pid_is_definitively_dead(pid: int) -> bool:
-    """Return True only when a signal-free PID probe proves ``ESRCH``.
-
-    A successful ``kill(pid, 0)`` means the process still exists. Permission
-    failures and every other probe error are uncertain, so destructive
-    cleanup must preserve the persisted PID/owner evidence and fail closed.
-    """
-
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return True
-    except OSError as exc:
-        return exc.errno == errno.ESRCH
-    except Exception:
-        return False
-    return False
-
-
 TaskGenerationFence = tuple[
     int,
     int | None,
@@ -391,7 +373,7 @@ class TestHarnessDeleteGraph:
     evidence_storage_keys: tuple[str, ...]
     child_tasks: tuple[tuple[int, str, str, int, int], ...]
     child_instances: tuple[
-        tuple[int, int, str, int | None, datetime | None], ...
+        tuple[int, int, str, int | None, str | None, datetime | None], ...
     ]
 
 
@@ -642,7 +624,10 @@ async def _lock_test_harness_delete_graph(
                     instance.pid is not None
                     and (
                         instance.status not in {"error", "stopped"}
-                        or not persisted_pid_is_definitively_dead(instance.pid)
+                        or not persisted_process_is_definitively_dead(
+                            instance.pid,
+                            instance.process_identity,
+                        )
                     )
                 )
             ):
@@ -741,6 +726,7 @@ async def _lock_test_harness_delete_graph(
                 int(instance.current_task_id),
                 instance.status,
                 instance.pid,
+                instance.process_identity,
                 instance.started_at,
             )
             for instance in child_instances
@@ -766,12 +752,24 @@ async def _delete_test_harness_graph(
     )
     from backend.models.workspace_review import WorkspaceReviewRun
 
-    for instance_id, child_task_id, status, pid, started_at in graph.child_instances:
+    for (
+        instance_id,
+        child_task_id,
+        status,
+        pid,
+        process_identity,
+        started_at,
+    ) in graph.child_instances:
         predicates = [
             Instance.id == instance_id,
             Instance.current_task_id == child_task_id,
             Instance.status == status,
             Instance.pid.is_(None) if pid is None else Instance.pid == pid,
+            (
+                Instance.process_identity.is_(None)
+                if process_identity is None
+                else Instance.process_identity == process_identity
+            ),
             (
                 Instance.started_at.is_(None)
                 if started_at is None
@@ -781,7 +779,11 @@ async def _delete_test_harness_graph(
         detached = await db.execute(
             update(Instance)
             .where(*predicates)
-            .values(current_task_id=None, pid=None)
+            .values(
+                current_task_id=None,
+                pid=None,
+                process_identity=None,
+            )
         )
         if detached.rowcount != 1:
             raise RuntimeError(
@@ -1914,7 +1916,10 @@ class TaskQueue:
                 continue
             if (
                 instance.status not in ("error", "stopped")
-                or not persisted_pid_is_definitively_dead(instance.pid)
+                or not persisted_process_is_definitively_dead(
+                    instance.pid,
+                    instance.process_identity,
+                )
             ):
                 await self.db.rollback()
                 return False
@@ -1930,6 +1935,11 @@ class TaskQueue:
             else:
                 predicates.append(Instance.pid == instance.pid)
             predicates.append(
+                Instance.process_identity.is_(None)
+                if instance.process_identity is None
+                else Instance.process_identity == instance.process_identity
+            )
+            predicates.append(
                 Instance.started_at.is_(None)
                 if instance.started_at is None
                 else Instance.started_at == instance.started_at
@@ -1937,7 +1947,11 @@ class TaskQueue:
             detached = await self.db.execute(
                 update(Instance)
                 .where(*predicates)
-                .values(current_task_id=None, pid=None)
+                .values(
+                    current_task_id=None,
+                    pid=None,
+                    process_identity=None,
+                )
             )
             if not detached.rowcount:
                 await self.db.rollback()

--- a/backend/tests/test_alembic_migrations.py
+++ b/backend/tests/test_alembic_migrations.py
@@ -110,6 +110,7 @@ WORKER_DESTROY_LIFECYCLE_NONCE_REVISION = "b4e1c7d9f203"
 WORKER_RENAME_TAG_OUTBOX_REVISION = "c4a8e2f6b190"
 PR_MONITOR_TASK_TOMBSTONE_REVISION = "e2a4c6f8b1d3"
 DELIVERY_PR_MONITOR_MERGE_REVISION = "f4c7a9d2e610"
+INSTANCE_PROCESS_IDENTITY_REVISION = "a56a13b7f287"
 CAPABILITY_CORE_REVISION = "6a4c2e9f1b73"
 CODE_REVIEW_REVISION = "8d4e1f7a9c20"
 DELIVERY_LOOP_REVISION = "9e5b2a7c4d10"
@@ -120,7 +121,7 @@ PLAN_RUNTIME_RECEIPT_REVISION = "8d2f5b7a1c90"
 WORKER_PLAN_DISPATCH_RECEIPT_REVISION = "a6e4c2d9f810"
 WORKER_TASK_DELETE_RECEIPT_REVISION = "b7f3d1a8c920"
 WORKER_PLAN_IMPORT_RECEIPT_REVISION = "d3c8a7f1e620"
-CURRENT_HEAD_REVISION = DELIVERY_PR_MONITOR_MERGE_REVISION
+CURRENT_HEAD_REVISION = INSTANCE_PROCESS_IDENTITY_REVISION
 
 
 def _alembic_cfg(db_path: str) -> Config:
@@ -3508,6 +3509,23 @@ class TestLegacyMigration:
         assert "attention_tag" in task_cols
         assert "delivery_run_id" in task_cols
         assert "delivery_role" in task_cols
+
+        instance_cols = _get_table_columns(engine, "instances")
+        assert instance_cols["process_identity"] == "VARCHAR(128)"
+        instance_checks = {
+            item["name"]
+            for item in inspect(engine).get_check_constraints("instances")
+        }
+        assert "ck_instances_process_identity_requires_pid" in instance_checks
+        with pytest.raises(IntegrityError):
+            with engine.begin() as conn:
+                conn.execute(
+                    text(
+                        "INSERT INTO instances (name, pid, process_identity) "
+                        "VALUES ('invalid-identity', NULL, 'v1:123:456:"
+                        "11111111-1111-4111-8111-111111111111')"
+                    )
+                )
         assert "turn_generation" in task_cols
         assert "capability_policy" in task_cols
 
@@ -8160,6 +8178,42 @@ class TestFreshMigration:
 
         engine.dispose()
 
+    def test_instance_process_identity_revision_roundtrips(self, tmp_path):
+        """The new Instance identity column owns a reversible linear step."""
+
+        db_path = str(tmp_path / "instance-process-identity-roundtrip.db")
+        cfg = _alembic_cfg(db_path)
+        _run_alembic(cfg, command.upgrade, DELIVERY_FRONTEND_REVIEW_REVISION)
+
+        engine = create_engine(f"sqlite:///{db_path}")
+        assert "process_identity" not in _get_table_columns(engine, "instances")
+        engine.dispose()
+
+        _run_alembic(cfg, command.upgrade, INSTANCE_PROCESS_IDENTITY_REVISION)
+        engine = create_engine(f"sqlite:///{db_path}")
+        assert (
+            _get_table_columns(engine, "instances")["process_identity"]
+            == "VARCHAR(128)"
+        )
+        engine.dispose()
+
+        _run_alembic(cfg, command.downgrade, DELIVERY_FRONTEND_REVIEW_REVISION)
+        engine = create_engine(f"sqlite:///{db_path}")
+        assert "process_identity" not in _get_table_columns(engine, "instances")
+        with engine.connect() as conn:
+            assert (
+                conn.execute(
+                    text("SELECT version_num FROM alembic_version")
+                ).scalar_one()
+                == DELIVERY_FRONTEND_REVIEW_REVISION
+            )
+        engine.dispose()
+
+        _run_alembic(cfg, command.upgrade, INSTANCE_PROCESS_IDENTITY_REVISION)
+        engine = create_engine(f"sqlite:///{db_path}")
+        assert "process_identity" in _get_table_columns(engine, "instances")
+        engine.dispose()
+
     def test_fresh_db_downgrade_and_upgrade(self, tmp_path):
         """Migrations are reversible: upgrade → downgrade → upgrade."""
         db_path = str(tmp_path / "roundtrip.db")
@@ -10525,6 +10579,18 @@ class TestPublishedMigrationHistory:
                 REMOVE_AGENT_SANDBOX_OVERRIDE_REVISION
             ).down_revision
             == DELIVERY_FRONTEND_REVIEW_REVISION
+        )
+        assert (
+            script.get_revision(
+                INSTANCE_PROCESS_IDENTITY_REVISION
+            ).down_revision
+            == DELIVERY_PR_MONITOR_MERGE_REVISION
+        )
+        assert (
+            script.get_revision(
+                DELIVERY_PR_MONITOR_MERGE_REVISION
+            ).down_revision
+            == PR_MONITOR_TASK_TOMBSTONE_REVISION
         )
         assert (
             script.get_revision(DELIVERY_FRONTEND_REVIEW_REVISION).down_revision

--- a/backend/tests/test_api_instances.py
+++ b/backend/tests/test_api_instances.py
@@ -1,6 +1,7 @@
 """Tests for Instance and Dispatcher API endpoints."""
 import asyncio
 import json
+import os
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -310,7 +311,7 @@ async def test_delete_instance_reconciles_definitively_dead_pid(
         patch("backend.main.instance_manager", mock_im),
         patch("backend.main.ralph_loop", mock_rl),
         patch(
-            "backend.services.task_queue.os.kill",
+            "backend.services.process_identity.os.kill",
             side_effect=ProcessLookupError,
         ) as probe,
     ):
@@ -345,7 +346,7 @@ async def test_delete_instance_preserves_pid_that_may_be_alive(
     with (
         patch("backend.main.instance_manager", mock_im),
         patch("backend.main.ralph_loop", mock_rl),
-        patch("backend.services.task_queue.os.kill", return_value=None),
+        patch("backend.services.process_identity.os.kill", return_value=None),
     ):
         response = await client.delete(f"/api/instances/{instance_id}")
 
@@ -355,6 +356,87 @@ async def test_delete_instance_preserves_pid_that_may_be_alive(
         instance = await db.get(Instance, instance_id)
         assert instance.pid == 45672
         assert instance.current_task_id == task_id
+
+
+@pytest.mark.asyncio
+async def test_delete_instance_frees_slot_when_pid_is_from_a_previous_boot(
+    client, session_factory,
+):
+    """A reused PID number must not pin a capacity slot forever.
+
+    The recorded boot id proves the owning process died with the old boot, so
+    the row is reconciled even though the PID number still answers.
+    """
+    from backend.services.process_identity import (
+        ProcessIdentity,
+        encode_process_identity,
+    )
+
+    live_pid = os.getpid()
+    identity = encode_process_identity(
+        ProcessIdentity(
+            pid=live_pid,
+            start_ticks=4242,
+            boot_id="11111111-1111-4111-8111-111111111111",
+        )
+    )
+    async with session_factory() as db:
+        instance = Instance(
+            name="previous-boot-orphan",
+            status="error",
+            pid=live_pid,
+            process_identity=identity,
+        )
+        db.add(instance)
+        await db.commit()
+        instance_id = instance.id
+
+    mock_im = _make_mock_instance_manager(is_running_val=False)
+    mock_rl = _make_mock_ralph_loop()
+    with (
+        patch("backend.main.instance_manager", mock_im),
+        patch("backend.main.ralph_loop", mock_rl),
+    ):
+        response = await client.delete(f"/api/instances/{instance_id}")
+
+    assert response.status_code == 200, response.text
+    async with session_factory() as db:
+        assert await db.get(Instance, instance_id) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_instance_preserves_exactly_matching_live_identity(
+    client, session_factory,
+):
+    """The safety property: a provably live generation is still protected."""
+    from backend.services import process_identity as pi
+    from backend.services.process_identity import encode_process_identity
+
+    live_pid = os.getpid()
+    current = pi.read_process_identity(live_pid)
+    async with session_factory() as db:
+        instance = Instance(
+            name="live-identity-orphan",
+            status="error",
+            pid=live_pid,
+            process_identity=encode_process_identity(current),
+        )
+        db.add(instance)
+        await db.commit()
+        instance_id = instance.id
+
+    mock_im = _make_mock_instance_manager(is_running_val=False)
+    mock_rl = _make_mock_ralph_loop()
+    with (
+        patch("backend.main.instance_manager", mock_im),
+        patch("backend.main.ralph_loop", mock_rl),
+    ):
+        response = await client.delete(f"/api/instances/{instance_id}")
+
+    assert response.status_code == 409
+    assert "may still be alive" in response.json()["detail"]
+    async with session_factory() as db:
+        assert (await db.get(Instance, instance_id)).pid == live_pid
 
 
 @pytest.mark.asyncio
@@ -547,7 +629,7 @@ async def test_cleanup_refuses_terminal_row_with_dirty_owner_metadata(
         patch("backend.main.instance_manager", mock_im),
         patch("backend.main.ralph_loop", mock_rl),
         patch("backend.main.dispatcher", mock_dispatcher),
-        patch("backend.services.task_queue.os.kill", return_value=None) as probe,
+        patch("backend.services.process_identity.os.kill", return_value=None) as probe,
     ):
         response = await client.delete("/api/instances/cleanup")
 
@@ -588,7 +670,7 @@ async def test_cleanup_reconciles_dead_terminal_pid(
         patch("backend.main.ralph_loop", mock_rl),
         patch("backend.main.dispatcher", mock_dispatcher),
         patch(
-            "backend.services.task_queue.os.kill",
+            "backend.services.process_identity.os.kill",
             side_effect=ProcessLookupError,
         ) as probe,
     ):

--- a/backend/tests/test_api_tasks.py
+++ b/backend/tests/test_api_tasks.py
@@ -3785,7 +3785,7 @@ async def test_retry_rejects_orphan_pid_that_may_be_alive(
         await db.commit()
         task_id, instance_id = task.id, instance.id
 
-    with patch("backend.api.tasks.os.kill", return_value=None):
+    with patch("backend.services.process_identity.os.kill", return_value=None):
         response = await client.post(f"/api/tasks/{task_id}/retry")
 
     assert response.status_code == 409
@@ -3797,6 +3797,114 @@ async def test_retry_rejects_orphan_pid_that_may_be_alive(
         assert task.instance_id == instance_id
         assert instance.pid == 43210
         assert instance.current_task_id == task_id
+
+
+@pytest.mark.asyncio
+async def test_retry_allows_task_whose_pid_is_from_a_previous_boot(
+    client, session_factory,
+):
+    """The reported dead end: retry must not be blocked by a reused PID.
+
+    Reproduces screenshot #1004. The recorded boot id differs from the current
+    one, which proves the owning generation died with the previous boot even
+    though an unrelated process now answers to that PID number.
+    """
+    import os as _os
+
+    from backend.models.instance import Instance
+    from backend.models.task import Task
+    from backend.services.process_identity import (
+        ProcessIdentity,
+        encode_process_identity,
+    )
+
+    live_pid = _os.getpid()
+    async with session_factory() as db:
+        task = Task(
+            title="orphan-previous-boot",
+            description="d",
+            status="failed",
+            error_message=(
+                f"Unmanaged process PID {live_pid} may still be running after "
+                "manager restart; automatic retry was blocked to prevent "
+                "duplicate execution"
+            ),
+        )
+        db.add(task)
+        await db.flush()
+        instance = Instance(
+            name="orphan-previous-boot-slot",
+            status="error",
+            pid=live_pid,
+            process_identity=encode_process_identity(
+                ProcessIdentity(
+                    pid=live_pid,
+                    start_ticks=999,
+                    boot_id="22222222-2222-4222-8222-222222222222",
+                )
+            ),
+            current_task_id=task.id,
+        )
+        db.add(instance)
+        await db.flush()
+        task.instance_id = instance.id
+        await db.commit()
+        task_id, instance_id = task.id, instance.id
+
+    response = await client.post(f"/api/tasks/{task_id}/retry")
+
+    assert response.status_code == 200, response.text
+    async with session_factory() as db:
+        task = await db.get(Task, task_id)
+        instance = await db.get(Instance, instance_id)
+        assert task.status == "pending"
+        assert task.instance_id is None
+        # The freed slot must stop consuming instance capacity.
+        assert instance.pid is None
+        assert instance.process_identity is None
+        assert instance.current_task_id is None
+
+
+@pytest.mark.asyncio
+async def test_retry_rejects_orphan_with_exactly_matching_live_identity(
+    client, session_factory,
+):
+    """The safety property: a provably live generation still blocks retry."""
+    import os as _os
+
+    from backend.models.instance import Instance
+    from backend.models.task import Task
+    from backend.services import process_identity as pi
+    from backend.services.process_identity import encode_process_identity
+
+    live_pid = _os.getpid()
+    async with session_factory() as db:
+        task = Task(title="orphan-live-identity", description="d", status="failed")
+        db.add(task)
+        await db.flush()
+        instance = Instance(
+            name="orphan-live-identity-slot",
+            status="error",
+            pid=live_pid,
+            process_identity=encode_process_identity(
+                pi.read_process_identity(live_pid)
+            ),
+            current_task_id=task.id,
+        )
+        db.add(instance)
+        await db.flush()
+        task.instance_id = instance.id
+        await db.commit()
+        task_id, instance_id = task.id, instance.id
+
+    response = await client.post(f"/api/tasks/{task_id}/retry")
+
+    assert response.status_code == 409
+    assert "still alive" in response.json()["detail"]
+    async with session_factory() as db:
+        task = await db.get(Task, task_id)
+        assert task.status == "failed"
+        assert (await db.get(Instance, instance_id)).pid == live_pid
 
 
 @pytest.mark.asyncio
@@ -3828,7 +3936,7 @@ async def test_retry_reconciles_dead_orphan_before_releasing_task(
         task_id, instance_id = task.id, instance.id
 
     with patch(
-        "backend.api.tasks.os.kill",
+        "backend.services.process_identity.os.kill",
         side_effect=ProcessLookupError,
     ):
         response = await client.post(f"/api/tasks/{task_id}/retry")
@@ -3942,7 +4050,7 @@ async def test_retry_checks_reverse_owner_when_task_side_owner_is_null(
         task_id = task.id
         instance_id = instance.id
 
-    with patch("backend.api.tasks.os.kill", return_value=None):
+    with patch("backend.services.process_identity.os.kill", return_value=None):
         response = await client.post(f"/api/tasks/{task_id}/retry")
 
     assert response.status_code == 409

--- a/backend/tests/test_process_identity.py
+++ b/backend/tests/test_process_identity.py
@@ -1,0 +1,233 @@
+"""Regression tests for PID-reuse-safe process identity probes.
+
+A bare ``os.kill(pid, 0)`` probe cannot distinguish "this exact managed
+process is still running" from "an unrelated process reused this PID number".
+Treating the second case as the first pins a Task as permanently un-retryable
+and leaks an Instance capacity slot, which is the bug these tests cover.
+
+These tests never signal or spawn a real process: the live PID used
+throughout is the test interpreter itself, whose identity is known-good.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from backend.services.process_identity import (
+    ProcessIdentity,
+    ProcessIdentityError,
+    capture_process_identity,
+    decode_process_identity,
+    encode_process_identity,
+    persisted_process_is_definitively_dead,
+    read_process_identity,
+)
+
+
+LIVE_PID = os.getpid()
+OTHER_BOOT_ID = "11111111-2222-3333-4444-555555555555"
+
+
+def _live_identity() -> str:
+    """Return the encoded identity of this test process."""
+
+    identity = capture_process_identity(LIVE_PID)
+    assert identity is not None, "test host must expose its own PID identity"
+    return identity
+
+
+def _fields(identity: str) -> tuple[int, str]:
+    decoded = decode_process_identity(identity, LIVE_PID)
+    assert decoded is not None
+    return decoded
+
+
+def test_capture_round_trips_through_decode():
+    """A captured identity decodes back for the PID it was recorded against."""
+
+    identity = _live_identity()
+    start_ticks, boot_id = _fields(identity)
+
+    assert start_ticks > 0
+    assert boot_id
+    assert identity == f"v1:{LIVE_PID}:{start_ticks}:{boot_id}"
+
+
+def test_capture_never_raises_for_unreadable_pid():
+    """Identity capture degrades to None instead of failing a launch."""
+
+    for error in (ProcessIdentityError("boom"), RuntimeError("ctypes boom")):
+        with patch(
+            "backend.services.process_identity.read_process_identity",
+            side_effect=error,
+        ):
+            assert capture_process_identity(LIVE_PID) is None
+
+
+@pytest.mark.parametrize("pid", [None, 0, 1, -5, "123", 12.0, True])
+def test_capture_rejects_unsafe_pids(pid):
+    """Only a real, safe PID may produce identity evidence."""
+
+    assert capture_process_identity(pid) is None
+
+
+def test_exact_live_process_is_not_dead():
+    """The recorded process really is running, so cleanup must fail closed."""
+
+    assert persisted_process_is_definitively_dead(LIVE_PID, _live_identity()) is False
+
+
+def test_reused_pid_is_definitively_dead():
+    """Same PID number, different start time: the recorded process is gone.
+
+    This is the PID wraparound case that previously pinned a Task as failed
+    forever, because the bare probe only saw "something answers to this PID".
+    """
+
+    _, boot_id = _fields(_live_identity())
+    reused = f"v1:{LIVE_PID}:1:{boot_id}"
+
+    assert persisted_process_is_definitively_dead(LIVE_PID, reused) is True
+
+
+def test_prior_boot_session_is_definitively_dead():
+    """No process survives a reboot, even if its PID is live again now."""
+
+    start_ticks, _ = _fields(_live_identity())
+    previous_boot = f"v1:{LIVE_PID}:{start_ticks}:{OTHER_BOOT_ID}"
+
+    assert persisted_process_is_definitively_dead(LIVE_PID, previous_boot) is True
+
+
+def test_vanished_pid_is_definitively_dead():
+    """A PID that no longer exists is provably gone."""
+
+    _, boot_id = _fields(_live_identity())
+    with patch(
+        "backend.services.process_identity.read_process_identity",
+        return_value=None,
+    ):
+        assert (
+            persisted_process_is_definitively_dead(
+                LIVE_PID, f"v1:{LIVE_PID}:999:{boot_id}"
+            )
+            is True
+        )
+
+
+def test_unreadable_current_identity_fails_closed():
+    """If death cannot be proven, owner evidence must be preserved."""
+
+    identity = _live_identity()
+    with patch(
+        "backend.services.process_identity.read_process_identity",
+        side_effect=ProcessIdentityError("permission denied"),
+    ):
+        assert persisted_process_is_definitively_dead(LIVE_PID, identity) is False
+
+
+def test_unexpected_identity_reader_failure_fails_closed():
+    """Platform reader failures cannot authorize a destructive cleanup."""
+
+    identity = _live_identity()
+    with patch(
+        "backend.services.process_identity.read_process_identity",
+        side_effect=RuntimeError("ctypes boom"),
+    ):
+        assert persisted_process_is_definitively_dead(LIVE_PID, identity) is False
+
+
+def test_legacy_row_without_identity_falls_back_to_bare_probe():
+    """Rows written by an older binary keep the previous conservative result."""
+
+    assert persisted_process_is_definitively_dead(LIVE_PID, None) is False
+    assert persisted_process_is_definitively_dead(999999, None) is True
+
+
+def test_identity_recorded_for_a_different_pid_is_unusable():
+    """A stale identity must never be read as proof that a fresh PID is dead.
+
+    The PID is embedded in the value precisely so that a writer which updates
+    ``pid`` without refreshing the identity column degrades to the
+    conservative probe, rather than authorizing duplicate execution.
+    """
+
+    start_ticks, boot_id = _fields(_live_identity())
+    mismatched = f"v1:{LIVE_PID + 1}:{start_ticks}:{boot_id}"
+
+    assert persisted_process_is_definitively_dead(LIVE_PID, mismatched) is False
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [
+        "",
+        "garbage",
+        "v1:only:three",
+        "v2:1:2:11111111-2222-3333-4444-555555555555",
+        "v1:x:2:11111111-2222-3333-4444-555555555555",
+        "v1:1:notanint:11111111-2222-3333-4444-555555555555",
+        "v1:1:2:not-a-uuid",
+        "v1:1:2:",
+        b"v1:1:2:11111111-2222-3333-4444-555555555555",
+        12345,
+    ],
+)
+def test_malformed_identity_falls_back_to_bare_probe(identity):
+    """Corrupt evidence is discarded rather than trusted in either direction."""
+
+    assert persisted_process_is_definitively_dead(LIVE_PID, identity) is False
+
+
+def test_zero_start_ticks_is_rejected_as_evidence():
+    """A non-positive start time cannot distinguish two processes."""
+
+    _, boot_id = _fields(_live_identity())
+
+    assert decode_process_identity(f"v1:{LIVE_PID}:0:{boot_id}", LIVE_PID) is None
+
+
+@pytest.mark.parametrize("pid", [None, 0, -1])
+def test_missing_pid_is_never_reported_dead(pid):
+    """Without a PID there is nothing to prove dead."""
+
+    assert persisted_process_is_definitively_dead(pid, None) is False
+
+
+def test_encode_binds_pid_into_value():
+    """Encoding embeds the PID so mismatches are detectable."""
+
+    encoded = encode_process_identity(
+        ProcessIdentity(pid=4242, start_ticks=99, boot_id=OTHER_BOOT_ID)
+    )
+
+    assert encoded == f"v1:4242:99:{OTHER_BOOT_ID}"
+    assert decode_process_identity(encoded, 4242) == (99, OTHER_BOOT_ID)
+    assert decode_process_identity(encoded, 4243) is None
+
+
+@pytest.mark.parametrize("pid", [0, 1, -1, "5", None])
+def test_read_process_identity_rejects_unsafe_pids(pid):
+    """The low-level reader refuses PIDs that could mean "every process"."""
+
+    with pytest.raises(ProcessIdentityError):
+        read_process_identity(pid)
+
+
+def test_read_process_identity_returns_none_for_missing_process():
+    """A vanished PID is reported as absent, not as an error."""
+
+    assert read_process_identity(999999) is None
+
+
+def test_read_process_identity_of_self_is_consistent():
+    """Two reads of a live process agree, so the value is a stable identity."""
+
+    first = read_process_identity(LIVE_PID)
+    second = read_process_identity(LIVE_PID)
+
+    assert first is not None and second is not None
+    assert first.pid == second.pid == LIVE_PID
+    assert first.start_ticks == second.start_ticks > 0
+    assert first.boot_id == second.boot_id

--- a/backend/tests/test_service_instance_manager.py
+++ b/backend/tests/test_service_instance_manager.py
@@ -11879,7 +11879,7 @@ async def test_reconcile_dead_reverse_owner_preserves_current_task_generation(
     broadcaster = MagicMock(broadcast=AsyncMock())
     manager = InstanceManager(db_factory, broadcaster)
     with patch(
-        "backend.services.instance_manager.os.kill",
+        "backend.services.process_identity.os.kill",
         side_effect=ProcessLookupError,
     ):
         reconciled = await manager.reconcile_dead_reverse_task_owner(
@@ -11913,6 +11913,69 @@ async def test_reconcile_dead_reverse_owner_preserves_current_task_generation(
 
 
 @pytest.mark.asyncio
+async def test_reconcile_dead_reverse_owner_accepts_previous_boot_identity(
+    db_factory,
+):
+    """A live reused PID cannot pin a superseded reverse owner forever."""
+
+    from backend.services.process_identity import (
+        ProcessIdentity,
+        encode_process_identity,
+    )
+
+    stale_started_at = datetime(2026, 8, 15, 12, 0, 0)
+    live_pid = os.getpid()
+    previous_boot_identity = encode_process_identity(
+        ProcessIdentity(
+            pid=live_pid,
+            start_ticks=1234,
+            boot_id="11111111-1111-4111-8111-111111111111",
+        )
+    )
+    async with db_factory() as db:
+        stale = Instance(
+            name="previous-boot-reverse-owner",
+            status="running",
+            pid=live_pid,
+            process_identity=previous_boot_identity,
+            started_at=stale_started_at,
+        )
+        live = Instance(name="current-owner", status="running")
+        db.add_all([stale, live])
+        await db.flush()
+        task = Task(
+            title="retry moved to another slot",
+            status="executing",
+            instance_id=live.id,
+        )
+        db.add(task)
+        await db.flush()
+        stale.current_task_id = task.id
+        live.current_task_id = task.id
+        await db.commit()
+        stale_id, task_id = stale.id, task.id
+
+    manager = InstanceManager(
+        db_factory,
+        MagicMock(broadcast=AsyncMock()),
+    )
+    reconciled = await manager.reconcile_dead_reverse_task_owner(
+        stale_id,
+        expected_task_id=task_id,
+        expected_pid=live_pid,
+        expected_started_at=stale_started_at,
+    )
+
+    assert reconciled is True
+    async with db_factory() as db:
+        stale = await db.get(Instance, stale_id)
+        assert stale.status == "idle"
+        assert stale.pid is None
+        assert stale.process_identity is None
+        assert stale.current_task_id is None
+
+
+@pytest.mark.asyncio
 async def test_reconcile_reverse_owner_refuses_a_live_pid(db_factory):
     started_at = datetime(2026, 8, 2, 7, 36, 23)
     async with db_factory() as db:
@@ -11940,7 +12003,7 @@ async def test_reconcile_reverse_owner_refuses_a_live_pid(db_factory):
         db_factory,
         MagicMock(broadcast=AsyncMock()),
     )
-    with patch("backend.services.instance_manager.os.kill") as probe:
+    with patch("backend.services.process_identity.os.kill") as probe:
         reconciled = await manager.reconcile_dead_reverse_task_owner(
             stale_id,
             expected_task_id=task_id,

--- a/backend/tests/test_stale_state_cleanup.py
+++ b/backend/tests/test_stale_state_cleanup.py
@@ -1787,7 +1787,7 @@ async def test_cleanup_fails_multi_owner_corruption_without_replay(db_factory):
         owner_ids = [owner.id for owner in owners]
 
     with patch(
-        "backend.services.dispatcher.os.kill",
+        "backend.services.process_identity.os.kill",
         side_effect=ProcessLookupError,
     ):
         await d._cleanup_stale_state()
@@ -1856,7 +1856,7 @@ async def test_cleanup_requeues_unique_consistent_dead_owner(db_factory):
         task_id, owner_id = task.id, owner.id
 
     with patch(
-        "backend.services.dispatcher.os.kill",
+        "backend.services.process_identity.os.kill",
         side_effect=ProcessLookupError,
     ):
         await d._cleanup_stale_state()
@@ -1899,7 +1899,7 @@ async def test_cleanup_fails_single_mismatched_reverse_owner(
         task_id = task.id
 
     with patch(
-        "backend.services.dispatcher.os.kill",
+        "backend.services.process_identity.os.kill",
         side_effect=ProcessLookupError,
     ):
         await d._cleanup_stale_state()
@@ -1943,7 +1943,7 @@ async def test_cleanup_preserves_live_owner_while_removing_dead_duplicate(
 
     d.instance_manager.processes[live_id] = MagicMock(returncode=None)
     with patch(
-        "backend.services.dispatcher.os.kill",
+        "backend.services.process_identity.os.kill",
         side_effect=ProcessLookupError,
     ):
         await d._cleanup_stale_state()
@@ -2094,7 +2094,7 @@ async def test_cleanup_acquires_task_write_before_instance_write(db_factory):
 
     with (
         patch(
-            "backend.services.dispatcher.os.kill",
+            "backend.services.process_identity.os.kill",
             side_effect=ProcessLookupError,
         ),
         patch.object(AsyncSession, "execute", new=record_writes),
@@ -3261,3 +3261,319 @@ async def test_cleanup_multiple_stale_entities(db_factory):
         assert (await db.get(Task, ids["task1"])).status == "pending"
         assert (await db.get(Task, ids["task2"])).status == "pending"
         assert (await db.get(Task, ids["task3"])).status == "pending"
+
+
+# ---------------------------------------------------------------------------
+# PID reuse / host restart recovery
+#
+# A bare os.kill(pid, 0) probe cannot distinguish "this exact generation is
+# still running" from "an unrelated process inherited this PID number". When it
+# guessed wrong the Task was fail-closed as failed forever and its Instance row
+# kept occupying a max_concurrent_instances slot, with no UI path out.
+# ---------------------------------------------------------------------------
+
+_OTHER_BOOT_ID = "11111111-1111-4111-8111-111111111111"
+
+
+def _encoded_identity(pid, start_ticks, boot_id):
+    from backend.services.process_identity import (
+        ProcessIdentity,
+        encode_process_identity,
+    )
+
+    return encode_process_identity(
+        ProcessIdentity(pid=pid, start_ticks=start_ticks, boot_id=boot_id)
+    )
+
+
+async def _add_unstarted_turn_source(
+    db,
+    task,
+    *,
+    generation=1,
+    actual_transport=None,
+):
+    """Attach proof that this turn never reached a provider boundary.
+
+    Without it the replay guard fail-closes for its own reason, which would
+    mask whether the PID identity probe reached the right verdict.
+    """
+    source = LogEntry(
+        task_id=task.id,
+        task_retry_count=task.retry_count or 0,
+        task_turn_generation=generation,
+        turn_scope="source",
+        event_type="turn_source",
+        role="system",
+        content=None,
+        raw_json=json.dumps(
+            {"original_source_log_id": None, "transport": None}
+        ),
+        actual_transport=actual_transport,
+        is_error=False,
+    )
+    db.add(source)
+    await db.flush()
+    task.turn_generation = generation
+    task.turn_source_log_id = source.id
+    return source
+
+
+@pytest.mark.asyncio
+async def test_cleanup_requeues_pid_recorded_in_a_previous_boot(db_factory):
+    """A PID from an earlier boot is provably dead even if the number answers.
+
+    This is the reported failure: after a host restart an unrelated process
+    answered PID 590565, so the owning task was permanently failed.
+    """
+    d = _make_dispatcher(db_factory)
+    live_pid = os.getpid()
+
+    async with db_factory() as db:
+        task = Task(title="previous boot owner", status="executing", retry_count=0)
+        db.add(task)
+        await db.flush()
+        await _add_unstarted_turn_source(db, task)
+        owner = Instance(
+            name="previous-boot-owner",
+            status="running",
+            pid=live_pid,
+            current_task_id=task.id,
+            process_identity=_encoded_identity(live_pid, 4242, _OTHER_BOOT_ID),
+        )
+        db.add(owner)
+        await db.flush()
+        task.instance_id = owner.id
+        await db.commit()
+        task_id, owner_id = task.id, owner.id
+
+    # No os.kill patch: the boot id alone proves death, and the live PID would
+    # otherwise be misread as this generation still running.
+    await d._cleanup_stale_state()
+
+    async with db_factory() as db:
+        task = await db.get(Task, task_id)
+        owner = await db.get(Instance, owner_id)
+        assert task.status == "pending", task.error_message
+        assert task.instance_id is None
+        assert owner.pid is None
+        assert owner.process_identity is None
+        assert owner.current_task_id is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_releases_previous_boot_pid_but_keeps_transport_boundary(
+    db_factory,
+):
+    """PID recovery must not weaken the independent provider-effect fence."""
+
+    d = _make_dispatcher(db_factory)
+    live_pid = os.getpid()
+
+    async with db_factory() as db:
+        task = Task(
+            title="previous boot after provider boundary",
+            status="executing",
+            retry_count=0,
+        )
+        db.add(task)
+        await db.flush()
+        await _add_unstarted_turn_source(
+            db,
+            task,
+            actual_transport="claude_pty",
+        )
+        owner = Instance(
+            name="previous-boot-provider-owner",
+            status="running",
+            pid=live_pid,
+            current_task_id=task.id,
+            process_identity=_encoded_identity(
+                live_pid,
+                4242,
+                _OTHER_BOOT_ID,
+            ),
+        )
+        db.add(owner)
+        await db.flush()
+        task.instance_id = owner.id
+        await db.commit()
+        task_id, owner_id = task.id, owner.id
+
+    await d._cleanup_stale_state()
+
+    async with db_factory() as db:
+        task = await db.get(Task, task_id)
+        owner = await db.get(Instance, owner_id)
+        assert task.status == "failed"
+        assert "exact turn selected transport claude_pty" in task.error_message
+        assert "Unmanaged process PID" not in task.error_message
+        assert task.instance_id is None
+        assert owner.status == "error"
+        assert owner.pid is None
+        assert owner.process_identity is None
+        assert owner.current_task_id is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_requeues_reused_pid_with_different_start_ticks(db_factory):
+    """Same boot, same PID number, different start time: the owner is gone."""
+    d = _make_dispatcher(db_factory)
+    live_pid = os.getpid()
+
+    from backend.services import process_identity as pi
+
+    current = pi.read_process_identity(live_pid)
+
+    async with db_factory() as db:
+        task = Task(title="reused pid owner", status="executing", retry_count=0)
+        db.add(task)
+        await db.flush()
+        await _add_unstarted_turn_source(db, task)
+        owner = Instance(
+            name="reused-pid-owner",
+            status="running",
+            pid=live_pid,
+            current_task_id=task.id,
+            process_identity=_encoded_identity(
+                live_pid,
+                current.start_ticks + 9999,
+                current.boot_id,
+            ),
+        )
+        db.add(owner)
+        await db.flush()
+        task.instance_id = owner.id
+        await db.commit()
+        task_id, owner_id = task.id, owner.id
+
+    await d._cleanup_stale_state()
+
+    async with db_factory() as db:
+        task = await db.get(Task, task_id)
+        owner = await db.get(Instance, owner_id)
+        assert task.status == "pending", task.error_message
+        assert task.instance_id is None
+        assert owner.pid is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_still_fails_closed_for_exact_matching_identity(db_factory):
+    """The safety property: a genuinely live generation is never requeued."""
+    d = _make_dispatcher(db_factory)
+    live_pid = os.getpid()
+
+    from backend.services import process_identity as pi
+
+    current = pi.read_process_identity(live_pid)
+
+    async with db_factory() as db:
+        task = Task(title="live owner", status="executing")
+        db.add(task)
+        await db.flush()
+        owner = Instance(
+            name="live-owner",
+            status="running",
+            pid=live_pid,
+            current_task_id=task.id,
+            process_identity=_encoded_identity(
+                live_pid,
+                current.start_ticks,
+                current.boot_id,
+            ),
+        )
+        db.add(owner)
+        await db.flush()
+        task.instance_id = owner.id
+        await db.commit()
+        task_id, owner_id = task.id, owner.id
+
+    await d._cleanup_stale_state()
+
+    async with db_factory() as db:
+        task = await db.get(Task, task_id)
+        owner = await db.get(Instance, owner_id)
+        assert task.status == "failed"
+        assert "may still be running" in task.error_message
+        # Owner evidence must survive so an operator can reconcile it.
+        assert owner.pid == live_pid
+
+
+@pytest.mark.asyncio
+async def test_cleanup_fails_closed_when_identity_pid_does_not_match(db_factory):
+    """A stale identity written for another PID must not prove death.
+
+    The PID is embedded in the persisted value so that a write site which
+    updates the PID without refreshing identity degrades to the conservative
+    probe instead of silently authorizing duplicate execution.
+    """
+    d = _make_dispatcher(db_factory)
+    live_pid = os.getpid()
+
+    async with db_factory() as db:
+        task = Task(title="mismatched identity", status="executing")
+        db.add(task)
+        await db.flush()
+        owner = Instance(
+            name="mismatched-identity-owner",
+            status="running",
+            pid=live_pid,
+            current_task_id=task.id,
+            # Identity recorded for a *different* PID, in a dead boot.
+            process_identity=_encoded_identity(
+                live_pid + 1,
+                4242,
+                _OTHER_BOOT_ID,
+            ),
+        )
+        db.add(owner)
+        await db.flush()
+        task.instance_id = owner.id
+        await db.commit()
+        task_id = task.id
+
+    await d._cleanup_stale_state()
+
+    async with db_factory() as db:
+        task = await db.get(Task, task_id)
+        assert task.status == "failed"
+        assert "may still be running" in task.error_message
+
+
+@pytest.mark.asyncio
+async def test_cleanup_treats_null_pid_as_nothing_alive(db_factory):
+    """A NULL PID records no process, so there is nothing that can be alive.
+
+    The identity probe reports ``unknown`` for a missing PID because it cannot
+    prove death from an absent value. Callers must keep the original NULL check
+    ahead of it, otherwise owner-only rows that never held a process would be
+    quarantined as live evidence and pin their task forever.
+    """
+    d = _make_dispatcher(db_factory)
+
+    async with db_factory() as db:
+        task = Task(title="owner without pid", status="executing", retry_count=0)
+        db.add(task)
+        await db.flush()
+        await _add_unstarted_turn_source(db, task)
+        owner = Instance(
+            name="pidless-owner",
+            status="error",
+            pid=None,
+            process_identity=None,
+            current_task_id=task.id,
+        )
+        db.add(owner)
+        await db.flush()
+        task.instance_id = owner.id
+        await db.commit()
+        task_id, owner_id = task.id, owner.id
+
+    await d._cleanup_stale_state()
+
+    async with db_factory() as db:
+        task = await db.get(Task, task_id)
+        owner = await db.get(Instance, owner_id)
+        assert task.status == "pending", task.error_message
+        assert task.instance_id is None
+        assert owner.current_task_id is None

--- a/backend/tests/test_task_queue.py
+++ b/backend/tests/test_task_queue.py
@@ -2731,7 +2731,7 @@ async def test_delete_task_preserves_possible_live_orphan_owner(queue):
     await queue.db.commit()
     task_id, instance_id = task.id, instance.id
 
-    with patch("backend.services.task_queue.os.kill", return_value=None):
+    with patch("backend.services.process_identity.os.kill", return_value=None):
         assert await queue.delete(task_id) is False
 
     queue.db.expire_all()
@@ -3023,7 +3023,7 @@ async def test_delete_task_preserves_orphan_when_pid_probe_is_denied(queue):
     task_id, instance_id = task.id, instance.id
 
     with patch(
-        "backend.services.task_queue.os.kill",
+        "backend.services.process_identity.os.kill",
         side_effect=PermissionError("not permitted"),
     ):
         assert await queue.delete(task_id) is False
@@ -3053,7 +3053,7 @@ async def test_delete_task_detaches_definitively_dead_orphan(queue):
     task_id, instance_id = task.id, instance.id
 
     with patch(
-        "backend.services.task_queue.os.kill",
+        "backend.services.process_identity.os.kill",
         side_effect=ProcessLookupError,
     ):
         assert await queue.delete(task_id) is True


### PR DESCRIPTION
## Summary

- Persist an exact OS process identity beside `Instance.pid`: PID, kernel start time, and boot session ID.
- Use that identity during startup recovery, manual retry, terminal cleanup, Task deletion, and stale reverse-owner reconciliation.
- Fence every cleanup with the persisted identity so a concurrent same-PID generation cannot be detached.
- Add a reversible Alembic migration plus Linux and macOS identity readers.
- Keep legacy or unreadable identities fail-closed, and retain the existing `claude_pty` external-effect boundary that blocks unsafe automatic replay.

## Problem

Recovery previously relied on `os.kill(pid, 0)`. After a host restart or PID reuse, an unrelated process can answer to the same PID, causing CCM to report that an unmanaged process may still be running and permanently block retry/capacity cleanup.

The exact start identity and boot ID distinguish the original managed process from a reused PID without weakening duplicate-execution protections.

## Validation

- `287 passed, 1 skipped`: process identity, startup recovery, Instance API, Task queue, and Plan runtime receipt suites.
- `19 passed`: Task retry regression selection.
- `3 passed`: stale reverse-owner reconciliation selection.
- New migration upgrade/downgrade/re-upgrade round-trip passed.
