### PR TITLE
fix(claude): recover oversized prompts safely

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -61,7 +61,8 @@ class Settings(BaseSettings):
     # 会话上下文利用率达到该比例即自动摘要+换新 session。超大 context 的请求
     # 在服务端易挂起（2026-07-08 task 22/27 连环 stall 均发生在 ~90% 区间），
     # 故不要设回 0.9 让 session 在重灾区长时间工作。
-    context_compact_threshold: float = 0.80
+    # Leave headroom for the next message, tool output, and provider framing.
+    context_compact_threshold: float = 0.70
     default_goal_evaluator_model: str = "claude-haiku-4-5"
     goal_evaluation_timeout: int = 120
     # --- Independent Plan Agent pipeline ---

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -14686,6 +14686,28 @@ class InstanceManager:
                 )
                 terminal_message = str(terminal_result.get("result") or "")
                 usage = terminal_result.get("usage")
+                required_usage_keys = (
+                    "input_tokens",
+                    "output_tokens",
+                )
+                optional_usage_keys = (
+                    "cache_creation_input_tokens",
+                    "cache_read_input_tokens",
+                )
+                usage_is_canonical_zero = (
+                    isinstance(usage, dict)
+                    and all(
+                        key in usage
+                        and type(usage[key]) is int
+                        and usage[key] == 0
+                        for key in required_usage_keys
+                    )
+                    and all(
+                        type(usage[key]) is int and usage[key] == 0
+                        for key in optional_usage_keys
+                        if key in usage
+                    )
+                )
                 if not (
                     terminal.event_type == "result"
                     and terminal.is_error is True
@@ -14693,17 +14715,9 @@ class InstanceManager:
                     and terminal_result.get("is_error") is True
                     and terminal_result.get("terminal_reason") == "blocking_limit"
                     and "prompt is too long" in terminal_message.lower()
+                    and type(terminal_result.get("duration_api_ms")) is int
                     and terminal_result.get("duration_api_ms") == 0
-                    and isinstance(usage, dict)
-                    and not any(
-                        int(usage.get(key) or 0)
-                        for key in (
-                            "input_tokens",
-                            "output_tokens",
-                            "cache_creation_input_tokens",
-                            "cache_read_input_tokens",
-                        )
-                    )
+                    and usage_is_canonical_zero
                 ):
                     return None
                 for row, raw in zip(rows[:-1], parsed_rows[:-1], strict=True):

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -6124,6 +6124,8 @@ class InstanceManager:
                 "Codex isolated workflow execution forbids exec fallback"
             )
 
