### PR TITLE
fix(claude): recover stalled response loops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,8 @@ claude-manager/
 
 ## 关键约定
 
+- **Claude 无进展恢复**: 同一前台回合仅在连续相似的 `stop_reason=null` 回复持续至少两分钟、且从未出现 `tool_use/tool_result` 时才可中止并用 generation-bound 一次性许可在新 session 自动重放原消息；自动恢复最多一次，恢复回合再次异常或存在任何工具行为必须停止并等待用户重试，禁止盲目重放。
+
 - **数据库更新快照**: 数据库回滚快照只在权威 Alembic revision 检查确认有待迁移项时生成，并且只能由停服后的外部 worker 一次性生成、目标完整性检查和 fsync；禁止先做在线全量快照再被停服快照覆盖的双重 I/O。默认只保留当前和上一个恢复点。
 
 - **Codex 号池在线策略**: `pool_settings` 与账号记录一起原子保存在 `CODEX_POOL_CONFIG_PATH` 的私有 JSON 中，前端可在线修改启停、冷却、主动换号阈值、API/OAuth 路由顺序和首选账号并立即生效；部署级总开关和路径仍由环境变量控制。暂停后所有新 Codex 主任务、Monitor、Sub-Agent 与 Distill 必须 fail closed，禁止回落到 ambient `CODEX_HOME`。Worker 上的设置和首选账号写入必须参加 node account-mutation fence。

--- a/backend/main.py
+++ b/backend/main.py
@@ -122,6 +122,9 @@ dispatcher = GlobalDispatcher(
 )
 dispatcher.cloudrouter_store = cloudrouter_store
 instance_manager.task_message_enqueuer = dispatcher.enqueue_message
+instance_manager.no_progress_recovery_scheduler = (
+    dispatcher.enqueue_no_progress_recovery
+)
 
 # Register provider-neutral capability adapters independently from admission.
 # Keeping them present while the feature flag is dark lets startup recovery

--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -770,7 +770,7 @@ class QueuedMessage:
     claimed_turn_generation: int | None = field(
         compare=False, default=None, repr=False
     )
-    # Once a compact retry has claimed G+1, bind later in-process launch
+    # Once an automatic retry has claimed G+1, bind later in-process launch
     # retries to the exact source row installed by that claim.  The original
     # permit still names rejected G; this field prevents it from floating to a
     # different G+1 source after a pre-launch rollback/requeue.
@@ -811,6 +811,12 @@ class QueuedMessage:
     context_retry_permit: "ContextRetryPermit | None" = field(
         compare=False,
         default=None,
+        repr=False,
+    )
+    # A no-progress recovery may replay the exact user input only once.
+    no_progress_retry_attempt: int = field(
+        compare=False,
+        default=0,
         repr=False,
     )
     # Internal producers snapshot this before committing the result which
@@ -857,17 +863,17 @@ def _context_retry_permit_matches(
     task: Task,
     msg: QueuedMessage,
 ) -> bool:
-    """Validate the exact rejected generation before compact-retry admission."""
+    """Validate the exact rejected generation before automatic retry."""
 
     permit = msg.context_retry_permit
     if permit is None:
-        # ``compact_retry`` is an internal replay authority, not merely a
-        # descriptive source label.  Legacy/forged queue items without the
-        # immutable rejected-generation proof must fail closed; ordinary
-        # queued messages do not need this specialized permit.
-        return msg.source != "compact_retry"
-    if msg.source != "compact_retry" or not isinstance(
-        permit, ContextRetryPermit
+        # Internal replay sources are authorities, not merely descriptive
+        # labels. Legacy/forged queue items without immutable generation proof
+        # must fail closed; ordinary messages do not need this permit.
+        return msg.source not in {"compact_retry", "no_progress_retry"}
+    if (
+        msg.source not in {"compact_retry", "no_progress_retry"}
+        or not isinstance(permit, ContextRetryPermit)
     ):
         return False
     baseline_matches = bool(
@@ -1291,7 +1297,7 @@ class GlobalDispatcher:
         started_at: datetime | None,
         completed_at: datetime | None,
     ) -> ContextRetryPermit:
-        """Issue one volatile authority for rejected G -> compact G+1."""
+        """Issue one volatile authority for a proven-safe rejected G -> G+1."""
 
         authority_id = secrets.token_hex(16)
         permit = ContextRetryPermit(
@@ -1305,7 +1311,7 @@ class GlobalDispatcher:
             started_at=started_at,
             completed_at=completed_at,
         )
-        # Only one compact authority for an exact rejected generation may be
+        # Only one retry authority for an exact rejected generation may be
         # live in this process.  Re-issuing revokes an older unconsumed copy.
         for existing_id, existing in tuple(
             self._context_retry_authorities.items()
@@ -1320,7 +1326,7 @@ class GlobalDispatcher:
         return permit
 
     def _context_retry_authority_is_live(self, msg: QueuedMessage) -> bool:
-        if msg.source != "compact_retry":
+        if msg.source not in {"compact_retry", "no_progress_retry"}:
             return msg.context_retry_permit is None
         permit = msg.context_retry_permit
         return bool(
@@ -1345,11 +1351,11 @@ class GlobalDispatcher:
             self._context_retry_authorities.pop(authority_id, None)
 
     def _consume_context_retry_authority(self, msg: QueuedMessage) -> None:
-        if msg.source != "compact_retry":
+        if msg.source not in {"compact_retry", "no_progress_retry"}:
             return
         if not self._context_retry_authority_is_live(msg):
             raise QueuedMessagePrelaunchError(
-                "Compact retry launch authority is no longer current"
+                "Automatic retry launch authority is no longer current"
             )
         self.revoke_context_retry_permit(msg.context_retry_permit)
 
@@ -18718,6 +18724,7 @@ Codex 中工具会显示为上述 mcp__ccm_monitor_agent__* canonical 名称；
         queue_timestamp: float | None = None,
         allow_new_session: bool | None = None,
         context_retry_permit: ContextRetryPermit | None = None,
+        no_progress_retry_attempt: int = 0,
         queue_admission_fence: QueueAdmissionFence | None = None,
         initiating_user_id: int | None = None,
         initiating_user_role: str = "member",
@@ -18745,6 +18752,19 @@ Codex 中工具会显示为上述 mcp__ccm_monitor_agent__* canonical 名称；
         ):
             raise ValueError(
                 "Shared messages must use the sandboxed system principal"
+            )
+        if source == "no_progress_retry":
+            if (
+                no_progress_retry_attempt != 1
+                or context_retry_permit is None
+                or allow_new_session is not True
+            ):
+                raise ValueError(
+                    "No-progress retry requires one fresh-session authority"
+                )
+        elif no_progress_retry_attempt != 0:
+            raise ValueError(
+                "No-progress retry attempt is only valid for its internal source"
             )
         internal_session_report = source.startswith(("monitor:", "sub-agent:"))
         msg = QueuedMessage(
@@ -18775,6 +18795,7 @@ Codex 中工具会显示为上述 mcp__ccm_monitor_agent__* canonical 名称；
                 allow_new_session is None and internal_session_report
             ),
             context_retry_permit=context_retry_permit,
+            no_progress_retry_attempt=no_progress_retry_attempt,
             queue_admission_fence=queue_admission_fence,
         )
         async with self._dispatch_claim_lock:
@@ -23726,6 +23747,7 @@ Codex 中工具会显示为上述 mcp__ccm_monitor_agent__* canonical 名称；
                 ssh_agent_socket_snapshot=msg.ssh_agent_socket_snapshot,
                 attachment_paths=msg.attachment_paths,
                 context_retry_permit=msg.context_retry_permit,
+                no_progress_retry_attempt=msg.no_progress_retry_attempt,
                 context_retry_claimed_source_log_id=(
                     msg.context_retry_claimed_source_log_id
                 ),

--- a/backend/services/dispatcher.py
+++ b/backend/services/dispatcher.py
@@ -1350,6 +1350,98 @@ class GlobalDispatcher:
         ):
             self._context_retry_authorities.pop(authority_id, None)
 
+    async def enqueue_no_progress_recovery(
+        self, *, task_id: int, instance_id: int, record, params: dict
+    ) -> bool:
+        """Authorize and enqueue one exact-generation Claude recovery.
+
+        InstanceManager supplies only the observed record and launch metadata;
+        all durable source validation and retry authority remain Dispatcher
+        policy, avoiding a dependency on the application singleton.
+        """
+        from backend.services.terminal_arbitration import (
+            source_alias_original_log_id,
+            source_shape_is_canonical,
+        )
+
+        requested_source_id = params.get("source_log_id")
+        async with self.db_factory() as db:
+            task = await db.get(Task, task_id)
+            if (
+                task is None
+                or (task.provider or "claude").lower() != "claude"
+                or task.status != "failed"
+                or task.instance_id != instance_id
+                or task.retry_count != record.task_retry_count
+                or task.turn_generation != record.task_turn_generation
+                or task.session_id is not None
+                or type(task.turn_source_log_id) is not int
+                or type(requested_source_id) is not int
+                or requested_source_id <= 0
+                or task.turn_source_log_id <= 0
+            ):
+                return False
+            source = await db.get(LogEntry, task.turn_source_log_id)
+            original_id = source_alias_original_log_id(source) if source else None
+            original = await db.get(LogEntry, original_id) if original_id else None
+            if (
+                source is None
+                or source.task_id != task.id
+                or source.task_retry_count != task.retry_count
+                or source.task_turn_generation != task.turn_generation
+                or source.turn_scope != "source"
+                or requested_source_id not in {source.id, original_id}
+                or not source_shape_is_canonical(source, original)
+            ):
+                return False
+            replay_source = original if source.event_type == "turn_source" else source
+            prompt = replay_source.content if replay_source else None
+            if not isinstance(prompt, str) or not prompt:
+                return False
+            permit = self.issue_context_retry_permit(
+                task_id=task.id,
+                instance_id=instance_id,
+                retry_count=task.retry_count,
+                turn_generation=task.turn_generation,
+                turn_source_log_id=task.turn_source_log_id,
+                session_id=None,
+                started_at=task.started_at,
+                completed_at=task.completed_at,
+            )
+        retry_kwargs = {
+            "task_id": task_id,
+            "prompt": prompt,
+            "priority": PRIORITY_USER,
+            "source": "no_progress_retry",
+            "source_log_id": requested_source_id,
+            "current_message": prompt,
+            "allow_new_session": True,
+            "context_retry_permit": permit,
+            "no_progress_retry_attempt": 1,
+            "initiating_user_id": params.get("initiating_user_id"),
+            "initiating_user_role": params.get("initiating_user_role", "member"),
+            "execution_mode": params.get("execution_mode", "sandbox"),
+            "execution_principal_kind": params.get("execution_principal_kind", "system"),
+            "attachment_paths": tuple(params.get("attachment_paths") or ()),
+            "ssh_agent_socket_snapshot": params.get("ssh_agent_socket_snapshot"),
+        }
+        if isinstance(params.get("enabled_skills"), dict):
+            retry_kwargs["command_skills"] = dict(params["enabled_skills"])
+        if isinstance(params.get("model"), str):
+            retry_kwargs["model_override"] = params["model"]
+        if params.get("queue_timestamp") is not None:
+            retry_kwargs["queue_timestamp"] = params["queue_timestamp"]
+        try:
+            admitted = await self.enqueue_message(**retry_kwargs)
+        except BaseException:
+            self.revoke_context_retry_permit(permit)
+            raise
+        if admitted is False:
+            self.revoke_context_retry_permit(permit)
+            return False
+        logger.warning("Task %d no-progress loop stopped; queued one fresh-session automatic retry", task_id)
+        return True
+
     def _consume_context_retry_authority(self, msg: QueuedMessage) -> None:
         if msg.source not in {"compact_retry", "no_progress_retry"}:
             return

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -778,6 +778,13 @@ class _ClaudeNoProgressState:
     first_seen_monotonic: float | None = None
     tool_activity_seen: bool = False
     triggered: bool = False
