### PR TITLE
markdown渲染

### DIFF
--- a/frontend/src/components/MarkdownContent.test.tsx
+++ b/frontend/src/components/MarkdownContent.test.tsx
@@ -13,7 +13,7 @@ $$`,
       '| value |',
       '| --- |',
       '| [docs](https://example.test) |',
-      String.raw`\`\(not math\)\` and escaped dollars: \$5 and \$7.`,
+      '`\\(not math\\)` and escaped dollars: \\$5 and \\$7.',
       '```tex',
       String.raw`\[not math\]`,
       '```',
@@ -24,7 +24,7 @@ $$`,
     expect(container.querySelector('.katex-display')).not.toBeNull();
     expect(container.querySelector('table')).not.toBeNull();
     expect(container.querySelector('a[href="https://example.test"]')).not.toBeNull();
-    expect(container.querySelector('code')?.textContent).toContain(String.raw`\(not math\)`);
+    expect(container.querySelector('code:not(pre code)')?.textContent).toBe(String.raw`\(not math\)`);
     expect(container.querySelector('pre code')?.textContent).toContain(String.raw`\[not math\]`);
     expect(container.textContent).toContain('$5 and $7');
   });

--- a/frontend/src/components/MarkdownContent.test.tsx
+++ b/frontend/src/components/MarkdownContent.test.tsx
@@ -5,6 +5,39 @@ import { MarkdownContent } from './MarkdownContent';
 
 
 describe('MarkdownContent', () => {
+  it('renders inline and display math while preserving GFM and code boundaries', () => {
+    const markdown = [
+      String.raw`Inline \(x^2\) and $$
+\sum_{i=1}^n i
+$$`,
+      '| value |',
+      '| --- |',
+      '| [docs](https://example.test) |',
+      String.raw`\`\(not math\)\` and escaped dollars: \$5 and \$7.`,
+      '```tex',
+      String.raw`\[not math\]`,
+      '```',
+    ].join('\n\n');
+    const { container } = render(<MarkdownContent content={markdown} />);
+
+    expect(container.querySelectorAll('.katex')).toHaveLength(2);
+    expect(container.querySelector('.katex-display')).not.toBeNull();
+    expect(container.querySelector('table')).not.toBeNull();
+    expect(container.querySelector('a[href="https://example.test"]')).not.toBeNull();
+    expect(container.querySelector('code')?.textContent).toContain(String.raw`\(not math\)`);
+    expect(container.querySelector('pre code')?.textContent).toContain(String.raw`\[not math\]`);
+    expect(container.textContent).toContain('$5 and $7');
+  });
+
+  it('keeps unfinished math readable during streaming', () => {
+    const { container } = render(
+      <MarkdownContent content={String.raw`Working on \(x^2`} />,
+    );
+
+    expect(container.querySelector('.katex')).toBeNull();
+    expect(container.textContent).toContain('Working on (x^2');
+  });
+
   it('constrains the document while keeping wide code locally scrollable', () => {
     const { container } = render(
       <MarkdownContent content={'Paragraph\n\n```text\n' + 'x'.repeat(500) + '\n```'} />,

--- a/frontend/src/components/MarkdownContent.tsx
+++ b/frontend/src/components/MarkdownContent.tsx
@@ -1,10 +1,10 @@
 import { memo, useState } from 'react';
 import type { ReactElement, ReactNode } from 'react';
-import ReactMarkdown, { type Components } from 'react-markdown';
-import remarkGfm from 'remark-gfm';
+import type { Components } from 'react-markdown';
 
 import { copyToClipboard } from './clipboard';
 import { Check, Copy } from './icons';
+import { MarkdownRenderer } from './Markdown/MarkdownRenderer';
 
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
@@ -24,8 +24,6 @@ function CopyButton({ text }: { text: string }) {
     </button>
   );
 }
-
-const remarkPlugins = [remarkGfm];
 
 const markdownComponents: Components = {
   pre({ children }) {
@@ -92,12 +90,10 @@ export const MarkdownContent = memo(function MarkdownContent({
 }: MarkdownContentProps) {
   return (
     <div className={`markdown-body min-w-0 max-w-full ${className || ''}`}>
-      <ReactMarkdown
-        remarkPlugins={remarkPlugins}
+      <MarkdownRenderer
         components={markdownComponents}
-      >
-        {content}
-      </ReactMarkdown>
+        content={content}
+      />
     </div>
   );
 });


### PR DESCRIPTION
<!-- ccm-delivery run=2 head=d1b46422870ebcadd0b54d15431d35c5ec777853 -->

你看一下之前codex版本的ccm加入了在chat中对数学公式渲染的，然后claude版的ccm好像还没有同步功能，你加一下这个功能，可以参考codex版本的。

---
Created by CCM Delivery Loop.