+        # PTY launches return above with the complete prompt. Only the direct
+        # exec transport reaches this argv-size fallback and owns stdin.
         claude_prompt_via_stdin = bool(
             provider == "claude"
             and len(prompt.encode("utf-8"))
@@ -14708,10 +14710,11 @@ class InstanceManager:
                     if row.event_type == "message":
                         if not (
                             row.role == "assistant"
-                            and row.is_error is False
+                            and row.is_error is True
                             and isinstance(raw, dict)
-                            and str(raw.get("error") or "").strip().lower()
-                            in {"", "invalid_request"}
+                            and raw.get("type") == "assistant"
+                            and raw.get("isApiErrorMessage") is True
+                            and raw.get("error") == "invalid_request"
                             and str(row.content or "").strip().lower()
                             == "prompt is too long"
                         ):

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -14684,7 +14684,7 @@ class InstanceManager:
                 terminal_result = (
                     terminal_raw if isinstance(terminal_raw, dict) else {}
                 )
-                terminal_message = str(terminal_result.get("result") or "")
+                terminal_message = terminal_result.get("result")
                 usage = terminal_result.get("usage")
                 required_usage_keys = (
                     "input_tokens",
@@ -14696,6 +14696,9 @@ class InstanceManager:
                 )
                 usage_is_canonical_zero = (
                     isinstance(usage, dict)
+                    and set(usage).issubset(
+                        {*required_usage_keys, *optional_usage_keys}
+                    )
                     and all(
                         key in usage
                         and type(usage[key]) is int
@@ -14714,6 +14717,7 @@ class InstanceManager:
                     and terminal_result.get("type") == "result"
                     and terminal_result.get("is_error") is True
                     and terminal_result.get("terminal_reason") == "blocking_limit"
+                    and isinstance(terminal_message, str)
                     and "prompt is too long" in terminal_message.lower()
                     and type(terminal_result.get("duration_api_ms")) is int
                     and terminal_result.get("duration_api_ms") == 0

--- a/backend/services/instance_manager.py
+++ b/backend/services/instance_manager.py
@@ -72,6 +72,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Linux rejects a single argv entry around 128 KiB (MAX_ARG_STRLEN), before
+# Claude Code can apply its own context-window guard. Keep ample room for
+# encoding/platform variance and send only large direct-Claude prompts over
+# stdin; ordinary launches retain their established argv shape.
+_CLAUDE_PROMPT_STDIN_THRESHOLD_BYTES = 64 * 1024
+
 
 async def _fence_worker_runtime_mutation(
     db: AsyncSession,
@@ -6118,9 +6124,15 @@ class InstanceManager:
                 "Codex isolated workflow execution forbids exec fallback"
             )
 
+        claude_prompt_via_stdin = bool(
+            provider == "claude"
+            and len(prompt.encode("utf-8"))
+            >= _CLAUDE_PROMPT_STDIN_THRESHOLD_BYTES
+        )
         cmd = self._build_command(
             provider=provider,
             prompt=prompt,
+            claude_prompt_via_stdin=claude_prompt_via_stdin,
             model=model,
             resume_session_id=resume_session_id,
             effort_level=effort_level,
@@ -6279,6 +6291,8 @@ class InstanceManager:
                 "env": env,
                 "limit": 10 * 1024 * 1024,
             }
+            if claude_prompt_via_stdin:
+                spawn_kwargs["stdin"] = asyncio.subprocess.PIPE
             if os.name == "posix":
                 spawn_kwargs["start_new_session"] = True
             await admit_external_launch("claude_exec")
@@ -6300,6 +6314,12 @@ class InstanceManager:
                         else None
                     ),
                 )
+                if claude_prompt_via_stdin:
+                    await self._write_direct_claude_prompt(
+                        instance_id,
+                        process,
+                        prompt,
+                    )
             except BaseException:
                 if task_private_tmpdir is not None:
                     exact_process = self.processes.get(instance_id)
@@ -12381,15 +12401,18 @@ class InstanceManager:
         claude_unrestricted_settings_path: Path | None = None,
         claude_unrestricted_tools: Sequence[str] | None = None,
         claude_unrestricted_allowed_rules: Sequence[str] | None = None,
+        claude_prompt_via_stdin: bool = False,
     ) -> list[str]:
         """Build the subprocess command for a supported coding-agent CLI."""
         if provider == "claude":
             cmd = [
                 settings.claude_binary,
-                "-p", prompt,
+                "-p",
                 "--output-format", "stream-json",
                 "--verbose",
             ]
+            if not claude_prompt_via_stdin:
+                cmd.insert(2, prompt)
             if claude_isolation_settings_path is not None:
                 from backend.services.task_agent_isolation import (
                     CLAUDE_TASK_BUILTIN_TOOLS,
@@ -14526,20 +14549,24 @@ class InstanceManager:
         expected_turn_generation: int | None = None,
         expected_started_at: datetime | None = None,
     ) -> _ContextPreflightPermit | None:
-        """Prove a direct Codex chat overflow happened before agent activity.
+        """Prove a direct chat overflow happened before agent activity.
 
         This is deliberately independent of stderr and rendered message text.
         Only the current exact source, its committed runtime transport, and a