+    recovery_claimed: bool = False
+
+    def mark_tool_activity(self) -> None:
+        self.tool_activity_seen = True
+        self.anchor_text = None
+        self.similar_messages = 0
+        self.first_seen_monotonic = None
 
     @staticmethod
     def _normalize(content: str) -> str:
@@ -817,12 +824,11 @@ class _ClaudeNoProgressState:
     def observe(self, event: dict, *, now: float) -> bool:
         """Return True once for a sustained, effect-free incomplete loop."""
 
+        if event.get("assistant_envelope_has_tool_use") is True:
+            self.mark_tool_activity()
         event_type = event.get("event_type")
         if event_type in {"tool_use", "tool_result"}:
-            self.tool_activity_seen = True
-            self.anchor_text = None
-            self.similar_messages = 0
-            self.first_seen_monotonic = None
+            self.mark_tool_activity()
             return False
         if self.triggered or self.tool_activity_seen:
             return False
@@ -14996,16 +15002,14 @@ class InstanceManager:
         state = record.claude_no_progress
         params = self._launch_params.get(instance_id) or {}
         attempt = params.get("no_progress_retry_attempt", 0)
-        prompt = params.get("current_message") or params.get("prompt")
         requested_source_id = params.get("source_log_id")
         if not (
             state.triggered
             and not state.tool_activity_seen
+            and not state.recovery_claimed
             and state.similar_messages >= state.MIN_SIMILAR_MESSAGES
             and type(attempt) is int
             and attempt == 0
-            and isinstance(prompt, str)
-            and bool(prompt)
             and type(requested_source_id) is int
             and requested_source_id > 0
             and record.provider == "claude"
@@ -15014,6 +15018,11 @@ class InstanceManager:
             and type(record.task_turn_generation) is int
         ):
             return False
+
+        # Both PTY terminal finalization and the proxy consumer may observe the
+        # same failed generation. Claim before the first await so only one can
+        # issue a permit or enqueue a replay for this exact consumer record.
+        state.recovery_claimed = True
 
         try:
             from backend.main import dispatcher
@@ -15060,6 +15069,17 @@ class InstanceManager:
                     not in {source.id, original_id}
                     or not source_shape_is_canonical(source, original)
                 ):
+                    return False
+                replay_source = (
+                    original if source.event_type == "turn_source" else source
+                )
+                prompt = (
+                    replay_source.content
+                    if replay_source is not None
+                    and isinstance(replay_source.content, str)
+                    else None
+                )
+                if not prompt:
                     return False
                 permit_values = {
                     "task_id": task.id,

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent.futures
+import difflib
 import hashlib
 import inspect
 import json
@@ -759,6 +760,118 @@ class _OutputConsumerRecord:
     # ``assistant`` envelope and again in the terminal ``result`` envelope.
     # Keep terminal metadata but suppress only that exact repeated body.
     last_claude_assistant_text: str | None = None
+    claude_no_progress: "_ClaudeNoProgressState" = field(
+        default_factory=lambda: _ClaudeNoProgressState()
+    )
+
+
+@dataclass
+class _ClaudeNoProgressState:
+    """Detect one Claude turn repeatedly emitting similar incomplete text."""
+
+    MIN_SIMILAR_MESSAGES = 3
+    MIN_ELAPSED_SECONDS = 120.0
+    SIMILARITY_THRESHOLD = 0.45
+
+    anchor_text: str | None = None
+    similar_messages: int = 0
+    first_seen_monotonic: float | None = None
+    tool_activity_seen: bool = False
+    triggered: bool = False
+
+    @staticmethod
+    def _normalize(content: str) -> str:
+        return " ".join(content.casefold().split()).strip(" .,!?:;，。！？：；")
+
+    @staticmethod
+    def _stop_reason(event: dict) -> tuple[bool, object]:
+        if "stop_reason" in event:
+            return True, event.get("stop_reason")
+        raw = event.get("raw_json")
+        try:
+            parsed = json.loads(raw) if isinstance(raw, str) else raw
+        except (TypeError, ValueError):
+            return False, None
+        if not isinstance(parsed, dict):
+            return False, None
+        message = parsed.get("message")
+        if not isinstance(message, dict) or "stop_reason" not in message:
+            return False, None
+        return True, message.get("stop_reason")
+
+    @staticmethod
+    def session_id(event: dict) -> str | None:
+        value = event.get("session_id")
+        if isinstance(value, str) and value:
+            return value
+        raw = event.get("raw_json")
+        try:
+            parsed = json.loads(raw) if isinstance(raw, str) else raw
+        except (TypeError, ValueError):
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        value = parsed.get("sessionId") or parsed.get("session_id")
+        return value if isinstance(value, str) and value else None
+
+    def observe(self, event: dict, *, now: float) -> bool:
+        """Return True once for a sustained, effect-free incomplete loop."""
+
+        event_type = event.get("event_type")
+        if event_type in {"tool_use", "tool_result"}:
+            self.tool_activity_seen = True
+            self.anchor_text = None
+            self.similar_messages = 0
+            self.first_seen_monotonic = None
+            return False
+        if self.triggered or self.tool_activity_seen:
+            return False
+        if event_type != "message" or event.get("role") != "assistant":
+            return False
+        has_stop_reason, stop_reason = self._stop_reason(event)
+        if not has_stop_reason:
+            return False
+        if stop_reason is not None:
+            self.anchor_text = None
+            self.similar_messages = 0
+            self.first_seen_monotonic = None
+            return False
+
+        content = event.get("content")
+        if not isinstance(content, str):
+            return False
+        normalized = self._normalize(content)
+        if len(normalized) < 5:
+            return False
+
+        if self.anchor_text is None:
+            self.anchor_text = normalized
+            self.similar_messages = 1
+            self.first_seen_monotonic = now
+            return False
+
+        similarity = difflib.SequenceMatcher(
+            None,
+            self.anchor_text,
+            normalized,
+            autojunk=False,
+        ).ratio()
+        if similarity < self.SIMILARITY_THRESHOLD:
+            self.anchor_text = normalized
+            self.similar_messages = 1
+            self.first_seen_monotonic = now
+            return False
+
+        self.similar_messages += 1
+        first_seen = self.first_seen_monotonic
+        if (
+            self.similar_messages >= self.MIN_SIMILAR_MESSAGES
+            and first_seen is not None
+            and now - first_seen >= self.MIN_ELAPSED_SECONDS
+        ):
+            self.triggered = True
+            return True
+        return False
 
 
 @dataclass
@@ -3231,6 +3344,7 @@ class InstanceManager:
         ssh_agent_socket_snapshot: _SshAgentSocketSnapshot | None = None,
         context_retry_permit: object | None = None,
         context_retry_claimed_source_log_id: int | None = None,
+        no_progress_retry_attempt: int = 0,
     ) -> int:
         """Admit one turn and spend continuation authority on every attempt.
 
@@ -3278,6 +3392,7 @@ class InstanceManager:
                 context_retry_claimed_source_log_id=(
                     context_retry_claimed_source_log_id
                 ),
+                no_progress_retry_attempt=no_progress_retry_attempt,
             )
         finally:
             self.revoke_sequential_turn_continuation(
@@ -3317,6 +3432,7 @@ class InstanceManager:
         sequential_turn_token: object | None = None,
         context_retry_permit: object | None = None,
         context_retry_claimed_source_log_id: int | None = None,
+        no_progress_retry_attempt: int = 0,
     ) -> int:
         """Atomically admit one turn into a reusable instance slot."""
 
@@ -3431,6 +3547,9 @@ class InstanceManager:
                                 ),
                                 context_retry_claimed_source_log_id=(
                                     context_retry_claimed_source_log_id
+                                ),
+                                no_progress_retry_attempt=(
+                                    no_progress_retry_attempt
                                 ),
                             )
                     except BaseException:
@@ -4346,6 +4465,7 @@ class InstanceManager:
         ssh_agent_socket_snapshot: _SshAgentSocketSnapshot | None = None,
         context_retry_permit: object | None = None,
         context_retry_claimed_source_log_id: int | None = None,
+        no_progress_retry_attempt: int = 0,
     ) -> int:
         """Launch a Claude Code subprocess for the given instance.
 
