### PR TITLE
fix(browser-review): stop forcing panel open for pre-existing runs

### DIFF
--- a/frontend/src/components/Chat/ChatView.tsx
+++ b/frontend/src/components/Chat/ChatView.tsx
@@ -1001,9 +1001,6 @@ export function ChatView({ task, projects, onBack, onTaskUpdated, onTaskForked, 
   const previousBrowserReviewActive = useRef(false);
   const handleBrowserReviewAvailable = useCallback((available: boolean) => {
     setBrowserReviewAvailable(available);
-    if (available && !previousBrowserReviewAvailable.current) {
-      setShowBrowserReviewPanel(true);
-    }
     previousBrowserReviewAvailable.current = available;
   }, []);
   const handleBrowserReviewActive = useCallback((active: boolean) => {


### PR DESCRIPTION
## Summary
- 修复打开一个已有历史（已完成）浏览器审查记录的任务时，审查面板会被强制自动展开的问题
- 只有当审查从非活跃状态转为**活跃/运行中**时才自动展开面板；仅有可用（但已终态）的历史记录不再触发自动展开

## Test plan
- [x] 打开一个已存在已完成浏览器审查记录的 Task，确认面板不再自动弹出
- [x] 触发一次新的浏览器审查运行，确认面板仍会在运行开始时自动展开
- [x] `cd frontend && npx tsc --noEmit` 类型检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)