-        strict durable ``turn.failed`` envelope can authorize compaction and
-        replay.  Missing, stale, malformed, or mixed-turn evidence fails
-        closed.
+        strict durable provider envelope can authorize compaction and replay.
+        Missing, stale, malformed, or mixed-turn evidence fails closed.
         """
 
+        provider = (
+            str(params.get("provider") or "").strip().lower()
+            if isinstance(params, dict)
+            else ""
+        )
         if (
             type(task_id) is not int
             or task_id <= 0
             or not isinstance(params, dict)
-            or str(params.get("provider") or "").strip().lower() != "codex"
+            or provider not in {"codex", "claude"}
         ):
             return None
         requested_source_id = params.get("source_log_id")
@@ -14571,7 +14598,7 @@ class InstanceManager:
             if (
                 task is None
                 or instance is None
-                or (task.provider or "claude").lower() != "codex"
+                or (task.provider or "claude").lower() != provider
                 or task.status not in {"executing", "in_progress"}
                 or task.instance_id != instance_id
                 or task.retry_count != expected_retry_count
@@ -14603,7 +14630,11 @@ class InstanceManager:
                 or source.task_turn_generation != task.turn_generation
                 or source.turn_scope != "source"
                 or source.actual_transport
-                not in {"codex_app_server", "codex_exec"}
+                not in (
+                    {"codex_app_server", "codex_exec"}
+                    if provider == "codex"
+                    else {"claude_pty", "claude_exec"}
+                )
                 or not source_shape_is_canonical(source, original)
                 or requested_source_id not in {source.id, original_id}
             ):
@@ -14647,6 +14678,59 @@ class InstanceManager:
 
             terminal = rows[-1]
             terminal_raw = parsed_rows[-1]
+            if provider == "claude":
+                terminal_result = (
+                    terminal_raw if isinstance(terminal_raw, dict) else {}
+                )
+                terminal_message = str(terminal_result.get("result") or "")
+                usage = terminal_result.get("usage")
+                if not (
+                    terminal.event_type == "result"
+                    and terminal.is_error is True
+                    and terminal_result.get("type") == "result"
+                    and terminal_result.get("is_error") is True
+                    and terminal_result.get("terminal_reason") == "blocking_limit"
+                    and "prompt is too long" in terminal_message.lower()
+                    and terminal_result.get("duration_api_ms") == 0
+                    and isinstance(usage, dict)
+                    and not any(
+                        int(usage.get(key) or 0)
+                        for key in (
+                            "input_tokens",
+                            "output_tokens",
+                            "cache_creation_input_tokens",
+                            "cache_read_input_tokens",
+                        )
+                    )
+                ):
+                    return None
+                for row, raw in zip(rows[:-1], parsed_rows[:-1], strict=True):
+                    if row.event_type == "message":
+                        if not (
+                            row.role == "assistant"
+                            and row.is_error is False
+                            and isinstance(raw, dict)
+                            and str(raw.get("error") or "").strip().lower()
+                            in {"", "invalid_request"}
+                            and str(row.content or "").strip().lower()
+                            == "prompt is too long"
+                        ):
+                            return None
+                    elif row.event_type in {"system_init", "rate_limit_event"}:
+                        continue
+                    else:
+                        return None
+                return _ContextPreflightPermit(
+                    task_id=task.id,
+                    status=task.status,
+                    instance_id=instance_id,
+                    retry_count=task.retry_count,
+                    turn_generation=task.turn_generation,
+                    turn_source_log_id=task.turn_source_log_id,
+                    session_id=task.session_id,
+                    started_at=task.started_at,
+                    completed_at=task.completed_at,
+                )
             error = (
                 terminal_raw.get("error")
                 if isinstance(terminal_raw, dict)
@@ -18110,6 +18194,36 @@ class InstanceManager:
                 "behavior": behavior,
             })
         return bool(ok)
+
+    async def _write_direct_claude_prompt(
+        self,
+        instance_id: int,
+        process: asyncio.subprocess.Process,
+        prompt: str,
+    ) -> None:
+        """Deliver a large Claude prompt without exposing it through argv."""
+
+        writer = process.stdin
+        if writer is None:
+            raise RuntimeError("Claude stdin prompt transport was not created")
+        try:
+            writer.write(prompt.encode("utf-8"))
+            await writer.drain()
+            writer.close()
+            wait_closed = getattr(writer, "wait_closed", None)
+            if wait_closed is not None:
+                await wait_closed()
+        except BaseException:
+            # The process was already registered as the exact generation.
+            # Reap it before surfacing input-delivery failure so a half-fed
+            # Claude process cannot remain attached to a reusable Instance.
+            if (
+                process.returncode is None
+                or self._process_group_alive(instance_id, process)
+            ):
+                self._signal_process_tree(instance_id, process, signal.SIGKILL)
+            await self._wait_process_tree(instance_id, process, 5.0)
+            raise
 
     async def _spawn_managed_direct_process(
         self,

--- a/backend/tests/test_service_instance_manager.py
+++ b/backend/tests/test_service_instance_manager.py
@@ -7040,7 +7040,7 @@ async def test_local_user_demotion_between_precheck_and_transport_commit_blocks_
 
 
 @pytest.mark.asyncio
-async def test_claude_pty_receives_task_ssh_guard_env_and_policy(
+async def test_claude_pty_large_prompt_receives_task_ssh_guard_env_and_policy(
     db_factory,
     monkeypatch,
     tmp_path,
@@ -7077,9 +7077,10 @@ async def test_claude_pty_receives_task_ssh_guard_env_and_policy(
     im._pty_backend = MagicMock()
     im._launch_pty = AsyncMock(return_value=54_321)
 
+    prompt = "inspect remote files\n" + "x" * (64 * 1024)
     pid = await im.launch(
         instance_id=inst.id,
-        prompt="inspect remote files",
+        prompt=prompt,
         task_id=task.id,
         cwd=str(tmp_path),
         provider="claude",
@@ -7099,6 +7100,7 @@ async def test_claude_pty_receives_task_ssh_guard_env_and_policy(
 
     assert pid == 54_321
     kwargs = im._launch_pty.await_args.kwargs
+    assert kwargs["prompt"] == prompt
     assert kwargs["claude_binary_override"] == settings.claude_binary
     assert kwargs["git_env"]["CCM_TASK_SSH_GUARD"] == "1"
     assert kwargs["git_env"]["SSH_AUTH_SOCK"] == ""
@@ -22208,8 +22210,8 @@ async def test_codex_context_window_failure_compacts_and_requeues(db_factory):
 
 
 @pytest.mark.asyncio
-async def test_claude_prompt_too_long_preflight_is_recoverable(db_factory):
-    """Claude's local blocking_limit can be compacted before any side effect."""
+async def test_claude_prompt_too_long_compacts_and_requeues(db_factory):
+    """A real Claude blocking_limit stream compacts and retries once."""
 
     started_at = datetime(2026, 8, 25, 10, 11, 12)
     async with db_factory() as db:
@@ -22250,57 +22252,233 @@ async def test_claude_prompt_too_long_preflight_is_recoverable(db_factory):
         await db.flush()
         task.turn_source_log_id = source.id
         instance.current_task_id = task.id
-        db.add_all([
-            LogEntry(
-                instance_id=instance.id,
-                task_id=task.id,
-                task_retry_count=0,
-                task_turn_generation=2,
-                turn_scope="foreground",
-                event_type="message",
-                role="assistant",
-                content="Prompt is too long",
-                raw_json=json.dumps({
-                    "type": "assistant",
-                    "error": "invalid_request",
-                }),
-            ),
-            LogEntry(
-                instance_id=instance.id,
-                task_id=task.id,
-                task_retry_count=0,
-                task_turn_generation=2,
-                turn_scope="foreground",
-                event_type="result",
-                is_error=True,
-                raw_json=json.dumps({
-                    "type": "result",
-                    "is_error": True,
-                    "result": "Prompt is too long",
-                    "terminal_reason": "blocking_limit",
-                    "duration_api_ms": 0,
-                    "usage": {"input_tokens": 0, "output_tokens": 0},
-                }),
-            ),
-        ])
         await db.commit()
         task_id, instance_id, source_id = task.id, instance.id, source.id
 
+    process = _make_mock_process(pid=73_107, returncode=1)
+    output = iter((
+        json.dumps({
+            "type": "assistant",
+            "isApiErrorMessage": True,
+            "error": "invalid_request",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Prompt is too long"}],
+            },
+        }).encode() + b"\n",
+        json.dumps({
+            "type": "result",
+            "is_error": True,
+            "result": "Prompt is too long",
+            "terminal_reason": "blocking_limit",
+            "duration_api_ms": 0,
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+        }).encode() + b"\n",
+        b"",
+    ))
+
+    async def readline():
+        return next(output)
+
+    process.stdout.readline = readline
     manager = InstanceManager(db_factory, MagicMock(broadcast=AsyncMock()))
-    permit = await manager._chat_structured_context_preflight_rejection(
-        task_id,
+    manager.processes[instance_id] = process
+    manager._launch_params[instance_id] = {
+        "prompt": "[already wrapped history]\ncontinue the task",
+        "current_message": "continue the task",
+        "provider": "claude",
+        "task_turn_generation": 2,
+        "source_log_id": source_id,
+        "model": "claude-opus-5",
+    }
+    dispatcher = MagicMock()
+    dispatcher._compact_session = AsyncMock(return_value="durable summary")
+    dispatcher.enqueue_message = AsyncMock()
+
+    with patch("backend.main.dispatcher", dispatcher):
+        consumer = asyncio.create_task(manager._consume_output(
+            instance_id,
+            task_id,
+            process,
+            chat_initiated=True,
+            provider="claude",
+        ))
+        manager._track_output_consumer(
+            instance_id,
+            process,
+            consumer,
+            chat_initiated=True,
+            provider="claude",
+            task_id=task_id,
+            task_retry_count=0,
+            task_turn_generation=2,
+            instance_started_at=started_at,
+        )
+        await consumer
+
+    dispatcher._compact_session.assert_awaited_once()
+    dispatcher.enqueue_message.assert_awaited_once()
+    retry = dispatcher.enqueue_message.await_args.kwargs
+    assert retry["source"] == "compact_retry"
+    assert retry["source_log_id"] == source_id
+    assert retry["current_message"] == "continue the task"
+    assert retry["model_override"] == "claude-opus-5"
+    assert "durable summary" in retry["prompt"]
+    assert "already wrapped history" not in retry["prompt"]
+    async with db_factory() as db:
+        current = await db.get(Task, task_id)
+        assert current.session_id is None
+        assert current.context_window_usage is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("activity", "synthetic_error"), [
+    (
+        {"type": "tool_use", "name": "Read", "input": {"path": "/tmp/a"}},
+        "invalid_request",
+    ),
+    (
         {
-            "provider": "claude",
-            "source_log_id": source_id,
-            "task_turn_generation": 2,
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "thinking", "thinking": "started"}],
+            },
         },