@@ -6368,6 +6488,7 @@ class InstanceManager:
                 "execution_principal_kind": execution_principal_kind,
                 "attachment_paths": tuple(attachment_paths),
                 "ssh_agent_socket_snapshot": ssh_agent_socket_snapshot,
+                "no_progress_retry_attempt": no_progress_retry_attempt,
             }
 
         return await self._persist_and_track_launch(
@@ -11727,11 +11848,11 @@ class InstanceManager:
             )
 
         ec = exit_code if exit_code is not None else 0
+        provider_error = (record.fatal_provider_error or "").strip()
         interrupted = ec in (-2, 130)
-        successful_terminal = ec == 0 or interrupted
+        successful_terminal = (ec == 0 or interrupted) and not provider_error
         final_status = "completed" if successful_terminal else "failed"
         completed_at = datetime.utcnow()
-        provider_error = (record.fatal_provider_error or "").strip()
         failure_notice_data = None
 
         def background_handoff_pending() -> bool:
@@ -12155,14 +12276,17 @@ class InstanceManager:
                 if (
                     not preserve_background_failure
                     and not successful_terminal
-                    and provider_error.startswith("Response timed out")
+                    and (
+                        provider_error.startswith("Response timed out")
+                        or provider_error.startswith(
+                            "Claude response made no progress"
+                        )
+                    )
                 ):
-                    # A silent Claude PTY timeout means the persisted native
-                    # turn may contain an unmatched tool_use. Resuming that
-                    # session deterministically reproduced the same dead turn
-                    # in production (task 315). Fence it off so the next user
-                    # turn starts a fresh native session instead of replaying
-                    # corrupted executor state.
+                    # A silent timeout may leave an unmatched tool_use, while
+                    # a no-progress loop proves the native turn itself is not
+                    # converging. Fence either session off so the next user
+                    # message starts fresh instead of resuming bad state.
                     task.session_id = None
                     task.context_window_usage = None
                     await db.flush()
@@ -12262,6 +12386,18 @@ class InstanceManager:
                                 return "background_armed"
                             return None
                 await db.commit()
+
+            if (
+                not preserve_background_failure
+                and provider_error.startswith(
+                    "Claude response made no progress"
+                )
+            ):
+                await self._try_enqueue_no_progress_recovery(
+                    instance_id,
+                    task_id,
+                    record,
+                )
 
             if preserve_background_failure:
                 # The watchdog already committed and broadcast the precise
@@ -13250,6 +13386,28 @@ class InstanceManager:
                 await asyncio.gather(reader, return_exceptions=True)
             raise
 