-        instance_id=instance_id,
-        expected_retry_count=0,
-        expected_turn_generation=2,
-        expected_started_at=started_at,
-    )
-    assert permit is not None
-    assert permit.session_id == "claude-old-session"
+        "invalid_request",
+    ),
+    (
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "I started working"}],
+            },
+        },
+        "invalid_request",
+    ),
+    (None, None),
+], ids=("tool", "thinking", "assistant", "missing-error-marker"))
+async def test_claude_prompt_too_long_unsafe_evidence_does_not_replay(
+    db_factory,
+    activity,
+    synthetic_error,
+):
+    """Prior activity or an inexact synthetic error fails closed."""
+
+    started_at = datetime(2026, 8, 25, 10, 12, 13)
+    async with db_factory() as db:
+        instance = Instance(
+            name="claude-context-activity",
+            status="running",
+            pid=73_108,
+            started_at=started_at,
+        )
+        db.add(instance)
+        await db.flush()
+        task = Task(
+            title="claude context activity",
+            provider="claude",
+            status="executing",
+            retry_count=0,
+            turn_generation=3,
+            instance_id=instance.id,
+            session_id="claude-active-session",
+        )
+        db.add(task)
+        await db.flush()
+        source = LogEntry(
+            instance_id=instance.id,
+            task_id=task.id,
+            task_retry_count=0,
+            task_turn_generation=3,
+            turn_scope="source",
+            event_type="turn_source",
+            role="system",
+            raw_json=json.dumps({
+                "transport": "claude",
+                "original_source_log_id": None,
+            }),
+            actual_transport="claude_exec",
+        )
+        db.add(source)
+        await db.flush()
+        task.turn_source_log_id = source.id
+        instance.current_task_id = task.id
+        await db.commit()
+        task_id, instance_id, source_id = task.id, instance.id, source.id
+
+    process = _make_mock_process(pid=73_108, returncode=1)
+    synthetic = {
+        "type": "assistant",
+        "isApiErrorMessage": True,
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Prompt is too long"}],
+        },
+    }
+    if synthetic_error is not None:
+        synthetic["error"] = synthetic_error
+    output_lines = []
+    if activity is not None:
+        output_lines.append(json.dumps(activity).encode() + b"\n")
+    output_lines.extend((
+        json.dumps(synthetic).encode() + b"\n",
+        json.dumps({
+            "type": "result",
+            "is_error": True,
+            "result": "Prompt is too long",
+            "terminal_reason": "blocking_limit",
+            "duration_api_ms": 0,
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+        }).encode() + b"\n",
+        b"",
+    ))
+    output = iter(output_lines)
+
+    async def readline():
+        return next(output)
+
+    process.stdout.readline = readline
+    manager = InstanceManager(db_factory, MagicMock(broadcast=AsyncMock()))
+    manager.processes[instance_id] = process
+    manager._launch_params[instance_id] = {
+        "prompt": "continue the task",
+        "current_message": "continue the task",
+        "provider": "claude",
+        "task_turn_generation": 3,
+        "source_log_id": source_id,
+    }
+    dispatcher = MagicMock()
+    dispatcher._compact_session = AsyncMock(return_value="must not compact")
+    dispatcher.enqueue_message = AsyncMock()
+
+    with patch("backend.main.dispatcher", dispatcher):
+        consumer = asyncio.create_task(manager._consume_output(
+            instance_id,
+            task_id,
+            process,
+            chat_initiated=True,
+            provider="claude",
+        ))
+        manager._track_output_consumer(
+            instance_id,
+            process,
+            consumer,
+            chat_initiated=True,
+            provider="claude",
+            task_id=task_id,
+            task_retry_count=0,
+            task_turn_generation=3,
+            instance_started_at=started_at,
+        )
+        await consumer
+
+    dispatcher._compact_session.assert_not_awaited()
+    dispatcher.enqueue_message.assert_not_awaited()
+    async with db_factory() as db:
+        current = await db.get(Task, task_id)
+        assert current.session_id == "claude-active-session"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_service_instance_manager.py
+++ b/backend/tests/test_service_instance_manager.py
@@ -4158,6 +4158,22 @@ def test_build_command_claude_basic():
     assert "--verbose" in cmd
 
 