+    async def _interrupt_no_progress_claude_turn(
+        self,
+        instance_id: int,
+        process: asyncio.subprocess.Process,
+    ) -> None:
+        """Interrupt only the exact Claude generation that emitted the loop."""
+
+        backend = self._pty_backend
+        session = getattr(process, "session", None)
+        if (
+            backend is not None
+            and session is not None
+            and getattr(backend, "_sessions", {}).get(instance_id) is session
+        ):
+            await session.send_interrupt()
+            return
+        await self._signal_managed_process_tree(
+            instance_id,
+            process,
+            signal.SIGINT,
+        )
+
     async def _consume_output_impl(self, instance_id: int, task_id: int | None, process: asyncio.subprocess.Process, loop_iteration: int | None = None, chat_initiated: bool = False, provider: str = "claude"):
         """Read NDJSON lines from stdout, parse, store, and broadcast.
 
@@ -13348,6 +13506,14 @@ class InstanceManager:
                                     record if tracked_generation else None
                                 ),
                             )
+                            if (
+                                record is not None
+                                and record.fatal_provider_error
+                                and _fatal_provider_error is None
+                            ):
+                                _fatal_provider_error = (
+                                    record.fatal_provider_error[:2000]
+                                )
                             if event.get("event_type") == "rate_limit_event":
                                 # Only a genuine near-limit/blocked event should
                                 # evaluate a switch. The CLI emits an
@@ -13424,7 +13590,7 @@ class InstanceManager:
             # DB ownership plus generation maps if proof still fails.
             reap_error = exc
         exit_code = process.returncode
-        if exit_code == 0 and _fatal_provider_error:
+        if exit_code in (0, -2, 130) and _fatal_provider_error:
             # The CLI can report a structurally failed provider turn while
             # exiting cleanly. Use the semantic result for retries and durable
             # task status; process health must not turn an API error into a
@@ -13925,6 +14091,15 @@ class InstanceManager:
                                 else f"Process exited with code {exit_code}"
                             )
                         await db.flush()
+                    if (
+                        not successful_terminal
+                        and failure_text.startswith(
+                            "Claude response made no progress"
+                        )
+                    ):
+                        current_task_generation.session_id = None
+                        current_task_generation.context_window_usage = None
+                        await db.flush()
                     final_status = current_task_generation.status
                     if not successful_terminal and not _fatal_provider_error:
                         process_label = self._provider_process_label(
@@ -14046,6 +14221,18 @@ class InstanceManager:
                 )
                 return
             await db.commit()
+
+        if (
+            task_id
+            and chat_initiated
+            and record is not None
+            and failure_text.startswith("Claude response made no progress")
+        ):
+            await self._try_enqueue_no_progress_recovery(
+                instance_id,
+                task_id,
+                record,
+            )
 
         await self._publish_agent_terminal_admission(admission)
 
@@ -14798,6 +14985,148 @@ class InstanceManager:
                 return True
             return source.actual_transport is not None
 
+    async def _try_enqueue_no_progress_recovery(
+        self,
+        instance_id: int,
+        task_id: int,
+        record: _OutputConsumerRecord,
+    ) -> bool:
+        """Queue one fresh-session replay after a proven effect-free loop."""
+
+        state = record.claude_no_progress
+        params = self._launch_params.get(instance_id) or {}
+        attempt = params.get("no_progress_retry_attempt", 0)
+        prompt = params.get("current_message") or params.get("prompt")
+        requested_source_id = params.get("source_log_id")
+        if not (
+            state.triggered
+            and not state.tool_activity_seen
+            and state.similar_messages >= state.MIN_SIMILAR_MESSAGES
+            and type(attempt) is int
+            and attempt == 0
+            and isinstance(prompt, str)
+            and bool(prompt)
+            and type(requested_source_id) is int
+            and requested_source_id > 0
+            and record.provider == "claude"
+            and record.task_id == task_id
+            and type(record.task_retry_count) is int
+            and type(record.task_turn_generation) is int
+        ):
+            return False
+
+        try:
+            from backend.main import dispatcher
+            from backend.services.dispatcher import PRIORITY_USER
+            from backend.services.terminal_arbitration import (
+                source_alias_original_log_id,
+                source_shape_is_canonical,
+            )
+
+            if dispatcher is None:
+                return False
+            async with self.db_factory() as db:
+                task = await db.get(Task, task_id)
+                if (
+                    task is None
+                    or (task.provider or "claude").lower() != "claude"
+                    or task.status != "failed"
+                    or task.instance_id != instance_id
+                    or task.retry_count != record.task_retry_count
+                    or task.turn_generation != record.task_turn_generation
+                    or task.session_id is not None
+                    or type(task.turn_source_log_id) is not int
+                    or task.turn_source_log_id <= 0
+                ):
+                    return False
+                source = await db.get(LogEntry, task.turn_source_log_id)
+                original_id = (
+                    source_alias_original_log_id(source)
+                    if source is not None
+                    else None
+                )
+                original = (
+                    await db.get(LogEntry, original_id)
+                    if original_id is not None
+                    else None
+                )
+                if (
+                    source is None
+                    or source.task_id != task.id
+                    or source.task_retry_count != task.retry_count
+                    or source.task_turn_generation != task.turn_generation
+                    or source.turn_scope != "source"
+                    or requested_source_id
+                    not in {source.id, original_id}
+                    or not source_shape_is_canonical(source, original)
+                ):
+                    return False
+                permit_values = {
+                    "task_id": task.id,
+                    "instance_id": instance_id,
+                    "retry_count": task.retry_count,
+                    "turn_generation": task.turn_generation,
+                    "turn_source_log_id": task.turn_source_log_id,
+                    "session_id": None,
+                    "started_at": task.started_at,
+                    "completed_at": task.completed_at,
+                }
+
+            permit = dispatcher.issue_context_retry_permit(**permit_values)
+            retry_kwargs = {
+                "task_id": task_id,
+                "prompt": prompt,
+                "priority": PRIORITY_USER,
+                "source": "no_progress_retry",
+                "source_log_id": requested_source_id,
+                "current_message": prompt,
+                "allow_new_session": True,
+                "context_retry_permit": permit,
+                "no_progress_retry_attempt": 1,
+                "initiating_user_id": params.get("initiating_user_id"),
+                "initiating_user_role": params.get(
+                    "initiating_user_role", "member"
+                ),
+                "execution_mode": params.get("execution_mode", "sandbox"),
+                "execution_principal_kind": params.get(
+                    "execution_principal_kind", "system"
+                ),
+                "attachment_paths": tuple(
+                    params.get("attachment_paths") or ()
+                ),
+                "ssh_agent_socket_snapshot": params.get(
+                    "ssh_agent_socket_snapshot"
+                ),
+            }
+            if isinstance(params.get("enabled_skills"), dict):
+                retry_kwargs["command_skills"] = dict(
+                    params["enabled_skills"]
+                )
+            if isinstance(params.get("model"), str):
+                retry_kwargs["model_override"] = params["model"]
+            if params.get("queue_timestamp") is not None:
+                retry_kwargs["queue_timestamp"] = params["queue_timestamp"]
+            try:
+                admitted = await dispatcher.enqueue_message(**retry_kwargs)
+            except BaseException:
+                dispatcher.revoke_context_retry_permit(permit)
+                raise
+            if admitted is False:
+                dispatcher.revoke_context_retry_permit(permit)
+                return False
+            logger.warning(
+                "Task %d no-progress loop stopped; queued one fresh-session "
+                "automatic retry",
+                task_id,
+            )
+            return True
+        except Exception:
+            logger.exception(
+                "Could not safely enqueue no-progress recovery for task %d",
+                task_id,
+            )
+            return False
+
     async def _try_chat_transient_retry(
         self, instance_id: int, task_id: int, exit_code: int, stderr_text: str,
     ) -> bool:
@@ -14919,6 +15248,9 @@ class InstanceManager:
                 ),
                 ssh_agent_socket_snapshot=params.get(
                     "ssh_agent_socket_snapshot"
+                ),
+                no_progress_retry_attempt=params.get(
+                    "no_progress_retry_attempt", 0
                 ),
             )
             return True
@@ -15170,6 +15502,9 @@ class InstanceManager:
                     ssh_agent_socket_snapshot=params.get(
                         "ssh_agent_socket_snapshot"
                     ),
+                    no_progress_retry_attempt=params.get(
+                        "no_progress_retry_attempt", 0
+                    ),
                 )
                 return True
 
@@ -15321,6 +15656,9 @@ class InstanceManager:
                 ),
                 ssh_agent_socket_snapshot=params.get(
                     "ssh_agent_socket_snapshot"
+                ),
+                no_progress_retry_attempt=params.get(
+                    "no_progress_retry_attempt", 0
                 ),
             )
             return True
@@ -16632,6 +16970,96 @@ class InstanceManager:
                 task_id,
             )
             return
+        if (
+            provider == "claude"
+            and event_record is not None
+            and event_record.chat_initiated
+            and not background_scoped
+            and not event.get("orphan")
+            and not event.get("autonomous")
+        ):
+            no_progress = event_record.claude_no_progress
+            process_session_id = getattr(
+                getattr(event_record.process, "session", None),
+                "session_id",
+                None,
+            )
+            exact_event_source = explicit_consumer_record or (
+                isinstance(process_session_id, str)
+                and process_session_id
+                and no_progress.session_id(event) == process_session_id
+            )
+            if not exact_event_source:
+                no_progress = None
+        else:
+            no_progress = None
+        if no_progress is not None:
+            triggered = no_progress.observe(event, now=time.monotonic())
+            has_stop_reason, stop_reason = no_progress._stop_reason(event)
+            if (
+                no_progress.triggered
+                and not triggered
+                and event.get("event_type") == "message"
+                and event.get("role") == "assistant"
+                and has_stop_reason
+                and stop_reason is None
+            ):
+                return
+            if triggered:
+                retry_attempt = (
+                    self._launch_params.get(instance_id, {}).get(
+                        "no_progress_retry_attempt", 0
+                    )
+                )
+                failure = (
+                    "Claude response made no progress: repeated similar "
+                    "incomplete assistant messages for at least two minutes"
+                )
+                object.__setattr__(
+                    event_record,
+                    "fatal_provider_error",
+                    failure,
+                )
+                logger.error(
+                    "Interrupting no-progress Claude turn for instance %s "
+                    "task %s after %s similar incomplete messages",
+                    instance_id,
+                    task_id,
+                    no_progress.similar_messages,
+                )
+                await self._interrupt_no_progress_claude_turn(
+                    instance_id,
+                    event_record.process,
+                )
+                event = dict(event)
+                event.update(
+                    event_type="system_event",
+                    role="system",
+                    content=(
+                        (
+                            "Claude 连续返回未完成且高度相似的回复，CCM 已"
+                            "中止异常回合，将尝试使用新会话自动恢复（仅重试一次）。"
+                        )
+                        if retry_attempt == 0
+                        else (
+                            "Claude 在自动恢复后仍连续返回未完成且高度相似的"
+                            "回复，CCM 已停止本轮。请重新发送消息后重试。"
+                        )
+                    ),
+                    is_error=True,
+                    protocol_anomaly="claude_no_progress_loop",
+                    raw_json=json.dumps(
+                        {
+                            "type": "ccm.turn.failed",
+                            "version": 1,
+                            "provider": "claude",
+                            "reason": "no_progress_loop",
+                            "recovery_attempt": retry_attempt,
+                        },
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    ),
+                )
         fatal_provider_error = self._fatal_provider_error_for_event(event)
         if (
             fatal_provider_error

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -772,6 +772,7 @@ class _ClaudeNoProgressState:
     MIN_SIMILAR_MESSAGES = 3
     MIN_ELAPSED_SECONDS = 120.0
     SIMILARITY_THRESHOLD = 0.45
+    COMPARISON_TEXT_LIMIT = 1024
 
     anchor_text: str | None = None
     similar_messages: int = 0
@@ -786,9 +787,25 @@ class _ClaudeNoProgressState:
         self.similar_messages = 0
         self.first_seen_monotonic = None
 
-    @staticmethod
-    def _normalize(content: str) -> str:
-        return " ".join(content.casefold().split()).strip(" .,!?:;，。！？：；")
+    @classmethod
+    def _representative_text(cls, content: str) -> str:
+        """Keep similarity work bounded while retaining both response ends."""
+
+        limit = cls.COMPARISON_TEXT_LIMIT
+        if len(content) <= limit:
+            return content
+        head = limit // 2
+        return content[:head] + content[-(limit - head):]
+
+    @classmethod
+    def _normalize(cls, content: str) -> str:
+        sampled = cls._representative_text(content)
+        normalized = " ".join(sampled.casefold().split()).strip(
+            " .,!?:;，。！？：；"
+        )
+        # Unicode case folding can expand a bounded source string. Apply the
+        # same representative cap again so SequenceMatcher has a hard limit.
+        return cls._representative_text(normalized)
 
     @staticmethod
     def _stop_reason(event: dict) -> tuple[bool, object]:

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -1068,6 +1068,8 @@ class InstanceManager:
         # tests) from importing the process-global Dispatcher and enqueueing
         # work against an unrelated database.
         self.task_message_enqueuer = None
+        # Dispatcher-owned capability for effect-free Claude recovery.
+        self.no_progress_recovery_scheduler = None
         # Dispatcher installs this optional terminal hook.  It is invoked only
         # after a completed Task's exact detached epoch is durably cleared, so
         # PR/share-style terminal consumers cannot observe partial output.
@@ -15041,122 +15043,16 @@ class InstanceManager:
         # issue a permit or enqueue a replay for this exact consumer record.
         state.recovery_claimed = True
 
+        scheduler = self.no_progress_recovery_scheduler
+        if scheduler is None:
+            return False
         try:
-            from backend.main import dispatcher
-            from backend.services.dispatcher import PRIORITY_USER
-            from backend.services.terminal_arbitration import (
-                source_alias_original_log_id,
-                source_shape_is_canonical,
-            )
-
-            if dispatcher is None:
-                return False
-            async with self.db_factory() as db:
-                task = await db.get(Task, task_id)
-                if (
-                    task is None
-                    or (task.provider or "claude").lower() != "claude"
-                    or task.status != "failed"
-                    or task.instance_id != instance_id
-                    or task.retry_count != record.task_retry_count
-                    or task.turn_generation != record.task_turn_generation
-                    or task.session_id is not None
-                    or type(task.turn_source_log_id) is not int
-                    or task.turn_source_log_id <= 0
-                ):
-                    return False
-                source = await db.get(LogEntry, task.turn_source_log_id)
-                original_id = (
-                    source_alias_original_log_id(source)
-                    if source is not None
-                    else None
-                )
-                original = (
-                    await db.get(LogEntry, original_id)
-                    if original_id is not None
-                    else None
-                )
-                if (
-                    source is None
-                    or source.task_id != task.id
-                    or source.task_retry_count != task.retry_count
-                    or source.task_turn_generation != task.turn_generation
-                    or source.turn_scope != "source"
-                    or requested_source_id
-                    not in {source.id, original_id}
-                    or not source_shape_is_canonical(source, original)
-                ):
-                    return False
-                replay_source = (
-                    original if source.event_type == "turn_source" else source
-                )
-                prompt = (
-                    replay_source.content
-                    if replay_source is not None
-                    and isinstance(replay_source.content, str)
-                    else None
-                )
-                if not prompt:
-                    return False
-                permit_values = {
-                    "task_id": task.id,
-                    "instance_id": instance_id,
-                    "retry_count": task.retry_count,
-                    "turn_generation": task.turn_generation,
-                    "turn_source_log_id": task.turn_source_log_id,
-                    "session_id": None,
-                    "started_at": task.started_at,
-                    "completed_at": task.completed_at,
-                }
-
-            permit = dispatcher.issue_context_retry_permit(**permit_values)
-            retry_kwargs = {
-                "task_id": task_id,
-                "prompt": prompt,
-                "priority": PRIORITY_USER,
-                "source": "no_progress_retry",
-                "source_log_id": requested_source_id,
-                "current_message": prompt,
-                "allow_new_session": True,
-                "context_retry_permit": permit,
-                "no_progress_retry_attempt": 1,
-                "initiating_user_id": params.get("initiating_user_id"),
-                "initiating_user_role": params.get(
-                    "initiating_user_role", "member"
-                ),
-                "execution_mode": params.get("execution_mode", "sandbox"),
-                "execution_principal_kind": params.get(
-                    "execution_principal_kind", "system"
-                ),
-                "attachment_paths": tuple(
-                    params.get("attachment_paths") or ()
-                ),
-                "ssh_agent_socket_snapshot": params.get(
-                    "ssh_agent_socket_snapshot"
-                ),
-            }
-            if isinstance(params.get("enabled_skills"), dict):
-                retry_kwargs["command_skills"] = dict(
-                    params["enabled_skills"]
-                )
-            if isinstance(params.get("model"), str):
-                retry_kwargs["model_override"] = params["model"]
-            if params.get("queue_timestamp") is not None:
-                retry_kwargs["queue_timestamp"] = params["queue_timestamp"]
-            try:
-                admitted = await dispatcher.enqueue_message(**retry_kwargs)
-            except BaseException:
-                dispatcher.revoke_context_retry_permit(permit)
-                raise
-            if admitted is False:
-                dispatcher.revoke_context_retry_permit(permit)
-                return False
-            logger.warning(
-                "Task %d no-progress loop stopped; queued one fresh-session "
-                "automatic retry",
-                task_id,
-            )
-            return True
+            return bool(await scheduler(
+                task_id=task_id,
+                instance_id=instance_id,
+                record=record,
+                params=params,
+            ))
         except Exception:
             logger.exception(
                 "Could not safely enqueue no-progress recovery for task %d",

--- a/backend/services/stream_parser.py
+++ b/backend/services/stream_parser.py
@@ -168,6 +168,7 @@ class StreamParser:
                 event = _base_event()
                 event["role"] = "assistant"
                 event["event_type"] = "message"
+                event["stop_reason"] = message_obj.get("stop_reason")
                 anomaly = detect_assistant_protocol_anomaly(
                     event["event_type"],
                     event["role"],
@@ -211,6 +212,7 @@ class StreamParser:
                 event = _base_event()
                 event["role"] = "assistant"
                 event["event_type"] = "message"
+                event["stop_reason"] = message_obj.get("stop_reason")
                 if data.get("isApiErrorMessage"):
                     event["is_error"] = True
                 if usage_data:
@@ -219,6 +221,9 @@ class StreamParser:
             if data.get("isApiErrorMessage"):
                 for event in events:
                     event["is_error"] = True
+            stop_reason = message_obj.get("stop_reason")
+            for event in events:
+                event["stop_reason"] = stop_reason
             # Attach usage data to the first event only
             if usage_data and events:
                 events[0]["context_usage"] = usage_data

--- a/backend/services/stream_parser.py
+++ b/backend/services/stream_parser.py
@@ -168,7 +168,8 @@ class StreamParser:
                 event = _base_event()
                 event["role"] = "assistant"
                 event["event_type"] = "message"
-                event["stop_reason"] = message_obj.get("stop_reason")
+                if "stop_reason" in message_obj:
+                    event["stop_reason"] = message_obj["stop_reason"]
                 anomaly = detect_assistant_protocol_anomaly(
                     event["event_type"],
                     event["role"],
@@ -182,11 +183,18 @@ class StreamParser:
                     event["context_usage"] = usage_data
                 return [event]
             events = []
+            envelope_has_tool_use = any(
+                isinstance(block, dict) and block.get("type") == "tool_use"
+                for block in content_blocks
+            )
             for block in content_blocks:
                 if not isinstance(block, dict):
                     continue
                 evt = _base_event()
                 evt["role"] = "assistant"
+                evt["assistant_envelope_has_tool_use"] = (
+                    envelope_has_tool_use
+                )
                 if block.get("type") == "tool_use":
                     evt["event_type"] = "tool_use"
                     evt["tool_name"] = block.get("name")
@@ -212,7 +220,8 @@ class StreamParser:
                 event = _base_event()
                 event["role"] = "assistant"
                 event["event_type"] = "message"
-                event["stop_reason"] = message_obj.get("stop_reason")
+                if "stop_reason" in message_obj:
+                    event["stop_reason"] = message_obj["stop_reason"]
                 if data.get("isApiErrorMessage"):
                     event["is_error"] = True
                 if usage_data:
@@ -221,9 +230,10 @@ class StreamParser:
             if data.get("isApiErrorMessage"):
                 for event in events:
                     event["is_error"] = True
-            stop_reason = message_obj.get("stop_reason")
-            for event in events:
-                event["stop_reason"] = stop_reason
+            if "stop_reason" in message_obj:
+                stop_reason = message_obj["stop_reason"]
+                for event in events:
+                    event["stop_reason"] = stop_reason
             # Attach usage data to the first event only
             if usage_data and events:
                 events[0]["context_usage"] = usage_data

--- a/backend/tests/test_instance_manager_capability_terminal.py
+++ b/backend/tests/test_instance_manager_capability_terminal.py
@@ -486,6 +486,57 @@ async def test_successful_auto_terminal_atomically_yields_to_capability(
 
 
 @pytest.mark.asyncio
+async def test_no_progress_pty_interrupt_fails_and_clears_native_session(
+    db_factory,
+):
+    scope = await _terminal_scope(
+        db_factory,
+        transport="claude_pty",
+        reason="must not execute after a no-progress loop",
+        generation=4,
+        pid=81_004,
+    )
+    manager = InstanceManager(db_factory, MagicMock(broadcast=AsyncMock()))
+    process = _process(pid=scope.pid, returncode=130)
+    manager.processes[scope.instance_id] = process
+    record = manager._track_output_consumer(
+        scope.instance_id,
+        process,
+        asyncio.current_task(),
+        chat_initiated=True,
+        provider="claude",
+        task_id=scope.task_id,
+        task_retry_count=scope.retry_count,
+        task_turn_generation=scope.generation,
+        instance_started_at=scope.started_at,
+    )
+    object.__setattr__(
+        record,
+        "fatal_provider_error",
+        "Claude response made no progress: test reproduction",
+    )
+
+    status = await manager.finalize_pty_chat_generation(
+        scope.instance_id,
+        scope.task_id,
+        130,
+        record,
+    )
+
+    assert status == "failed"
+    async with db_factory() as db:
+        task = await db.get(Task, scope.task_id)
+        instance = await db.get(Instance, scope.instance_id)
+        assert task.status == "failed"
+        assert task.session_id is None
+        assert task.context_window_usage is None
+        assert "made no progress" in task.error_message
+        assert instance.status == "error"
+        assert instance.pid is None
+        assert instance.current_task_id is None
+
+
+@pytest.mark.asyncio
 async def test_resumed_generation_settles_then_requests_next_capability(
     db_factory,
     monkeypatch,

--- a/backend/tests/test_service_dispatcher.py
+++ b/backend/tests/test_service_dispatcher.py
@@ -601,6 +601,130 @@ async def test_no_progress_retry_claims_next_generation_with_fresh_session(
     assert current.session_id is None
 
 
+@pytest.mark.asyncio
+async def test_no_progress_scheduler_validates_and_enqueues_recovery(db_factory):
+    started_at = datetime(2026, 8, 24, 10, 5, 0)
+    async with db_factory() as db:
+        instance = Instance(name="scheduler-source", status="error")
+        task = Task(
+            title="scheduler recovery", status="failed", provider="claude",
+            retry_count=0, turn_generation=3, instance_id=None,
+            session_id=None, started_at=started_at,
+        )
+        db.add_all([instance, task])
+        await db.flush()
+        task.instance_id = instance.id
+        source = LogEntry(
+            instance_id=instance.id, task_id=task.id,
+            task_retry_count=0, task_turn_generation=3, turn_scope="source",
+            event_type="user_message", role="user", content="authoritative input",
+            raw_json=_system_source_metadata(raw_content="authoritative input"),
+            is_error=False, actual_transport="claude_pty",
+        )
+        db.add(source)
+        await db.flush()
+        task.turn_source_log_id = source.id
+        await db.commit()
+        task_id, instance_id, source_id = task.id, instance.id, source.id
+
+    dispatcher = _make_dispatcher(db_factory)
+    dispatcher._ensure_queue_worker = MagicMock()
+    record = SimpleNamespace(task_retry_count=0, task_turn_generation=3)
+    ok = await dispatcher.enqueue_no_progress_recovery(
+        task_id=task_id,
+        instance_id=instance_id,
+        record=record,
+        params={"source_log_id": source_id, "no_progress_retry_attempt": 0},
+    )
+    assert ok is True
+    queued = dispatcher._get_task_queue(task_id).get_nowait()
+    assert queued.source == "no_progress_retry"
+    assert queued.prompt == "authoritative input"
+    assert queued.allow_new_session is True
+    assert queued.no_progress_retry_attempt == 1
+    assert queued.context_retry_permit is not None
+    assert dispatcher._context_retry_authority_is_live(queued)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"turn_generation": 4},
+        {"session_id": "already-live"},
+    ],
+)
+async def test_no_progress_scheduler_rejects_stale_generation_or_session(
+    db_factory, changes,
+):
+    async with db_factory() as db:
+        instance = Instance(name="scheduler-reject", status="error")
+        task = Task(
+            title="scheduler reject", status="failed", provider="claude",
+            retry_count=0, turn_generation=3, instance_id=None, session_id=None,
+        )
+        db.add_all([instance, task])
+        await db.flush()
+        task.instance_id = instance.id
+        source = LogEntry(
+            instance_id=instance.id, task_id=task.id,
+            task_retry_count=0, task_turn_generation=3, turn_scope="source",
+            event_type="user_message", role="user", content="input",
+            raw_json=_system_source_metadata(raw_content="input"),
+            is_error=False, actual_transport="claude_pty",
+        )
+        db.add(source)
+        await db.flush()
+        task.turn_source_log_id = source.id
+        for key, value in changes.items():
+            setattr(task, key, value)
+        await db.commit()
+        task_id, instance_id, source_id = task.id, instance.id, source.id
+    dispatcher = _make_dispatcher(db_factory)
+    dispatcher.enqueue_message = AsyncMock()
+    result = await dispatcher.enqueue_no_progress_recovery(
+        task_id=task_id, instance_id=instance_id,
+        record=SimpleNamespace(task_retry_count=0, task_turn_generation=3),
+        params={"source_log_id": source_id, "no_progress_retry_attempt": 0},
+    )
+    assert result is False
+    dispatcher.enqueue_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_progress_scheduler_revokes_permit_on_enqueue_failure(db_factory):
+    async with db_factory() as db:
+        instance = Instance(name="scheduler-failure", status="error")
+        task = Task(
+            title="scheduler failure", status="failed", provider="claude",
+            retry_count=0, turn_generation=3, instance_id=None, session_id=None,
+        )
+        db.add_all([instance, task])
+        await db.flush()
+        task.instance_id = instance.id
+        source = LogEntry(
+            instance_id=instance.id, task_id=task.id,
+            task_retry_count=0, task_turn_generation=3, turn_scope="source",
+            event_type="user_message", role="user", content="input",
+            raw_json=_system_source_metadata(raw_content="input"),
+            is_error=False, actual_transport="claude_pty",
+        )
+        db.add(source)
+        await db.flush()
+        task.turn_source_log_id = source.id
+        await db.commit()
+        task_id, instance_id, source_id = task.id, instance.id, source.id
+    dispatcher = _make_dispatcher(db_factory)
+    dispatcher.enqueue_message = AsyncMock(side_effect=RuntimeError("queue down"))
+    with pytest.raises(RuntimeError):
+        await dispatcher.enqueue_no_progress_recovery(
+            task_id=task_id, instance_id=instance_id,
+            record=SimpleNamespace(task_retry_count=0, task_turn_generation=3),
+            params={"source_log_id": source_id, "no_progress_retry_attempt": 0},
+        )
+    assert dispatcher._context_retry_authorities == {}
+
+
 async def _bind_hidden_lifecycle_source(db_factory, task_id: int) -> None:
     from backend.services.terminal_arbitration import bind_turn_source
 

--- a/backend/tests/test_service_dispatcher.py
+++ b/backend/tests/test_service_dispatcher.py
@@ -25,6 +25,7 @@ from backend.services.dispatcher import (
     WorkerTurnLaunchOutcomeUncertainError,
     _ModeTurnSequence,
     _ModeTurnTerminalProof,
+    _context_retry_permit_matches,
     _prepend_task_artifact_policy,
     _should_ensure_agent_docs,
 )
@@ -467,6 +468,137 @@ async def test_compact_retry_without_generation_permit_fails_closed(db_factory):
         assert current.retry_count == 1
         assert current.turn_generation == 3
         assert current.session_id is None
+
+
+def test_no_progress_retry_requires_and_matches_exact_generation_permit():
+    started_at = datetime(2026, 8, 24, 10, 0, 0)
+    task = Task(
+        id=41,
+        title="no-progress retry permit",
+        status="failed",
+        provider="claude",
+        retry_count=2,
+        turn_generation=8,
+        instance_id=17,
+        turn_source_log_id=91,
+        session_id=None,
+        started_at=started_at,
+        completed_at=None,
+    )
+    unproven = QueuedMessage(
+        priority=0,
+        timestamp=0,
+        prompt="retry",
+        source="no_progress_retry",
+        no_progress_retry_attempt=1,
+    )
+    proven = QueuedMessage(
+        priority=0,
+        timestamp=0,
+        prompt="retry",
+        source="no_progress_retry",
+        no_progress_retry_attempt=1,
+        context_retry_permit=ContextRetryPermit(
+            task_id=41,
+            instance_id=17,
+            retry_count=2,
+            turn_generation=8,
+            turn_source_log_id=91,
+            session_id=None,
+            started_at=started_at,
+            completed_at=None,
+        ),
+    )
+
+    assert _context_retry_permit_matches(task, unproven) is False
+    assert _context_retry_permit_matches(task, proven) is True
+
+
+@pytest.mark.asyncio
+async def test_no_progress_retry_claims_next_generation_with_fresh_session(
+    db_factory,
+):
+    started_at = datetime(2026, 8, 24, 10, 5, 0)
+    async with db_factory() as db:
+        previous = Instance(name="failed-no-progress", status="error")
+        idle = Instance(name="fresh-recovery-slot", status="idle")
+        db.add_all([previous, idle])
+        await db.flush()
+        task = Task(
+            title="no-progress automatic recovery",
+            description="retry once",
+            target_repo="/tmp",
+            status="failed",
+            provider="claude",
+            retry_count=0,
+            turn_generation=4,
+            instance_id=previous.id,
+            session_id=None,
+            started_at=started_at,
+            completed_at=None,
+        )
+        db.add(task)
+        await db.flush()
+        source = LogEntry(
+            instance_id=previous.id,
+            task_id=task.id,
+            task_retry_count=task.retry_count,
+            task_turn_generation=task.turn_generation,
+            turn_scope="source",
+            event_type="user_message",
+            role="user",
+            content="finish the document",
+            raw_json=_system_source_metadata(
+                raw_content="finish the document",
+            ),
+            is_error=False,
+            actual_transport="claude_pty",
+        )
+        db.add(source)
+        await db.flush()
+        task.turn_source_log_id = source.id
+        await db.commit()
+        task_id = task.id
+        previous_id = previous.id
+        source_id = source.id
+
+    dispatcher = _make_dispatcher(db_factory)
+    dispatcher._ensure_queue_worker = MagicMock()
+    dispatcher._resolve_resume_config_dir = AsyncMock(return_value=None)
+    permit = dispatcher.issue_context_retry_permit(
+        task_id=task_id,
+        instance_id=previous_id,
+        retry_count=0,
+        turn_generation=4,
+        turn_source_log_id=source_id,
+        session_id=None,
+        started_at=started_at,
+        completed_at=None,
+    )
+    await dispatcher.enqueue_message(
+        task_id=task_id,
+        prompt="finish the document",
+        source="no_progress_retry",
+        source_log_id=source_id,
+        current_message="finish the document",
+        allow_new_session=True,
+        context_retry_permit=permit,
+        no_progress_retry_attempt=1,
+    )
+    queued = dispatcher._get_task_queue(task_id).get_nowait()
+
+    await dispatcher._process_queued_message(task_id, queued)
+
+    dispatcher.instance_manager.launch.assert_awaited_once()
+    launch = dispatcher.instance_manager.launch.await_args.kwargs
+    assert launch["resume_session_id"] is None
+    assert launch["task_turn_generation"] == 5
+    assert launch["no_progress_retry_attempt"] == 1
+    async with db_factory() as db:
+        current = await db.get(Task, task_id)
+    assert current.status == "executing"
+    assert current.turn_generation == 5
+    assert current.session_id is None
 
 
 async def _bind_hidden_lifecycle_source(db_factory, task_id: int) -> None:

--- a/backend/tests/test_service_instance_manager.py
+++ b/backend/tests/test_service_instance_manager.py
@@ -1,5 +1,6 @@
 """Tests for InstanceManager — subprocess lifecycle management."""
 import asyncio
+import difflib
 import json
 import os
 import signal
@@ -191,6 +192,46 @@ def test_claude_no_progress_state_reproduces_task_584_sequence():
         _incomplete_claude_message("让我重写一版。"),
         now=180,
     )
+
+
+def test_claude_no_progress_similarity_bounds_large_repetitive_text(
+    monkeypatch,
+):
+    state = _ClaudeNoProgressState()
+    huge = "I will rewrite this now. " + ("abcabc" * 200_000) + " ending"
+    compared_lengths = []
+    real_matcher = difflib.SequenceMatcher
+
+    def bounded_matcher(_isjunk, left, right, *, autojunk):
+        compared_lengths.append((len(left), len(right)))
+        return real_matcher(None, left, right, autojunk=autojunk)
+
+    monkeypatch.setattr(
+        "backend.services.instance_manager.difflib.SequenceMatcher",
+        bounded_matcher,
+    )
+
+    assert not state.observe(_incomplete_claude_message(huge), now=0)
+    assert len(state.anchor_text) <= state.COMPARISON_TEXT_LIMIT
+    assert not state.observe(_incomplete_claude_message(huge), now=60)
+    assert state.observe(_incomplete_claude_message(huge), now=121)
+    assert len(state.anchor_text) <= state.COMPARISON_TEXT_LIMIT
+    assert compared_lengths
+    assert all(
+        left <= state.COMPARISON_TEXT_LIMIT
+        and right <= state.COMPARISON_TEXT_LIMIT
+        for left, right in compared_lengths
+    )
+
+
+def test_claude_no_progress_sampling_retains_both_response_ends():
+    state = _ClaudeNoProgressState()
+    middle = "x" * (state.COMPARISON_TEXT_LIMIT * 2)
+    normalized = state._normalize("START " + middle + " END")
+
+    assert len(normalized) <= state.COMPARISON_TEXT_LIMIT
+    assert normalized.startswith("start")
+    assert normalized.endswith("end")
 
 
 def test_claude_no_progress_state_ignores_real_progress_and_terminal_answers():

--- a/backend/tests/test_service_instance_manager.py
+++ b/backend/tests/test_service_instance_manager.py
@@ -399,31 +399,22 @@ async def test_no_progress_failure_queues_one_fresh_session_recovery(db_factory)
         "no_progress_retry_attempt": 0,
     }
 
-    with patch("backend.main.dispatcher", dispatcher):
-        recovered = await manager._try_enqueue_no_progress_recovery(
-            instance_id,
-            task_id,
-            record,
-        )
-        duplicate = await manager._try_enqueue_no_progress_recovery(
-            instance_id,
-            task_id,
-            record,
-        )
+    scheduler = AsyncMock(return_value=True)
+    manager.no_progress_recovery_scheduler = scheduler
+    recovered = await manager._try_enqueue_no_progress_recovery(
+        instance_id, task_id, record,
+    )
+    duplicate = await manager._try_enqueue_no_progress_recovery(
+        instance_id, task_id, record,
+    )
 
     assert recovered is True
     assert duplicate is False
-    dispatcher.issue_context_retry_permit.assert_called_once()
-    dispatcher.enqueue_message.assert_awaited_once()
-    retry = dispatcher.enqueue_message.await_args.kwargs
-    assert retry["source"] == "no_progress_retry"
-    assert retry["prompt"] == "finish the document"
-    assert retry["current_message"] == "finish the document"
-    assert retry["source_log_id"] == source_id
-    assert retry["allow_new_session"] is True
-    assert retry["context_retry_permit"] is permit
-    assert retry["no_progress_retry_attempt"] == 1
-    assert retry["command_skills"] == {"monitor": True}
+    scheduler.assert_awaited_once()
+    request = scheduler.await_args.kwargs
+    assert request["task_id"] == task_id
+    assert request["instance_id"] == instance_id
+    assert request["params"]["source_log_id"] == source_id
 
 
 @pytest.mark.asyncio
@@ -459,15 +450,73 @@ async def test_no_progress_recovery_does_not_replay_unsafe_or_second_attempt(
     dispatcher = MagicMock()
     dispatcher.enqueue_message = AsyncMock()
 
-    with patch("backend.main.dispatcher", dispatcher):
-        recovered = await manager._try_enqueue_no_progress_recovery(
-            9,
-            8,
-            record,
-        )
+    manager.no_progress_recovery_scheduler = dispatcher.enqueue_message
+    recovered = await manager._try_enqueue_no_progress_recovery(9, 8, record)
 
     assert recovered is False
     dispatcher.enqueue_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tool_result_from_process_event_blocks_no_progress_recovery(db_factory):
+    """A real parsed tool_result disables recovery before terminal handling."""
+    async with db_factory() as db:
+        instance = Instance(name="tool-result-recovery", status="running", pid=58403)
+        task = Task(
+            title="tool result safety", status="executing", provider="claude",
+            retry_count=0, turn_generation=1, session_id=None,
+        )
+        db.add_all([instance, task])
+        await db.flush()
+        task.instance_id = instance.id
+        started_at = datetime.utcnow()
+        instance.started_at = started_at
+        task.started_at = started_at
+        source = LogEntry(
+            instance_id=instance.id, task_id=task.id,
+            task_retry_count=0, task_turn_generation=1, turn_scope="source",
+            event_type="user_message", role="user", content="do the work",
+            is_error=False, actual_transport="claude_pty",
+        )
+        db.add(source)
+        await db.flush()
+        task.turn_source_log_id = source.id
+        await db.commit()
+        instance_id, task_id, source_id = instance.id, task.id, source.id
+
+    record = _OutputConsumerRecord(
+        process=_make_mock_process(pid=58_403, returncode=130),
+        task=asyncio.current_task(), chat_initiated=True, provider="claude",
+        task_id=task_id, task_retry_count=0, task_turn_generation=1,
+        instance_started_at=started_at,
+    )
+    record.process.session = MagicMock(session_id="tool-session")
+    scheduler = AsyncMock(return_value=True)
+    manager = InstanceManager(db_factory, MagicMock(broadcast=AsyncMock()))
+    manager.no_progress_recovery_scheduler = scheduler
+    manager._consumer_records[instance_id] = record
+    manager.processes[instance_id] = record.process
+    manager._tasks[instance_id] = record.task
+    manager._launch_params[instance_id] = {
+        "source_log_id": source_id, "no_progress_retry_attempt": 0,
+    }
+
+    await manager._process_event(instance_id, task_id, {
+        "event_type": "tool_result", "role": "tool",
+        "content": "changed the file", "raw_json": json.dumps({
+            "type": "user", "message": {
+                "content": [{"type": "tool_result", "content": "ok"}],
+            },
+            "session_id": "tool-session",
+        }), "is_error": False,
+    })
+    record.claude_no_progress.triggered = True
+    record.claude_no_progress.similar_messages = 3
+    assert record.claude_no_progress.tool_activity_seen
+    assert await manager._try_enqueue_no_progress_recovery(
+        instance_id, task_id, record,
+    ) is False
+    scheduler.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_service_instance_manager.py
+++ b/backend/tests/test_service_instance_manager.py
@@ -27,6 +27,7 @@ from backend.services.instance_manager import (
     LaunchSupersededError,
     LiveAttachmentInjectionUnsupportedError,
     SharedProjectAgentLaunchDisabledError,
+    _ClaudeNoProgressState,
     _OutputConsumerRecord,
     _SshAgentSocketSnapshot,
 )
@@ -160,6 +161,342 @@ def test_claude_terminal_result_suppresses_only_exact_assistant_duplicate():
         record,
         "claude",
     )["content"] == " Finished safely. "
+
+
+def _incomplete_claude_message(content: str) -> dict:
+    return {
+        "event_type": "message",
+        "role": "assistant",
+        "content": content,
+        "stop_reason": None,
+    }
+
+
+def test_claude_no_progress_state_reproduces_task_584_sequence():
+    state = _ClaudeNoProgressState()
+
+    assert not state.observe(
+        _incomplete_claude_message("让我重写一版更易读的文档。"),
+        now=0,
+    )
+    assert not state.observe(
+        _incomplete_claude_message("让我重写，用更通俗的方式讲。"),
+        now=60,
+    )
+    assert state.observe(
+        _incomplete_claude_message("让我重新写一版更通俗、更详细的文档。"),
+        now=121,
+    )
+    assert not state.observe(
+        _incomplete_claude_message("让我重写一版。"),
+        now=180,
+    )
+
+
+def test_claude_no_progress_state_ignores_real_progress_and_terminal_answers():
+    state = _ClaudeNoProgressState()
+
+    assert not state.observe(
+        _incomplete_claude_message("I will inspect the backend logs now."),
+        now=0,
+    )
+    assert not state.observe(
+        _incomplete_claude_message("The database query found 18 rows."),
+        now=130,
+    )
+    assert not state.observe(
+        {
+            **_incomplete_claude_message("The fix is complete."),
+            "stop_reason": "end_turn",
+        },
+        now=260,
+    )
+    assert not state.triggered
+
+
+def test_claude_no_progress_state_reads_pty_stop_reason_from_raw_json():
+    state = _ClaudeNoProgressState()
+    pty_event = {
+        "event_type": "message",
+        "role": "assistant",
+        "content": "I will rewrite the document now.",
+        "raw_json": json.dumps({
+            "type": "assistant",
+            "message": {"stop_reason": None},
+        }),
+    }
+
+    assert not state.observe(pty_event, now=0)
+    assert state.similar_messages == 1
+    assert not state.observe(
+        {**pty_event, "raw_json": "{}"},
+        now=200,
+    )
+    assert state.similar_messages == 1
+
+
+def test_claude_no_progress_state_disables_detection_after_tool_activity():
+    state = _ClaudeNoProgressState()
+    assert not state.observe(
+        _incomplete_claude_message("I will read the file now."),
+        now=0,
+    )
+    assert not state.observe(
+        {"event_type": "tool_use", "role": "assistant"},
+        now=10,
+    )
+    for now in (130, 200, 270):
+        assert not state.observe(
+            _incomplete_claude_message("I will read the file now."),
+            now=now,
+        )
+    assert not state.triggered
+
+
+@pytest.mark.asyncio
+async def test_no_progress_failure_queues_one_fresh_session_recovery(db_factory):
+    started_at = datetime.utcnow()
+    async with db_factory() as db:
+        instance = Instance(
+            name="no-progress-recovery",
+            status="error",
+            started_at=started_at,
+        )
+        task = Task(
+            title="safe no-progress recovery",
+            status="failed",
+            provider="claude",
+            retry_count=0,
+            turn_generation=4,
+            session_id=None,
+            started_at=started_at,
+        )
+        db.add_all([instance, task])
+        await db.flush()
+        task.instance_id = instance.id
+        source = LogEntry(
+            instance_id=instance.id,
+            task_id=task.id,
+            task_retry_count=task.retry_count,
+            task_turn_generation=task.turn_generation,
+            turn_scope="source",
+            event_type="user_message",
+            role="user",
+            content="finish the document",
+            is_error=False,
+            actual_transport="claude_pty",
+        )
+        db.add(source)
+        await db.flush()
+        task.turn_source_log_id = source.id
+        await db.commit()
+        instance_id, task_id, source_id = instance.id, task.id, source.id
+
+    record = _OutputConsumerRecord(
+        process=_make_mock_process(pid=58_401, returncode=130),
+        task=asyncio.current_task(),
+        chat_initiated=True,
+        provider="claude",
+        task_id=task_id,
+        task_retry_count=0,
+        task_turn_generation=4,
+        instance_started_at=started_at,
+    )
+    record.claude_no_progress.triggered = True
+    record.claude_no_progress.similar_messages = 3
+    dispatcher = MagicMock()
+    permit = object()
+    dispatcher.issue_context_retry_permit.return_value = permit
+    dispatcher.enqueue_message = AsyncMock(return_value=True)
+    manager = InstanceManager(db_factory, MagicMock(broadcast=AsyncMock()))
+    manager._launch_params[instance_id] = {
+        "prompt": "wrapped prompt",
+        "current_message": "finish the document",
+        "source_log_id": source_id,
+        "model": "claude-opus-4-6[1m]",
+        "enabled_skills": {"monitor": True},
+        "no_progress_retry_attempt": 0,
+    }
+
+    with patch("backend.main.dispatcher", dispatcher):
+        recovered = await manager._try_enqueue_no_progress_recovery(
+            instance_id,
+            task_id,
+            record,
+        )
+
+    assert recovered is True
+    dispatcher.issue_context_retry_permit.assert_called_once()
+    retry = dispatcher.enqueue_message.await_args.kwargs
+    assert retry["source"] == "no_progress_retry"
+    assert retry["prompt"] == "finish the document"
+    assert retry["current_message"] == "finish the document"
+    assert retry["source_log_id"] == source_id
+    assert retry["allow_new_session"] is True
+    assert retry["context_retry_permit"] is permit
+    assert retry["no_progress_retry_attempt"] == 1
+    assert retry["command_skills"] == {"monitor": True}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("attempt", "tool_activity"),
+    [(1, False), (0, True)],
+)
+async def test_no_progress_recovery_does_not_replay_unsafe_or_second_attempt(
+    db_factory,
+    attempt,
+    tool_activity,
+):
+    manager = InstanceManager(db_factory, MagicMock(broadcast=AsyncMock()))
+    manager._launch_params[9] = {
+        "prompt": "must not replay",
+        "current_message": "must not replay",
+        "source_log_id": 10,
+        "no_progress_retry_attempt": attempt,
+    }
+    record = _OutputConsumerRecord(
+        process=_make_mock_process(pid=58_402, returncode=130),
+        task=asyncio.current_task(),
+        chat_initiated=True,
+        provider="claude",
+        task_id=8,
+        task_retry_count=0,
+        task_turn_generation=1,
+        instance_started_at=datetime.utcnow(),
+    )
+    record.claude_no_progress.triggered = True
+    record.claude_no_progress.similar_messages = 3
+    record.claude_no_progress.tool_activity_seen = tool_activity
+    dispatcher = MagicMock()
+    dispatcher.enqueue_message = AsyncMock()
+
+    with patch("backend.main.dispatcher", dispatcher):
+        recovered = await manager._try_enqueue_no_progress_recovery(
+            9,
+            8,
+            record,
+        )
+
+    assert recovered is False
+    dispatcher.enqueue_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_event_interrupts_task_584_pty_loop_once(
+    db_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(_ClaudeNoProgressState, "MIN_ELAPSED_SECONDS", 0)
+    async with db_factory() as db:
+        instance = Instance(name="claude-no-progress", status="running")
+        task = Task(
+            title="task 584 reproduction",
+            status="executing",
+            provider="claude",
+        )
+        db.add_all([instance, task])
+        await db.flush()
+        started_at = datetime.utcnow()
+        task.instance_id = instance.id
+        task.started_at = started_at
+        instance.pid = 58_400
+        instance.started_at = started_at
+        instance.current_task_id = task.id
+        await db.commit()
+        instance_id = instance.id
+        task_id = task.id
+        retry_count = task.retry_count
+        turn_generation = task.turn_generation
+
+    process = _make_mock_process(pid=58_400, returncode=None)
+    session = MagicMock(
+        session_id="cf5b187f-6a62-4c10-a75a-be97b378fe05",
+        send_interrupt=AsyncMock(),
+    )
+    process.session = session
+    consumer = asyncio.current_task()
+    assert consumer is not None
+    record = _OutputConsumerRecord(
+        process=process,
+        task=consumer,
+        chat_initiated=True,
+        provider="claude",
+        task_id=task_id,
+        task_retry_count=retry_count,
+        task_turn_generation=turn_generation,
+        instance_started_at=started_at,
+    )
+    manager = InstanceManager(db_factory, MagicMock(broadcast=AsyncMock()))
+    manager._pty_backend = MagicMock()
+    manager._pty_backend._sessions = {instance_id: session}
+    manager.processes[instance_id] = process
+    manager._tasks[instance_id] = consumer
+    manager._consumer_records[instance_id] = record
+
+    await manager._process_event(
+        instance_id,
+        task_id,
+        {
+            "event_type": "message",
+            "role": "assistant",
+            "content": "让我重写一版更易读的文档。",
+            "raw_json": json.dumps({
+                "type": "assistant",
+                "session_id": "stale-session",
+                "message": {"stop_reason": None},
+            }),
+            "is_error": False,
+        },
+    )
+    assert record.claude_no_progress.similar_messages == 0
+
+    messages = (
+        "让我重写一版更易读的文档。",
+        "让我重写，用更通俗的方式讲。",
+        "让我重新写一版更通俗、更详细的文档。",
+        "让我重写一版更清楚的文档。",
+    )
+    for content in messages:
+        raw_json = json.dumps({
+            "type": "assistant",
+            "session_id": session.session_id,
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": content}],
+                "stop_reason": None,
+            },
+        })
+        await manager._process_event(
+            instance_id,
+            task_id,
+            {
+                "event_type": "message",
+                "role": "assistant",
+                "content": content,
+                "raw_json": raw_json,
+                "is_error": False,
+            },
+        )
+
+    session.send_interrupt.assert_awaited_once_with()
+    process.send_signal.assert_not_called()
+    assert record.fatal_provider_error is not None
+    assert record.claude_no_progress.triggered
+    async with db_factory() as db:
+        entries = list((await db.scalars(
+            select(LogEntry)
+            .where(LogEntry.task_id == task_id)
+            .order_by(LogEntry.id)
+        )).all())
+    assert [entry.event_type for entry in entries] == [
+        "message",
+        "message",
+        "message",
+        "system_event",
+    ]
+    assert entries[-1].is_error is True
+    assert "CCM 已中止" in entries[-1].content
 
 
 def test_claude_hot_runtime_fingerprint_covers_mcp_and_full_git_environment(

--- a/backend/tests/test_service_instance_manager.py
+++ b/backend/tests/test_service_instance_manager.py
@@ -235,6 +235,46 @@ def test_claude_no_progress_state_reads_pty_stop_reason_from_raw_json():
     assert state.similar_messages == 1
 
 
+def test_claude_no_progress_state_ignores_missing_stop_reason():
+    state = _ClaudeNoProgressState()
+    event = {
+        "event_type": "message",
+        "role": "assistant",
+        "content": "I will rewrite the document now.",
+        "raw_json": json.dumps({
+            "type": "assistant",
+            "message": {"role": "assistant"},
+        }),
+    }
+
+    for now in (0, 130, 260):
+        assert not state.observe(event, now=now)
+    assert state.similar_messages == 0
+    assert not state.triggered
+
+
+def test_claude_no_progress_state_sees_sibling_tool_before_text():
+    state = _ClaudeNoProgressState()
+    for now in (0, 60):
+        assert not state.observe(
+            _incomplete_claude_message("I will rewrite the document now."),
+            now=now,
+        )
+
+    assert not state.observe(
+        {
+            **_incomplete_claude_message(
+                "I will rewrite the document now."
+            ),
+            "assistant_envelope_has_tool_use": True,
+        },
+        now=130,
+    )
+    assert state.tool_activity_seen
+    assert state.similar_messages == 0
+    assert not state.triggered
+
+
 def test_claude_no_progress_state_disables_detection_after_tool_activity():
     state = _ClaudeNoProgressState()
     assert not state.observe(
@@ -311,7 +351,7 @@ async def test_no_progress_failure_queues_one_fresh_session_recovery(db_factory)
     manager = InstanceManager(db_factory, MagicMock(broadcast=AsyncMock()))
     manager._launch_params[instance_id] = {
         "prompt": "wrapped prompt",
-        "current_message": "finish the document",
+        "current_message": "stale launch parameter",
         "source_log_id": source_id,
         "model": "claude-opus-4-6[1m]",
         "enabled_skills": {"monitor": True},
@@ -324,9 +364,16 @@ async def test_no_progress_failure_queues_one_fresh_session_recovery(db_factory)
             task_id,
             record,
         )
+        duplicate = await manager._try_enqueue_no_progress_recovery(
+            instance_id,
+            task_id,
+            record,
+        )
 
     assert recovered is True
+    assert duplicate is False
     dispatcher.issue_context_retry_permit.assert_called_once()
+    dispatcher.enqueue_message.assert_awaited_once()
     retry = dispatcher.enqueue_message.await_args.kwargs
     assert retry["source"] == "no_progress_retry"
     assert retry["prompt"] == "finish the document"

--- a/backend/tests/test_stream_parser.py
+++ b/backend/tests/test_stream_parser.py
@@ -90,6 +90,51 @@ def test_assistant_api_error_message_is_marked_error(parser):
     assert result["is_error"] is True
 
 
+def test_assistant_stop_reason_preserves_absent_vs_explicit_null(parser):
+    without_stop_reason = parser.parse_line(json.dumps({
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "still working"}],
+        },
+    }))[0]
+    explicit_null = parser.parse_line(json.dumps({
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "still working"}],
+            "stop_reason": None,
+        },
+    }))[0]
+
+    assert "stop_reason" not in without_stop_reason
+    assert "stop_reason" in explicit_null
+    assert explicit_null["stop_reason"] is None
+
+
+def test_assistant_mixed_envelope_marks_tool_before_text_processing(parser):
+    events = parser.parse_line(json.dumps({
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "I will inspect the file now."},
+                {"type": "tool_use", "name": "Read", "input": {}},
+            ],
+            "stop_reason": None,
+        },
+    }))
+
+    assert [event["event_type"] for event in events] == [
+        "message",
+        "tool_use",
+    ]
+    assert all(
+        event["assistant_envelope_has_tool_use"] is True
+        for event in events
+    )
+
+
 def test_tool_use(parser):
     line = json.dumps({
         "type": "tool_use",

--- a/backend/tests/test_stream_parser.py
+++ b/backend/tests/test_stream_parser.py
@@ -266,6 +266,28 @@ def test_assistant_legacy_tool_markup_remains_inert_text(parser, text):
     assert results[0]["protocol_anomaly"] == LEGACY_TOOL_MARKUP_ANOMALY
 
 
+def test_assistant_message_preserves_stop_reason(parser):
+    incomplete = parser.parse_line(json.dumps({
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "I will rewrite it."}],
+            "stop_reason": None,
+        },
+    }))
+    complete = parser.parse_line(json.dumps({
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Done."}],
+            "stop_reason": "end_turn",
+        },
+    }))
+
+    assert incomplete[0]["stop_reason"] is None
+    assert complete[0]["stop_reason"] == "end_turn"
+
+
 @pytest.mark.parametrize(
     ("event_type", "role", "text"),
     [


### PR DESCRIPTION
## Summary

- detect sustained, similar Claude assistant responses whose `stop_reason` remains null and stop the exact foreground PTY generation
- clear the unhealthy native session and perform one generation-bound fresh-session retry only when the turn had no tool activity
- fail closed after tool activity, on a second stalled retry, or when the volatile retry permit is missing or stale
- preserve Claude `stop_reason` in parsed stream events and cover the Task 584 event shape with regression tests

## Safety

- any `tool_use` or `tool_result` disables automatic replay for that turn
- recovery advances the task generation and never resumes the unhealthy session
- late events from an old PTY session cannot interrupt a newer session
- automatic recovery is limited to one attempt

## Verification

- focused no-progress regression: `10 passed`
- affected suites: `1028 passed, 1 failed`; the remaining CloudRouter PTY binary projection failure also reproduces on unchanged `main`
- local CCM synthetic Task 584 reproduction triggered the guard, interrupted the PTY once, cleared the session, and completed a fresh-session recovery
- real Claude API smoke test completed with `stop_reason=end_turn`, no tool activity, no retry, and no false-positive guard trigger

This PR only adds the guard and recovery behavior; it does not change the upstream Claude gateway.