+def test_build_command_claude_large_prompt_uses_stdin_shape():
+    im = InstanceManager(MagicMock(), MagicMock())
+    prompt = "x" * (64 * 1024)
+    cmd = im._build_command(
+        provider="claude",
+        prompt=prompt,
+        model=None,
+        resume_session_id=None,
+        effort_level=None,
+        claude_prompt_via_stdin=True,
+    )
+    assert cmd[1] == "-p"
+    assert prompt not in cmd
+    assert "--output-format" in cmd
+
+
 def test_build_command_claude_with_resume_and_model():
     im = InstanceManager(MagicMock(), MagicMock())
     cmd = im._build_command(provider="claude", prompt="follow up", model="opus", resume_session_id="sess-1", effort_level="high")
@@ -5929,6 +5945,37 @@ async def test_launch_creates_subprocess(db_factory):
     if os.name == "posix":
         assert mock_exec.call_args.kwargs["start_new_session"] is True
     # Wait for consumer task to finish
+    await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_launch_large_claude_prompt_streams_stdin(db_factory):
+    async with db_factory() as db:
+        inst = Instance(name="large-prompt-inst")
+        db.add(inst)
+        await db.commit()
+        await db.refresh(inst)
+        inst_id = inst.id
+
+    prompt = "large prompt " * 7000
+    mock_proc = _make_mock_process()
+    mock_proc.stdin = MagicMock()
+    mock_proc.stdin.drain = AsyncMock()
+    mock_proc.stdin.wait_closed = AsyncMock()
+    im = InstanceManager(db_factory, MagicMock(broadcast=AsyncMock()))
+
+    with patch(
+        "backend.services.instance_manager.asyncio.create_subprocess_exec",
+        new_callable=AsyncMock,
+        return_value=mock_proc,
+    ) as mock_exec:
+        await im.launch(instance_id=inst_id, prompt=prompt, cwd="/tmp")
+
+    assert prompt not in mock_exec.call_args.args
+    assert mock_exec.call_args.kwargs["stdin"] == asyncio.subprocess.PIPE
+    mock_proc.stdin.write.assert_called_once_with(prompt.encode("utf-8"))
+    mock_proc.stdin.drain.assert_awaited_once()
+    mock_proc.stdin.close.assert_called_once()
     await asyncio.sleep(0.1)
 
 
@@ -22158,6 +22205,102 @@ async def test_codex_context_window_failure_compacts_and_requeues(db_factory):
     assert "durable summary" in retry["prompt"]
     assert "continue the task" in retry["prompt"]
     assert "already wrapped history" not in retry["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_claude_prompt_too_long_preflight_is_recoverable(db_factory):
+    """Claude's local blocking_limit can be compacted before any side effect."""
+
+    started_at = datetime(2026, 8, 25, 10, 11, 12)
+    async with db_factory() as db:
+        instance = Instance(
+            name="claude-context-proof",
+            status="running",
+            pid=73_107,
+            started_at=started_at,
+        )
+        db.add(instance)
+        await db.flush()
+        task = Task(
+            title="claude context proof",
+            provider="claude",
+            status="executing",
+            retry_count=0,
+            turn_generation=2,
+            instance_id=instance.id,
+            session_id="claude-old-session",
+        )
+        db.add(task)
+        await db.flush()
+        source = LogEntry(
+            instance_id=instance.id,
+            task_id=task.id,
+            task_retry_count=0,
+            task_turn_generation=2,
+            turn_scope="source",
+            event_type="turn_source",
+            role="system",
+            raw_json=json.dumps({
+                "transport": "claude",
+                "original_source_log_id": None,
+            }),
+            actual_transport="claude_exec",
+        )
+        db.add(source)
+        await db.flush()
+        task.turn_source_log_id = source.id
+        instance.current_task_id = task.id
+        db.add_all([
+            LogEntry(
+                instance_id=instance.id,
+                task_id=task.id,
+                task_retry_count=0,
+                task_turn_generation=2,
+                turn_scope="foreground",
+                event_type="message",
+                role="assistant",
+                content="Prompt is too long",
+                raw_json=json.dumps({
+                    "type": "assistant",
+                    "error": "invalid_request",
+                }),
+            ),
+            LogEntry(
+                instance_id=instance.id,
+                task_id=task.id,
+                task_retry_count=0,
+                task_turn_generation=2,
+                turn_scope="foreground",
+                event_type="result",
+                is_error=True,
+                raw_json=json.dumps({
+                    "type": "result",
+                    "is_error": True,
+                    "result": "Prompt is too long",
+                    "terminal_reason": "blocking_limit",
+                    "duration_api_ms": 0,
+                    "usage": {"input_tokens": 0, "output_tokens": 0},
+                }),
+            ),
+        ])
+        await db.commit()
+        task_id, instance_id, source_id = task.id, instance.id, source.id
+
+    manager = InstanceManager(db_factory, MagicMock(broadcast=AsyncMock()))
+    permit = await manager._chat_structured_context_preflight_rejection(
+        task_id,
+        {
+            "provider": "claude",
+            "source_log_id": source_id,
+            "task_turn_generation": 2,
+        },
+        instance_id=instance_id,
+        expected_retry_count=0,
+        expected_turn_generation=2,
+        expected_started_at=started_at,
+    )
+    assert permit is not None
+    assert permit.session_id == "claude-old-session"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_service_instance_manager.py
+++ b/backend/tests/test_service_instance_manager.py
@@ -22272,7 +22272,12 @@ async def test_claude_prompt_too_long_compacts_and_requeues(db_factory):
             "result": "Prompt is too long",
             "terminal_reason": "blocking_limit",
             "duration_api_ms": 0,
-            "usage": {"input_tokens": 0, "output_tokens": 0},
+            "usage": {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
         }).encode() + b"\n",
         b"",
     ))
@@ -22332,10 +22337,14 @@ async def test_claude_prompt_too_long_compacts_and_requeues(db_factory):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(("activity", "synthetic_error"), [
+@pytest.mark.parametrize(
+    ("activity", "synthetic_error", "usage", "duration_api_ms"),
+    [
     (
         {"type": "tool_use", "name": "Read", "input": {"path": "/tmp/a"}},
         "invalid_request",
+        {"input_tokens": 0, "output_tokens": 0},
+        0,
     ),
     (
         {
@@ -22346,6 +22355,8 @@ async def test_claude_prompt_too_long_compacts_and_requeues(db_factory):
             },
         },
         "invalid_request",
+        {"input_tokens": 0, "output_tokens": 0},
+        0,
     ),
     (
         {
@@ -22356,13 +22367,53 @@ async def test_claude_prompt_too_long_compacts_and_requeues(db_factory):
             },
         },
         "invalid_request",
+        {"input_tokens": 0, "output_tokens": 0},
+        0,
     ),
-    (None, None),
-], ids=("tool", "thinking", "assistant", "missing-error-marker"))
+    (None, None, {"input_tokens": 0, "output_tokens": 0}, 0),
+    (None, "invalid_request", {}, 0),
+    (None, "invalid_request", {"output_tokens": 0}, 0),
+    (None, "invalid_request", {"input_tokens": None, "output_tokens": 0}, 0),
+    (None, "invalid_request", {"input_tokens": True, "output_tokens": 0}, 0),
+    (None, "invalid_request", {"input_tokens": "0", "output_tokens": 0}, 0),
+    (None, "invalid_request", {"input_tokens": 0.5, "output_tokens": 0}, 0),
+    (None, "invalid_request", {"input_tokens": "unknown", "output_tokens": 0}, 0),
+    (None, "invalid_request", {"input_tokens": 1, "output_tokens": 0}, 0),
+    (
+        None,
+        "invalid_request",
+        {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_input_tokens": "0",
+        },
+        0,
+    ),
+    (None, "invalid_request", {"input_tokens": 0, "output_tokens": 0}, False),
+    (None, "invalid_request", {"input_tokens": 0, "output_tokens": 0}, "0"),
+], ids=(
+    "tool",
+    "thinking",
+    "assistant",
+    "missing-error-marker",
+    "empty-usage",
+    "missing-input",
+    "none-input",
+    "bool-input",
+    "string-input",
+    "fractional-input",
+    "unknown-input",
+    "nonzero-input",
+    "string-cache",
+    "bool-duration",
+    "string-duration",
+))
 async def test_claude_prompt_too_long_unsafe_evidence_does_not_replay(
     db_factory,
     activity,
     synthetic_error,
+    usage,
+    duration_api_ms,
 ):
     """Prior activity or an inexact synthetic error fails closed."""
 
@@ -22429,8 +22480,8 @@ async def test_claude_prompt_too_long_unsafe_evidence_does_not_replay(
             "is_error": True,
             "result": "Prompt is too long",
             "terminal_reason": "blocking_limit",
-            "duration_api_ms": 0,
-            "usage": {"input_tokens": 0, "output_tokens": 0},
+            "duration_api_ms": duration_api_ms,
+            "usage": usage,
         }).encode() + b"\n",
         b"",
     ))

--- a/backend/tests/test_service_instance_manager.py
+++ b/backend/tests/test_service_instance_manager.py
@@ -22391,6 +22391,22 @@ async def test_claude_prompt_too_long_compacts_and_requeues(db_factory):
     ),
     (None, "invalid_request", {"input_tokens": 0, "output_tokens": 0}, False),
     (None, "invalid_request", {"input_tokens": 0, "output_tokens": 0}, "0"),
+    (
+        {"_terminal_result": {"detail": "Prompt is too long"}},
+        "invalid_request",
+        {"input_tokens": 0, "output_tokens": 0},
+        0,
+    ),
+    (
+        None,
+        "invalid_request",
+        {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "future_input_tokens": 1,
+        },
+        0,
+    ),
 ], ids=(
     "tool",
     "thinking",
@@ -22407,6 +22423,8 @@ async def test_claude_prompt_too_long_compacts_and_requeues(db_factory):
     "string-cache",
     "bool-duration",
     "string-duration",
+    "non-string-result",
+    "unknown-usage-field",
 ))
 async def test_claude_prompt_too_long_unsafe_evidence_does_not_replay(
     db_factory,
@@ -22470,6 +22488,10 @@ async def test_claude_prompt_too_long_unsafe_evidence_does_not_replay(
     }
     if synthetic_error is not None:
         synthetic["error"] = synthetic_error
+    terminal_result_value = "Prompt is too long"
+    if isinstance(activity, dict) and "_terminal_result" in activity:
+        terminal_result_value = activity["_terminal_result"]
+        activity = None
     output_lines = []
     if activity is not None:
         output_lines.append(json.dumps(activity).encode() + b"\n")
@@ -22478,7 +22500,7 @@ async def test_claude_prompt_too_long_unsafe_evidence_does_not_replay(
         json.dumps({
             "type": "result",
             "is_error": True,
-            "result": "Prompt is too long",
+            "result": terminal_result_value,
             "terminal_reason": "blocking_limit",
             "duration_api_ms": duration_api_ms,
             "usage": usage,


### PR DESCRIPTION
## Summary

- send large direct Claude prompts over stdin so Linux `MAX_ARG_STRLEN` does not fail with `E2BIG` before Claude Code starts
- recognize Claude Code's side-effect-free local `blocking_limit` envelope (`Prompt is too long`, zero API duration/usage) and reuse the fenced compact/retry recovery path
- lower the default proactive compaction threshold from 80% to 70% to leave room for the next message, tool output, and provider framing

## Safety

Claude automatic replay remains fail-closed. It requires the exact Task/Instance/retry/turn/source transport fence, a terminal `blocking_limit` result with `duration_api_ms=0` and zero usage, and no preceding tool/thinking/normal assistant activity.

## Tests

- `uv run pytest backend/tests/test_service_instance_manager.py -q -k 'large_prompt or large_claude_prompt or claude_prompt_too_long_preflight or codex_context_proof_loses_to_cancel'` — 4 passed
- `uv run pytest backend/tests/test_context_compaction.py backend/tests/test_claude_models.py backend/tests/test_api_settings_runtime.py -q` — 29 passed
- full `test_service_instance_manager.py`: 529 passed; 2 pre-existing environment-dependent failures caused by this host's `CLAUDE_BINARY=/home/ubuntu/.local/bin/claude` override and an existing PTY fixture expecting `/opt/claude-real`

## Reproduction evidence

A real 8010 test-environment Task with a ~660 KB initial prompt previously failed before Claude Code with `[Errno 7] Argument list too long`. Historical Wanghuan logs show the target Claude failure is a synthetic `invalid_request` followed by `terminal_reason=blocking_limit`, `duration_api_ms=0`, and zero token usage, proving it is a local preflight rejection with no model/tool side effects.
